### PR TITLE
Add `.well-known` files for Matrix

### DIFF
--- a/apps/kalkulacka.one/assets/.well-known/matrix/client
+++ b/apps/kalkulacka.one/assets/.well-known/matrix/client
@@ -1,0 +1,12 @@
+{
+  "m.homeserver": {
+    "base_url": "https://talk.kalkulacka.one"
+  },
+  "org.matrix.msc3575.proxy": {
+    "url": "https://talk.kalkulacka.one"
+  },
+  "org.matrix.msc2965.authentication": {
+    "issuer": "https://auth.talk.kalkulacka.one/",
+    "account": "https://auth.talk.kalkulacka.one/account"
+  }
+}

--- a/apps/kalkulacka.one/assets/.well-known/matrix/server
+++ b/apps/kalkulacka.one/assets/.well-known/matrix/server
@@ -1,0 +1,3 @@
+{
+  "m.server": "talk.kalkulacka.one:443"
+}

--- a/apps/kalkulacka.one/wrangler.json
+++ b/apps/kalkulacka.one/wrangler.json
@@ -5,5 +5,11 @@
   "assets": {
     "directory": "./assets",
     "binding": "ASSETS"
-  }
+  },
+  "routes": [
+    {
+      "pattern": "kalkulacka.one",
+      "custom_domain": true
+    }
+  ]
 }


### PR DESCRIPTION
Actually adds Matrix `.well-known` files to www-less domain (instead of #91).