### PR TITLE
Remove Herohero everywhere

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,3 @@
 custom:
   - https://www.kalkulacka.one/cs/podporte-kalkulacku
-  - https://herohero.co/volebnikalkulacka
   - https://www.darujme.cz/darovat/1200653

--- a/apps/www.kalkulacka.one/app/[locale]/podporte-kalkulacku/page.tsx
+++ b/apps/www.kalkulacka.one/app/[locale]/podporte-kalkulacku/page.tsx
@@ -21,10 +21,7 @@ export default function Page() {
       <section className="grid gap-2">
         <h2 className="text-3xl font-display font-bold">Podpořte Volební kalkulačku a&nbsp;demokracii</h2>
         <p>Líbí se vám Volební kalkulačka? Díky dobrovolníkům a štědrým dárcům můžeme kalkulačku poskytovat zdarma.</p>
-        <p>
-          Abychom však mohli pokračovat v naší práci pro nadcházející volby a vylepšovat kalkulačku, potřebujeme vaši pomoc. Přidejte se do klubu podporovatelů nebo nás podpořte jednorázově. Každý
-          příspěvek se počítá!
-        </p>
+        <p>Abychom však mohli pokračovat v naší práci pro nadcházející volby a vylepšovat kalkulačku, potřebujeme vaši pomoc. Podpořte nás finančním příspěvkem. Každý příspěvek se počítá!</p>
         <p>
           Nebo se{" "}
           <Link href="/cs/zapojit-se" className="underline hover:no-underline">
@@ -35,28 +32,8 @@ export default function Page() {
         <p>Vaše podpora je klíčová pro to, abychom mohli pokračovat v naší práci pro nadcházející volby a vylepšovat kalkulačku. Děkujeme!</p>
       </section>
       <section className="grid gap-2">
-        <h3 className="text-2xl font-bold">Přidejte se do klubu podporovatelů</h3>
-        <p>
-          Přidejte se do klubu podporovatelů Volební kalkulačky na{" "}
-          <a href="https://herohero.co/volebnikalkulacka" className="underline hover:no-underline">
-            Herohero
-          </a>{" "}
-          a kromě dobrého pocitu, že pomůžete zajistit tvorbu dalších kalkulaček a podpoříte demokracii:
-        </p>
-        <ul className="list-disc pl-6">
-          <li>vám poděkujeme v kalkulačce</li>
-          <li>získáte exkluzivní přístup ke kalkulačce den před oficiálním spuštěním</li>
-          <li>budete moci navrhnout otázku do kalkulačky a společně s ostatními podporovateli hlasovat, která otázka se do kalkulačky dostane</li>
-        </ul>
-        <div className="flex gap-2">
-          <a className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" href="https://herohero.co/volebnikalkulacka">
-            Přidat se na Herohero
-          </a>
-        </div>
-      </section>
-      <section className="grid gap-2">
         <h3 className="text-2xl font-bold">Jednorázový příspěvek</h3>
-        <p>Nebo nás můžete podpořit i jednorázově:</p>
+        <p>Podpořte nás jednorázovým příspěvkem:</p>
         <div className="max-w-md" data-darujme-widget-token="w2acrk0w61fgr3so">
           Načítám…
         </div>


### PR DESCRIPTION
Removes the Herohero supporters' club everywhere it appears. Darujme is now the only donation route.

- `apps/www.kalkulacka.one/.../podporte-kalkulacku/page.tsx` — drops the whole "Přidejte se do klubu podporovatelů" section (club perks + "Přidat se na Herohero" button), and adjusts the surrounding copy that framed the Darujme widget as the *alternative* to the club ("Nebo nás můžete podpořit i jednorázově" → "Podpořte nás jednorázovým příspěvkem").
- `.github/FUNDING.yml` — drops the `herohero.co` link.

The Darujme widget and its token are untouched.

Note: `npm run typecheck` fails on `apps/www.volebnikalkulacka.cz/server/city-signup.ts` — this is pre-existing on `main` and unrelated to this PR. It's a stale local Prisma client; `schema.prisma` already has `metadata` and `@@unique([email, origin])`, so a `prisma generate` clears it. Lint and tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQyRaMuaD6oCzGHnMLyNLq