### PR TITLE
Add new `kalkulacka.one` app for root domain without www

### DIFF
--- a/apps/kalkulacka.one/index.js
+++ b/apps/kalkulacka.one/index.js
@@ -1,0 +1,8 @@
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+
+    url.hostname = `www.${url.hostname}`;
+    return Response.redirect(url.toString(), 301);
+  },
+};

--- a/apps/kalkulacka.one/package.json
+++ b/apps/kalkulacka.one/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "kalkulacka.one",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "lint": "biome check .",
+    "lint:fix": "biome check --write ."
+  }
+}

--- a/apps/kalkulacka.one/wrangler.json
+++ b/apps/kalkulacka.one/wrangler.json
@@ -1,0 +1,9 @@
+{
+  "name": "kalkulacka-one",
+  "main": "index.js",
+  "compatibility_date": "2025-02-15",
+  "assets": {
+    "directory": "./assets",
+    "binding": "ASSETS"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,9 @@
         "typescript": "^5.8.2"
       }
     },
+    "apps/kalkulacka.one": {
+      "version": "1.0.0"
+    },
     "apps/schema-web": {
       "version": "1.0.0",
       "devDependencies": {
@@ -10806,6 +10809,10 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/kalkulacka.one": {
+      "resolved": "apps/kalkulacka.one",
+      "link": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",


### PR DESCRIPTION
This PR adds new `kalkulacka.one` app for the www-less domain where we need to publish certain files (like `.well-known` for Matrix as in #91, coming in another PR).