### PR TITLE
Add attribution to navigation card in embeds

### DIFF
--- a/apps/www.volebnikalkulacka.cz/.env
+++ b/apps/www.volebnikalkulacka.cz/.env
@@ -1,3 +1,3 @@
-CANONICAL_URL=https://www.volebnikalkulacka.cz
+NEXT_PUBLIC_CANONICAL_URL=https://www.volebnikalkulacka.cz
 DATA_ENDPOINT=https://data.kalkulacka.one/www.volebnikalkulacka.cz
 X_HANDLE=@volebniklak

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/guide-navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/guide-navigation-card.tsx
@@ -4,12 +4,12 @@ import { NavigationCard } from "./navigation-card";
 
 export type GuideNavigationCard = {
   onNextClick: () => void;
-  attributionHref?: string;
+  attribution?: boolean;
 };
 
-export function GuideNavigationCard({ onNextClick, attributionHref }: GuideNavigationCard) {
+export function GuideNavigationCard({ onNextClick, attribution }: GuideNavigationCard) {
   return (
-    <NavigationCard attributionHref={attributionHref}>
+    <NavigationCard attribution={attribution}>
       <Button onClick={onNextClick}>Začít odpovídat</Button>
     </NavigationCard>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/guide-navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/guide-navigation-card.tsx
@@ -4,11 +4,12 @@ import { NavigationCard } from "./navigation-card";
 
 export type GuideNavigationCard = {
   onNextClick: () => void;
+  attributionHref?: string;
 };
 
-export function GuideNavigationCard({ onNextClick }: GuideNavigationCard) {
+export function GuideNavigationCard({ onNextClick, attributionHref }: GuideNavigationCard) {
   return (
-    <NavigationCard>
+    <NavigationCard attributionHref={attributionHref}>
       <Button onClick={onNextClick}>Začít odpovídat</Button>
     </NavigationCard>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/index.ts
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/index.ts
@@ -5,6 +5,7 @@ export * from "./introduction-navigation-card";
 export * from "./layout";
 export * from "./match-card";
 export * from "./navigation-card";
+export * from "./navigation-card-attribution";
 export * from "./question-card";
 export * from "./question-navigation-card";
 export * from "./review-navigation-card";

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/introduction-navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/introduction-navigation-card.tsx
@@ -4,12 +4,12 @@ import { NavigationCard } from "./navigation-card";
 
 export type IntroductionNavigationCard = {
   onNextClick: () => void;
-  attributionHref?: string;
+  attribution?: boolean;
 };
 
-export function IntroductionNavigationCard({ onNextClick, attributionHref }: IntroductionNavigationCard) {
+export function IntroductionNavigationCard({ onNextClick, attribution }: IntroductionNavigationCard) {
   return (
-    <NavigationCard attributionHref={attributionHref}>
+    <NavigationCard attribution={attribution}>
       <Button onClick={onNextClick}>Pokračovat</Button>
     </NavigationCard>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/introduction-navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/introduction-navigation-card.tsx
@@ -4,11 +4,12 @@ import { NavigationCard } from "./navigation-card";
 
 export type IntroductionNavigationCard = {
   onNextClick: () => void;
+  attributionHref?: string;
 };
 
-export function IntroductionNavigationCard({ onNextClick }: IntroductionNavigationCard) {
+export function IntroductionNavigationCard({ onNextClick, attributionHref }: IntroductionNavigationCard) {
   return (
-    <NavigationCard>
+    <NavigationCard attributionHref={attributionHref}>
       <Button onClick={onNextClick}>Pokračovat</Button>
     </NavigationCard>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card-attribution.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card-attribution.tsx
@@ -1,13 +1,11 @@
 import { Logo } from "@repo/design-system/client";
 
-export type NavigationCardAttribution = {
-  href: string;
-};
+import { canonical } from "../../../../lib/routing/url-builders";
 
-export function NavigationCardAttribution({ href }: NavigationCardAttribution) {
+export function NavigationCardAttribution() {
   return (
     <div className="flex justify-center">
-      <a href={href} target="_blank" className="group p-2 flex items-center gap-2 rounded-lg text-sm text-slate-600 hover:text-slate-800 hover:bg-slate-100">
+      <a href={canonical.homepage()} target="_blank" className="group p-2 flex items-center gap-2 rounded-lg text-sm text-slate-600 hover:text-slate-800 hover:bg-slate-100">
         <span>Přináší</span>
         <div className="group-hover:hidden">
           <Logo title="Volební kalkulačka" size="small" monochrome />

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card-attribution.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card-attribution.tsx
@@ -4,7 +4,7 @@ import { canonical } from "../../../../lib/routing/url-builders";
 
 export function NavigationCardAttribution() {
   return (
-    <a href={canonical.homepage()} target="_blank" className="group p-2 flex items-center gap-2 rounded-lg text-sm text-slate-600 hover:text-slate-800 hover:bg-slate-100">
+    <a href={canonical.homepage()} target="_blank" className="group p-2 flex items-center gap-2 rounded-lg text-sm text-slate-600 hover:text-slate-800 hover:bg-slate-100 min-w-max">
       <span>Přináší</span>
       <div className="group-hover:hidden">
         <Logo title="Volební kalkulačka" size="small" monochrome />

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card-attribution.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card-attribution.tsx
@@ -4,17 +4,15 @@ import { canonical } from "../../../../lib/routing/url-builders";
 
 export function NavigationCardAttribution() {
   return (
-    <div className="flex justify-center">
-      <a href={canonical.homepage()} target="_blank" className="group p-2 flex items-center gap-2 rounded-lg text-sm text-slate-600 hover:text-slate-800 hover:bg-slate-100">
-        <span>Přináší</span>
-        <div className="group-hover:hidden">
-          <Logo title="Volební kalkulačka" size="small" monochrome />
-        </div>
-        <div className="hidden group-hover:block">
-          <Logo title="Volební kalkulačka" size="small" />
-        </div>
-        <span>Volební kalkulačka</span>
-      </a>
-    </div>
+    <a href={canonical.homepage()} target="_blank" className="group p-2 flex items-center gap-2 rounded-lg text-sm text-slate-600 hover:text-slate-800 hover:bg-slate-100">
+      <span>Přináší</span>
+      <div className="group-hover:hidden">
+        <Logo title="Volební kalkulačka" size="small" monochrome />
+      </div>
+      <div className="hidden group-hover:block">
+        <Logo title="Volební kalkulačka" size="small" />
+      </div>
+      <span>Volební kalkulačka</span>
+    </a>
   );
 }

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card-attribution.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card-attribution.tsx
@@ -1,0 +1,22 @@
+import { Logo } from "@repo/design-system/client";
+
+export type NavigationCardAttribution = {
+  href: string;
+};
+
+export function NavigationCardAttribution({ href }: NavigationCardAttribution) {
+  return (
+    <div className="flex justify-center">
+      <a href={href} target="_blank" className="group p-2 flex items-center gap-2 rounded-lg text-sm text-slate-600 hover:text-slate-800 hover:bg-slate-100">
+        <span>Přináší</span>
+        <div className="group-hover:hidden">
+          <Logo title="Volební kalkulačka" size="small" monochrome />
+        </div>
+        <div className="hidden group-hover:block">
+          <Logo title="Volební kalkulačka" size="small" />
+        </div>
+        <span>Volební kalkulačka</span>
+      </a>
+    </div>
+  );
+}

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card.tsx
@@ -1,14 +1,20 @@
 import { Card } from "@repo/design-system/server";
 
+import { NavigationCardAttribution } from "./navigation-card-attribution";
+
 export type NavigationCard = {
   children: React.ReactNode;
+  attributionHref?: string;
 };
 
-export function NavigationCard({ children }: NavigationCard) {
+export function NavigationCard({ children, attributionHref }: NavigationCard) {
   return (
     <div className="grid justify-items-end m-4">
       <Card corner="bottomRight" shadow="elevated">
-        <div className="p-4">{children}</div>
+        <div className="p-4">
+          {children}
+          {attributionHref && <NavigationCardAttribution href={attributionHref} />}
+        </div>
       </Card>
     </div>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/navigation-card.tsx
@@ -4,16 +4,16 @@ import { NavigationCardAttribution } from "./navigation-card-attribution";
 
 export type NavigationCard = {
   children: React.ReactNode;
-  attributionHref?: string;
+  attribution?: boolean;
 };
 
-export function NavigationCard({ children, attributionHref }: NavigationCard) {
+export function NavigationCard({ children, attribution }: NavigationCard) {
   return (
     <div className="grid justify-items-end m-4">
       <Card corner="bottomRight" shadow="elevated">
         <div className="p-4">
           {children}
-          {attributionHref && <NavigationCardAttribution href={attributionHref} />}
+          {attribution && <NavigationCardAttribution />}
         </div>
       </Card>
     </div>

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/question-navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/question-navigation-card.tsx
@@ -13,14 +13,15 @@ export type QuestionNavigationCard = {
   onAgreeChange: (agree: boolean) => void;
   onDisagreeChange: (disagree: boolean) => void;
   onImportantChange: (isImportant: boolean) => void;
+  attributionHref?: string;
 };
 
-export function QuestionNavigationCard({ current, total, onPreviousClick, onNextClick, answer, onAgreeChange, onDisagreeChange, onImportantChange }: QuestionNavigationCard) {
+export function QuestionNavigationCard({ current, total, onPreviousClick, onNextClick, answer, onAgreeChange, onDisagreeChange, onImportantChange, attributionHref }: QuestionNavigationCard) {
   const previousButtonLabel = current === 1 ? "Návod" : "Předchozí";
   const nextButtonLabel = answer.answer?.answer !== undefined ? "Další" : "Přeskočit";
 
   return (
-    <NavigationCard>
+    <NavigationCard attributionHref={attributionHref}>
       <div className="grid grid-flow-row gap-4">
         <div className="grid grid-flow-col items-center">
           <Button variant="link" color="neutral" onClick={onPreviousClick}>

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/question-navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/question-navigation-card.tsx
@@ -13,15 +13,15 @@ export type QuestionNavigationCard = {
   onAgreeChange: (agree: boolean) => void;
   onDisagreeChange: (disagree: boolean) => void;
   onImportantChange: (isImportant: boolean) => void;
-  attributionHref?: string;
+  attribution?: boolean;
 };
 
-export function QuestionNavigationCard({ current, total, onPreviousClick, onNextClick, answer, onAgreeChange, onDisagreeChange, onImportantChange, attributionHref }: QuestionNavigationCard) {
+export function QuestionNavigationCard({ current, total, onPreviousClick, onNextClick, answer, onAgreeChange, onDisagreeChange, onImportantChange, attribution }: QuestionNavigationCard) {
   const previousButtonLabel = current === 1 ? "Návod" : "Předchozí";
   const nextButtonLabel = answer.answer?.answer !== undefined ? "Další" : "Přeskočit";
 
   return (
-    <NavigationCard attributionHref={attributionHref}>
+    <NavigationCard attribution={attribution}>
       <div className="grid grid-flow-row gap-4">
         <div className="grid grid-flow-col items-center">
           <Button variant="link" color="neutral" onClick={onPreviousClick}>

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/review-navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/review-navigation-card.tsx
@@ -4,12 +4,12 @@ import { NavigationCard } from "./navigation-card";
 
 export type ReviewNavigationCard = {
   onNextClick: () => void;
-  attributionHref?: string;
+  attribution?: boolean;
 };
 
-export function ReviewNavigationCard({ onNextClick, attributionHref }: ReviewNavigationCard) {
+export function ReviewNavigationCard({ onNextClick, attribution }: ReviewNavigationCard) {
   return (
-    <NavigationCard attributionHref={attributionHref}>
+    <NavigationCard attribution={attribution}>
       <Button onClick={onNextClick}>Zobrazit výsledky</Button>
     </NavigationCard>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/components/review-navigation-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/components/review-navigation-card.tsx
@@ -4,11 +4,12 @@ import { NavigationCard } from "./navigation-card";
 
 export type ReviewNavigationCard = {
   onNextClick: () => void;
+  attributionHref?: string;
 };
 
-export function ReviewNavigationCard({ onNextClick }: ReviewNavigationCard) {
+export function ReviewNavigationCard({ onNextClick, attributionHref }: ReviewNavigationCard) {
   return (
-    <NavigationCard>
+    <NavigationCard attributionHref={attributionHref}>
       <Button onClick={onNextClick}>Zobrazit výsledky</Button>
     </NavigationCard>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/guide.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/guide.tsx
@@ -2,6 +2,7 @@ import { mdiArrowLeft, mdiClose } from "@mdi/js";
 import { Button, Icon } from "@repo/design-system/client";
 
 import { HideOnEmbed } from "../../../../components/client";
+import { canonical } from "../../../../lib/routing/url-builders";
 import type { CalculatorViewModel } from "../../../view-models";
 import { AppHeader, AppHeaderBottom, AppHeaderBottomLeft, AppHeaderBottomMain, AppHeaderMain, AppHeaderRight } from "../../client";
 import { Guide, GuideNavigationCard, LayoutBottomNavigation, LayoutContent, LayoutHeader } from "../components";
@@ -11,9 +12,10 @@ export type GuidePage = {
   onNextClick: () => void;
   onBackClick: () => void;
   onCloseClick: () => void;
+  isEmbed?: boolean;
 };
 
-export function GuidePage({ calculator, onNextClick, onBackClick, onCloseClick }: GuidePage) {
+export function GuidePage({ calculator, onNextClick, onBackClick, onCloseClick, isEmbed }: GuidePage) {
   return (
     <>
       <LayoutHeader>
@@ -42,7 +44,7 @@ export function GuidePage({ calculator, onNextClick, onBackClick, onCloseClick }
         <Guide calculator={calculator} />
       </LayoutContent>
       <LayoutBottomNavigation>
-        <GuideNavigationCard onNextClick={onNextClick} />
+        <GuideNavigationCard onNextClick={onNextClick} attributionHref={isEmbed ? canonical.homepage() : undefined} />
       </LayoutBottomNavigation>
     </>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/guide.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/guide.tsx
@@ -2,7 +2,6 @@ import { mdiArrowLeft, mdiClose } from "@mdi/js";
 import { Button, Icon } from "@repo/design-system/client";
 
 import { HideOnEmbed } from "../../../../components/client";
-import { canonical } from "../../../../lib/routing/url-builders";
 import type { CalculatorViewModel } from "../../../view-models";
 import { AppHeader, AppHeaderBottom, AppHeaderBottomLeft, AppHeaderBottomMain, AppHeaderMain, AppHeaderRight } from "../../client";
 import { Guide, GuideNavigationCard, LayoutBottomNavigation, LayoutContent, LayoutHeader } from "../components";
@@ -44,7 +43,7 @@ export function GuidePage({ calculator, onNextClick, onBackClick, onCloseClick, 
         <Guide calculator={calculator} />
       </LayoutContent>
       <LayoutBottomNavigation>
-        <GuideNavigationCard onNextClick={onNextClick} attributionHref={isEmbed ? canonical.homepage() : undefined} />
+        <GuideNavigationCard onNextClick={onNextClick} attribution={isEmbed} />
       </LayoutBottomNavigation>
     </>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/introduction.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/introduction.tsx
@@ -2,6 +2,7 @@ import { mdiClose } from "@mdi/js";
 import { Button, Icon } from "@repo/design-system/client";
 
 import { HideOnEmbed } from "../../../../components/client";
+import { canonical } from "../../../../lib/routing/url-builders";
 import type { CalculatorViewModel } from "../../../view-models";
 import { AppHeader, AppHeaderBottom, AppHeaderBottomMain, AppHeaderMain, AppHeaderRight } from "../../client";
 import { Introduction, IntroductionNavigationCard, LayoutBottomNavigation, LayoutContent, LayoutHeader } from "../components";
@@ -10,9 +11,10 @@ export type IntroductionPage = {
   calculator: CalculatorViewModel;
   onNextClick: () => void;
   onCloseClick: () => void;
+  isEmbed?: boolean;
 };
 
-export function IntroductionPage({ calculator, onNextClick, onCloseClick }: IntroductionPage) {
+export function IntroductionPage({ calculator, onNextClick, onCloseClick, isEmbed }: IntroductionPage) {
   return (
     <>
       <LayoutHeader>
@@ -36,7 +38,7 @@ export function IntroductionPage({ calculator, onNextClick, onCloseClick }: Intr
         <Introduction calculator={calculator} />
       </LayoutContent>
       <LayoutBottomNavigation>
-        <IntroductionNavigationCard onNextClick={onNextClick} />
+        <IntroductionNavigationCard onNextClick={onNextClick} attributionHref={isEmbed ? canonical.homepage() : undefined} />
       </LayoutBottomNavigation>
     </>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/introduction.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/introduction.tsx
@@ -2,7 +2,6 @@ import { mdiClose } from "@mdi/js";
 import { Button, Icon } from "@repo/design-system/client";
 
 import { HideOnEmbed } from "../../../../components/client";
-import { canonical } from "../../../../lib/routing/url-builders";
 import type { CalculatorViewModel } from "../../../view-models";
 import { AppHeader, AppHeaderBottom, AppHeaderBottomMain, AppHeaderMain, AppHeaderRight } from "../../client";
 import { Introduction, IntroductionNavigationCard, LayoutBottomNavigation, LayoutContent, LayoutHeader } from "../components";
@@ -38,7 +37,7 @@ export function IntroductionPage({ calculator, onNextClick, onCloseClick, isEmbe
         <Introduction calculator={calculator} />
       </LayoutContent>
       <LayoutBottomNavigation>
-        <IntroductionNavigationCard onNextClick={onNextClick} attributionHref={isEmbed ? canonical.homepage() : undefined} />
+        <IntroductionNavigationCard onNextClick={onNextClick} attribution={isEmbed} />
       </LayoutBottomNavigation>
     </>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/question.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/question.tsx
@@ -2,7 +2,6 @@ import { mdiClose } from "@mdi/js";
 import { Button, Icon } from "@repo/design-system/client";
 
 import { HideOnEmbed } from "../../../../components/client";
-import { canonical } from "../../../../lib/routing/url-builders";
 import type { AnswerViewModel, CalculatorViewModel, QuestionViewModel } from "../../../view-models";
 import { AppHeader, AppHeaderMain, AppHeaderRight, WithCondenseOnScroll } from "../../client";
 import { LayoutBottomNavigation, LayoutContent, LayoutHeader, QuestionCard, QuestionNavigationCard } from "../components";
@@ -88,7 +87,7 @@ export function QuestionPage({ question, number, total, calculator, onPreviousCl
           onAgreeChange={handleAgreeChange}
           onDisagreeChange={handleDisagreeChange}
           onImportantChange={handleImportantChange}
-          attributionHref={isEmbed ? canonical.homepage() : undefined}
+          attribution={isEmbed}
         />
       </LayoutBottomNavigation>
     </>

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/question.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/question.tsx
@@ -2,6 +2,7 @@ import { mdiClose } from "@mdi/js";
 import { Button, Icon } from "@repo/design-system/client";
 
 import { HideOnEmbed } from "../../../../components/client";
+import { canonical } from "../../../../lib/routing/url-builders";
 import type { AnswerViewModel, CalculatorViewModel, QuestionViewModel } from "../../../view-models";
 import { AppHeader, AppHeaderMain, AppHeaderRight, WithCondenseOnScroll } from "../../client";
 import { LayoutBottomNavigation, LayoutContent, LayoutHeader, QuestionCard, QuestionNavigationCard } from "../components";
@@ -15,9 +16,10 @@ export type QuestionPage = {
   onPreviousClick: () => void;
   onNextClick: () => void;
   onCloseClick: () => void;
+  isEmbed?: boolean;
 };
 
-export function QuestionPage({ question, number, total, calculator, onPreviousClick, onNextClick, answer, onCloseClick }: QuestionPage) {
+export function QuestionPage({ question, number, total, calculator, onPreviousClick, onNextClick, answer, onCloseClick, isEmbed }: QuestionPage) {
   const handleAgreeChange = (checked: boolean) => {
     if (checked) {
       answer.setAnswer({
@@ -86,6 +88,7 @@ export function QuestionPage({ question, number, total, calculator, onPreviousCl
           onAgreeChange={handleAgreeChange}
           onDisagreeChange={handleDisagreeChange}
           onImportantChange={handleImportantChange}
+          attributionHref={isEmbed ? canonical.homepage() : undefined}
         />
       </LayoutBottomNavigation>
     </>

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/review.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/review.tsx
@@ -2,7 +2,6 @@ import { mdiArrowLeft, mdiClose } from "@mdi/js";
 import { Button, Icon } from "@repo/design-system/client";
 
 import { HideOnEmbed } from "../../../../components/client";
-import { canonical } from "../../../../lib/routing/url-builders";
 import type { AnswersViewModel, CalculatorViewModel, QuestionsViewModel } from "../../../view-models";
 import { AppHeader, AppHeaderBottom, AppHeaderBottomLeft, AppHeaderBottomMain, AppHeaderMain, AppHeaderRight, WithCondenseOnScroll } from "../../client";
 import { LayoutBottomNavigation, LayoutContent, LayoutHeader, ReviewNavigationCard, ReviewQuestionCard } from "../components";
@@ -105,7 +104,7 @@ export function ReviewPage({ questions, answers, calculator, onNextClick, onPrev
         </div>
       </LayoutContent>
       <LayoutBottomNavigation>
-        <ReviewNavigationCard onNextClick={onNextClick} attributionHref={isEmbed ? canonical.homepage() : undefined} />
+        <ReviewNavigationCard onNextClick={onNextClick} attribution={isEmbed} />
       </LayoutBottomNavigation>
     </>
   );

--- a/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/review.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/server/pages/review.tsx
@@ -2,6 +2,7 @@ import { mdiArrowLeft, mdiClose } from "@mdi/js";
 import { Button, Icon } from "@repo/design-system/client";
 
 import { HideOnEmbed } from "../../../../components/client";
+import { canonical } from "../../../../lib/routing/url-builders";
 import type { AnswersViewModel, CalculatorViewModel, QuestionsViewModel } from "../../../view-models";
 import { AppHeader, AppHeaderBottom, AppHeaderBottomLeft, AppHeaderBottomMain, AppHeaderMain, AppHeaderRight, WithCondenseOnScroll } from "../../client";
 import { LayoutBottomNavigation, LayoutContent, LayoutHeader, ReviewNavigationCard, ReviewQuestionCard } from "../components";
@@ -13,9 +14,10 @@ export type ReviewPage = {
   onNextClick: () => void;
   onPreviousClick: () => void;
   onCloseClick: () => void;
+  isEmbed?: boolean;
 };
 
-export function ReviewPage({ questions, answers, calculator, onNextClick, onPreviousClick, onCloseClick }: ReviewPage) {
+export function ReviewPage({ questions, answers, calculator, onNextClick, onPreviousClick, onCloseClick, isEmbed }: ReviewPage) {
   const handleAgreeChange = (questionId: string, agree: boolean) => {
     if (agree) {
       answers.setAnswer({
@@ -103,7 +105,7 @@ export function ReviewPage({ questions, answers, calculator, onNextClick, onPrev
         </div>
       </LayoutContent>
       <LayoutBottomNavigation>
-        <ReviewNavigationCard onNextClick={onNextClick} />
+        <ReviewNavigationCard onNextClick={onNextClick} attributionHref={isEmbed ? canonical.homepage() : undefined} />
       </LayoutBottomNavigation>
     </>
   );

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/guide.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/guide.tsx
@@ -8,7 +8,7 @@ import { useEmbed } from "../../../client/embed-context-provider";
 export function GuidePageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
-  const { isEmbed } = useEmbed();
+  const embed = useEmbed();
 
   const handleNavigationNextClick = () => {
     router.push(routes.question(segments, 1));
@@ -22,5 +22,7 @@ export function GuidePageWithRouting({ segments }: { segments: RouteSegments }) 
     router.push("/");
   };
 
-  return <AppGuidePage calculator={calculator} onNextClick={handleNavigationNextClick} onBackClick={handleBackClick} onCloseClick={handleCloseClick} isEmbed={isEmbed} />;
+  const showAttribution = embed.isEmbed && (embed.config?.navigationAttribution ?? true);
+
+  return <AppGuidePage calculator={calculator} onNextClick={handleNavigationNextClick} onBackClick={handleBackClick} onCloseClick={handleCloseClick} isEmbed={showAttribution} />;
 }

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/guide.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/guide.tsx
@@ -3,10 +3,12 @@ import { useRouter } from "next/navigation";
 import { GuidePage as AppGuidePage } from "../../../../calculator/components/server";
 import { useCalculator } from "../../../../calculator/view-models";
 import { type RouteSegments, routes } from "../../../../lib/routing/route-builders";
+import { useEmbed } from "../../../client/embed-context-provider";
 
 export function GuidePageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
+  const { isEmbed } = useEmbed();
 
   const handleNavigationNextClick = () => {
     router.push(routes.question(segments, 1));
@@ -20,5 +22,5 @@ export function GuidePageWithRouting({ segments }: { segments: RouteSegments }) 
     router.push("/");
   };
 
-  return <AppGuidePage calculator={calculator} onNextClick={handleNavigationNextClick} onBackClick={handleBackClick} onCloseClick={handleCloseClick} />;
+  return <AppGuidePage calculator={calculator} onNextClick={handleNavigationNextClick} onBackClick={handleBackClick} onCloseClick={handleCloseClick} isEmbed={isEmbed} />;
 }

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
@@ -8,7 +8,7 @@ import { useEmbed } from "../../../client/embed-context-provider";
 export function IntroductionPageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
-  const { isEmbed } = useEmbed();
+  const embed = useEmbed();
 
   const handleNavigationNextClick = () => {
     router.push(routes.guide(segments));
@@ -18,5 +18,7 @@ export function IntroductionPageWithRouting({ segments }: { segments: RouteSegme
     router.push("/");
   };
 
-  return <IntroductionPage calculator={calculator} onNextClick={handleNavigationNextClick} onCloseClick={handleCloseClick} isEmbed={isEmbed} />;
+  const showAttribution = embed.isEmbed && (embed.config?.navigationAttribution ?? true);
+
+  return <IntroductionPage calculator={calculator} onNextClick={handleNavigationNextClick} onCloseClick={handleCloseClick} isEmbed={showAttribution} />;
 }

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
@@ -3,10 +3,12 @@ import { useRouter } from "next/navigation";
 import { IntroductionPage } from "../../../../calculator/components/server";
 import { useCalculator } from "../../../../calculator/view-models";
 import { type RouteSegments, routes } from "../../../../lib/routing/route-builders";
+import { useEmbed } from "../../../client/embed-context-provider";
 
 export function IntroductionPageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
+  const { isEmbed } = useEmbed();
 
   const handleNavigationNextClick = () => {
     router.push(routes.guide(segments));
@@ -16,5 +18,5 @@ export function IntroductionPageWithRouting({ segments }: { segments: RouteSegme
     router.push("/");
   };
 
-  return <IntroductionPage calculator={calculator} onNextClick={handleNavigationNextClick} onCloseClick={handleCloseClick} />;
+  return <IntroductionPage calculator={calculator} onNextClick={handleNavigationNextClick} onCloseClick={handleCloseClick} isEmbed={isEmbed} />;
 }

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/question.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/question.tsx
@@ -10,7 +10,7 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
   const calculator = useCalculator();
   const { questions, total } = useQuestions();
   const question = questions[current - 1];
-  const { isEmbed } = useEmbed();
+  const embed = useEmbed();
 
   if (!question) {
     notFound();
@@ -37,6 +37,7 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
   };
 
   const answer = useAnswer(question.id);
+  const showAttribution = embed.isEmbed && (embed.config?.navigationAttribution ?? true);
 
   return (
     <div>
@@ -49,7 +50,7 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
         onNextClick={handleNextClick}
         onCloseClick={handleCloseClick}
         answer={answer}
-        isEmbed={isEmbed}
+        isEmbed={showAttribution}
       />
     </div>
   );

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/question.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/question.tsx
@@ -3,12 +3,14 @@ import { notFound, useRouter } from "next/navigation";
 import { QuestionPage as AppQuestionPage } from "../../../../calculator/components/server";
 import { useAnswer, useCalculator, useQuestions } from "../../../../calculator/view-models";
 import { type RouteSegments, routes } from "../../../../lib/routing/route-builders";
+import { useEmbed } from "../../../client/embed-context-provider";
 
 export function QuestionPageWithRouting({ current, segments }: { current: number; segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
   const { questions, total } = useQuestions();
   const question = questions[current - 1];
+  const { isEmbed } = useEmbed();
 
   if (!question) {
     notFound();
@@ -47,6 +49,7 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
         onNextClick={handleNextClick}
         onCloseClick={handleCloseClick}
         answer={answer}
+        isEmbed={isEmbed}
       />
     </div>
   );

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/review.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/review.tsx
@@ -3,12 +3,14 @@ import { useRouter } from "next/navigation";
 import { ReviewPage as AppReviewPage } from "../../../../calculator/components/server";
 import { useAnswers, useCalculator, useQuestions } from "../../../../calculator/view-models";
 import { type RouteSegments, routes } from "../../../../lib/routing/route-builders";
+import { useEmbed } from "../../../client/embed-context-provider";
 
 export function ReviewPageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
   const questions = useQuestions();
   const answers = useAnswers();
+  const { isEmbed } = useEmbed();
 
   const handleNextClick = () => {
     router.push(routes.result(segments));
@@ -24,7 +26,15 @@ export function ReviewPageWithRouting({ segments }: { segments: RouteSegments })
 
   return (
     <div>
-      <AppReviewPage calculator={calculator} questions={questions} answers={answers} onNextClick={handleNextClick} onPreviousClick={handlePreviousClick} onCloseClick={handleCloseClick} />
+      <AppReviewPage
+        calculator={calculator}
+        questions={questions}
+        answers={answers}
+        onNextClick={handleNextClick}
+        onPreviousClick={handlePreviousClick}
+        onCloseClick={handleCloseClick}
+        isEmbed={isEmbed}
+      />
     </div>
   );
 }

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/review.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/review.tsx
@@ -10,7 +10,7 @@ export function ReviewPageWithRouting({ segments }: { segments: RouteSegments })
   const calculator = useCalculator();
   const questions = useQuestions();
   const answers = useAnswers();
-  const { isEmbed } = useEmbed();
+  const embed = useEmbed();
 
   const handleNextClick = () => {
     router.push(routes.result(segments));
@@ -24,6 +24,8 @@ export function ReviewPageWithRouting({ segments }: { segments: RouteSegments })
     router.push("/");
   };
 
+  const showAttribution = embed.isEmbed && (embed.config?.navigationAttribution ?? true);
+
   return (
     <div>
       <AppReviewPage
@@ -33,7 +35,7 @@ export function ReviewPageWithRouting({ segments }: { segments: RouteSegments })
         onNextClick={handleNextClick}
         onPreviousClick={handlePreviousClick}
         onCloseClick={handleCloseClick}
-        isEmbed={isEmbed}
+        isEmbed={showAttribution}
       />
     </div>
   );

--- a/apps/www.volebnikalkulacka.cz/config/embeds.ts
+++ b/apps/www.volebnikalkulacka.cz/config/embeds.ts
@@ -3,6 +3,7 @@ import type { ThemeName } from "./themes";
 export type EmbedConfig = {
   theme?: ThemeName;
   logo?: "monochrome" | "color";
+  navigationAttribution?: boolean;
 };
 
 export const embedsConfig = {

--- a/apps/www.volebnikalkulacka.cz/lib/routing/url-builders.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/routing/url-builders.ts
@@ -1,10 +1,9 @@
 import { createBaseSegment, type RouteSegments, routes } from "./route-builders";
 
-const CANONICAL_URL = process.env.CANONICAL_URL;
-
 function buildCanonicalUrl(path: string): string {
+  const CANONICAL_URL = process.env.NEXT_PUBLIC_CANONICAL_URL;
   if (!CANONICAL_URL) {
-    throw new Error("Missing `CANONICAL_URL` environment variable");
+    throw new Error("Missing `NEXT_PUBLIC_CANONICAL_URL` environment variable");
   }
   const baseUrl = CANONICAL_URL.replace(/\/$/, "");
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;

--- a/apps/www.volebnikalkulacka.cz/lib/routing/url-builders.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/routing/url-builders.ts
@@ -12,6 +12,7 @@ function buildCanonicalUrl(path: string): string {
 }
 
 export const canonical = {
+  homepage: (): string => buildCanonicalUrl("/"),
   base: (segments: RouteSegments): string => buildCanonicalUrl(createBaseSegment(segments)),
   introduction: (segments: RouteSegments): string => buildCanonicalUrl(routes.introduction(segments)),
   guide: (segments: RouteSegments): string => buildCanonicalUrl(routes.guide(segments)),


### PR DESCRIPTION
<img width="350" height="242" alt="image" src="https://github.com/user-attachments/assets/8264fe68-b390-4816-af95-730c89c6f9eb" />

Navigation card will be fixed in separate PR. Logo colors will be always brand colors, will be fixed in separate PR (set in specific themes).