### PR TITLE
Change Storybook static build output directory to `build`

### DIFF
--- a/apps/design-system/.gitignore
+++ b/apps/design-system/.gitignore
@@ -1,1 +1,0 @@
-storybook-static

--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "storybook build",
+    "build": "storybook build --output-dir build",
     "dev": "storybook dev -p 6006 --no-open",
     "format": "prettier . --check",
     "format:fix": "prettier . --write",

--- a/apps/design-system/vercel.json
+++ b/apps/design-system/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": "build"
+}


### PR DESCRIPTION
Using default `storybook-static` was breaking build on Vercel.