### PR TITLE
Add ProgressBar

### DIFF
--- a/apps/design-system.kalkulacka.one/stories/ProgressBar.stories.ts
+++ b/apps/design-system.kalkulacka.one/stories/ProgressBar.stories.ts
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { ProgressBar } from "@repo/design-system/server";
+
+const meta: Meta<typeof ProgressBar> = {
+  title: "Components/ProgressBar",
+  component: ProgressBar,
+  tags: ["autodocs"],
+  argTypes: {
+    value: {
+      control: {
+        type: "range",
+        min: 0,
+        max: 100,
+      },
+    },
+  },
+};
+
+type ProgressBarStory = StoryObj<typeof meta>;
+
+export const Default: ProgressBarStory = {
+  args: {
+    value: 50,
+  },
+};
+
+export default meta;

--- a/packages/design-system/src/components/server/index.ts
+++ b/packages/design-system/src/components/server/index.ts
@@ -1,0 +1,1 @@
+export * from "./progressBar";

--- a/packages/design-system/src/components/server/progressBar.test.tsx
+++ b/packages/design-system/src/components/server/progressBar.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProgressBar } from "./progressBar";
+
+describe("ProgressBar", () => {
+  describe("when given valid value", () => {
+    it("should render with the correct width and aria-attributes based on value", () => {
+      render(<ProgressBar value={50} />);
+      const progressBar = screen.getByRole("progressbar");
+      const innerBar = progressBar.firstChild as HTMLElement;
+      expect(innerBar.style.width).toBe("50%");
+      expect(progressBar).toHaveAttribute("aria-valuenow", "50");
+      expect(progressBar).toHaveAttribute("aria-valuemin", "0");
+      expect(progressBar).toHaveAttribute("aria-valuemax", "100");
+    });
+  });
+
+  it("should clamp the value to 100 if value is greater than 100", () => {
+    render(<ProgressBar value={150} />);
+    const progressBar = screen.getByRole("progressbar");
+    const innerBar = progressBar.firstChild as HTMLElement;
+    expect(innerBar.style.width).toBe("100%");
+  });
+
+  it("should apply the primary color variant by default", () => {
+    render(<ProgressBar value={50} />);
+    const progressBar = screen.getByRole("progressbar");
+    const innerBar = progressBar.firstChild as HTMLElement;
+    expect(innerBar).toHaveClass("ko:bg-primary");
+  });
+});

--- a/packages/design-system/src/components/server/progressBar.tsx
+++ b/packages/design-system/src/components/server/progressBar.tsx
@@ -1,0 +1,28 @@
+import { twMerge } from "@repo/design-system/utils";
+import { type VariantProps, cva } from "class-variance-authority";
+
+export type ProgressBar = {
+  value: number;
+} & VariantProps<typeof ProgressBarVariants>;
+
+const ProgressBarVariants = cva("ko:h-full ko:w-full", {
+  variants: {
+    color: {
+      primary: "ko:bg-primary",
+    },
+  },
+  defaultVariants: {
+    color: "primary",
+  },
+});
+
+export function ProgressBar({ value, color }: ProgressBar) {
+  const width = value > 100 ? 100 : value < 0 ? 0 : value;
+
+  return (
+    // biome-ignore lint/a11y/useFocusableInteractive: A non-interactive progressbar should not be focusable
+    <div role="progressbar" aria-valuenow={width} aria-valuemin={0} aria-valuemax={100} className={twMerge("ko:h-1.5 ko:w-full ko:overflow-hidden ko:rounded-full ko:bg-neutral-inactive")}>
+      <div className={twMerge(ProgressBarVariants({ color }))} style={{ width: `${width}%` }} />
+    </div>
+  );
+}

--- a/packages/design-system/src/styles.css
+++ b/packages/design-system/src/styles.css
@@ -75,6 +75,11 @@
     var(--ko-palette-neutral-active-dark, oklch(from var(--ko-palette-neutral) calc(l - 0.5) calc(c - 0.2) h))
   );
 
+  --color-neutral-inactive: light-dark(
+    var(--ko-palette-neutral-inactive-light, oklch(from var(--ko-palette-neutral) 0.9  calc(c - 0.01) h)),
+    var(--ko-palette-neutral-inactive-dark, oklch(from var(--ko-palette-neutral) 0.9 calc(c - 0.2) h))
+  );
+
   --color-neutral-disabled: light-dark(
     var(--ko-palette-neutral-disabled-light, oklch(from var(--ko-palette-neutral) 0.9  calc(c - 0.01) h)),
     var(--ko-palette-neutral-disabled-dark, oklch(from var(--ko-palette-neutral) 0.9 calc(c - 0.2) h))


### PR DESCRIPTION
- omit of tabIndex when role="progressbar" should be fine since the component is not interactive
- there is one a11y improvement for consideration:

1. If a visible label is present, use aria-labelledby to link to it.
2. If no visible label is present, use aria-label for a descriptive fallback.
This logic is handled cleanly within the component:

```
const accessibilityProps = labelledby
  ? {
      // Use the visible label's ID.
      "aria-labelledby": labelledby,
    }
  : {
      // Fall back to a descriptive, self-contained label.
      "aria-label": `Progress ${value}%`,
    };
<div role="progressbar" {...accessibilityProps} />;
```

@krystof-k 
