### PR TITLE
Add missing images property to calculator schema

### DIFF
--- a/packages/schema/schemas/calculator.schema.json
+++ b/packages/schema/schemas/calculator.schema.json
@@ -166,6 +166,9 @@
     },
     "tags": {
       "$ref": "#/$defs/tags"
+    },
+    "images": {
+      "$ref": "#/$defs/images"
     }
   },
   "unevaluatedProperties": false,


### PR DESCRIPTION
Bug introduced in #320.