### PR TITLE
Track donate clicks in Plausible

### DIFF
--- a/apps/www.volebnakalkulacka.sk/calculator/components/client/donate-card.tsx
+++ b/apps/www.volebnakalkulacka.sk/calculator/components/client/donate-card.tsx
@@ -6,11 +6,15 @@ import { Card } from "@kalkulacka-one/design-system/server";
 import { mdiClose } from "@mdi/js";
 import { useState } from "react";
 
+import { plausibleEvent } from "@/lib/analytics";
+
 export function DonateCard() {
   const [selectedAmount, setSelectedAmount] = useState<string | null>("9");
   const [isVisible, setIsVisible] = useState(true);
 
   if (!isVisible) return null;
+
+  const plausibleClassNames = plausibleEvent("Donate", { source: "result-card", amount: selectedAmount ?? "custom", currency: "EUR" });
 
   const getDarujmeUrl = (amount?: string) => {
     if (amount) {
@@ -79,7 +83,7 @@ export function DonateCard() {
             </button>
           </div>
           <div className="col-span-3 @sm:col-start-2 @sm:col-span-3">
-            <a href={getDarujmeUrl(selectedAmount || undefined)} target="_blank" className="grid">
+            <a href={getDarujmeUrl(selectedAmount || undefined)} target="_blank" className={`grid ${plausibleClassNames}`}>
               <Button variant="outline" color="primary" size="medium">
                 Podporiť Volebnú kalkulačku
               </Button>

--- a/apps/www.volebnakalkulacka.sk/lib/analytics/index.ts
+++ b/apps/www.volebnakalkulacka.sk/lib/analytics/index.ts
@@ -1,0 +1,1 @@
+export * from "./plausible-event";

--- a/apps/www.volebnakalkulacka.sk/lib/analytics/plausible-event.ts
+++ b/apps/www.volebnakalkulacka.sk/lib/analytics/plausible-event.ts
@@ -1,0 +1,7 @@
+// Plausible reads custom events off the class list, which works only with the tagged-events script variant loaded in `components/server/plausible.tsx`
+export function plausibleEvent(name: string, props: Record<string, string | number> = {}): string {
+  // Plausible interprets spaces as separators between tags and encodes them as `+`
+  const encode = (value: string | number) => String(value).trim().replace(/\s+/g, "+");
+
+  return [`plausible-event-name=${encode(name)}`, ...Object.entries(props).map(([key, value]) => `plausible-event-${key}=${encode(value)}`)].join(" ");
+}

--- a/apps/www.volebnikalkulacka.cz/calculator/components/client/donate-card.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/client/donate-card.tsx
@@ -4,11 +4,15 @@ import { Card } from "@kalkulacka-one/design-system/server";
 import { mdiClose } from "@mdi/js";
 import { useState } from "react";
 
+import { plausibleEvent } from "@/lib/analytics";
+
 export function DonateCard() {
   const [selectedAmount, setSelectedAmount] = useState<string | null>("200");
   const [isVisible, setIsVisible] = useState(true);
 
   if (!isVisible) return null;
+
+  const plausibleClassNames = plausibleEvent("Donate", { source: "result-card", amount: selectedAmount ?? "custom", currency: "CZK" });
 
   const getDarujmeUrl = (amount?: string) => {
     if (amount) {
@@ -77,7 +81,7 @@ export function DonateCard() {
             </button>
           </div>
           <div className="col-span-3 @sm:col-start-2 @sm:col-span-3">
-            <a href={getDarujmeUrl(selectedAmount || undefined)} target="_blank" className="grid">
+            <a href={getDarujmeUrl(selectedAmount || undefined)} target="_blank" className={`grid ${plausibleClassNames}`}>
               <Button variant="outline" color="primary" size="medium">
                 Podpořit Volební kalkulačku
               </Button>

--- a/apps/www.volebnikalkulacka.cz/lib/analytics/index.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/analytics/index.ts
@@ -1,0 +1,1 @@
+export * from "./plausible-event";

--- a/apps/www.volebnikalkulacka.cz/lib/analytics/plausible-event.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/analytics/plausible-event.ts
@@ -1,0 +1,7 @@
+// Plausible reads custom events off the class list, which works only with the tagged-events script variant loaded in `components/server/plausible.tsx`
+export function plausibleEvent(name: string, props: Record<string, string | number> = {}): string {
+  // Plausible interprets spaces as separators between tags and encodes them as `+`
+  const encode = (value: string | number) => String(value).trim().replace(/\s+/g, "+");
+
+  return [`plausible-event-name=${encode(name)}`, ...Object.entries(props).map(([key, value]) => `plausible-event-${key}=${encode(value)}`)].join(" ");
+}


### PR DESCRIPTION
Makes donation clicks measurable. Today the donate link is an untagged outbound link, so Plausible records a click count to darujme.cz with no amount, no source and no variant — which means no change to the donate flow can be evaluated.

`script.tagged-events.outbound-links.js` is already loaded in all apps (`components/server/plausible.tsx`); only the class was missing.

**Event**: `Donate`, with props:
- `source` — `result-card` (so later asks on other surfaces are distinguishable)
- `amount` — the selected amount, or `custom` when the user deselects all chips
- `currency` — `CZK` / `EUR`

Applied to CZ and SK. MK's `DonateCard` returns `null`, so nothing to tag.

### Privacy
No new personal data and no cookie: Plausible is cookieless, and the props are amount/currency/source only — nothing identifying. The privacy policy's claim *"Nepoužíváme žádné analytické ani marketingové cookies"* stays true.

Separately, the policy never mentions Plausible at all — a pre-existing gap, addressed in its own PR.

### Not included
Tagging the card's dismiss (×) button. `Button` from the design system omits `className`, so it would need a wrapper element and relies on Plausible walking up the DOM — worth doing, but not worth risking silent no-op instrumentation in the PR that establishes the baseline.

### Checks
`lint:fix` and `test` pass. `typecheck` fails on `apps/www.volebnikalkulacka.cz/server/city-signup.ts` — pre-existing on `main`, unrelated, stale local Prisma client (see #494). SK typecheck is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQyRaMuaD6oCzGHnMLyNLq