### PR TITLE
Run typecheck in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,8 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
       - name: Build
         run: npm run build
       - name: Test


### PR DESCRIPTION
`typecheck` exists as a turbo task and a `tsc --noEmit` script in every package — and CLAUDE.md mandates it as the first local post-task check — but CI never ran it. `next build` catches some of it, but not in non-Next packages. One line in `build.yaml` closes the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)