### PR TITLE
Disclose analytics in privacy policy

### DIFF
--- a/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/(pages)/soukromi/page.mdx
+++ b/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/(pages)/soukromi/page.mdx
@@ -15,7 +15,7 @@ V tomto dokumentu naleznete informace o tom, jaké údaje o vás zpracovává Vo
 
 ## Cookies
 
-Volební kalkulačka používá pouze **nezbytné cookies**, které slouží k technickému fungování aplikace, zabezpečení a uložení vašeho postupu, abyste nepřišli o rozpracované odpovědi. Tyto cookies se uchovávají maximálně 90 dní. Nepoužíváme žádné analytické ani marketingové cookies.
+Volební kalkulačka používá pouze **nezbytné cookies**, které slouží k technickému fungování aplikace, zabezpečení a uložení vašeho postupu, abyste nepřišli o rozpracované odpovědi. Tyto cookies se uchovávají maximálně 90 dní. Nepoužíváme žádné analytické ani marketingové cookies – nástroj, kterým [měříme návštěvnost](#měření-návštěvnosti), cookies nepoužívá.
 
 ## Jaké osobní údaje zpracováváme, za jakými účely a jak dlouho?
 
@@ -46,6 +46,12 @@ Vaše odpovědi dále využíváme v anonymizované a agregované podobě pro st
 - jak se mění odpovědi na otázky v čase.
 
 Takové informace zveřejňujeme výhradně v agregované podobě, nikdy ne jednotlivě, a není je možné spojit s vaší osobou.
+
+### Měření návštěvnosti
+
+K měření návštěvnosti webu používáme službu [**Plausible**](https://plausible.io), jejíž servery jsou provozovány v Evropské unii. Tato služba je navržena tak, aby nezpracovávala osobní údaje – nepoužívá cookies ani jiné úložiště ve vašem prohlížeči, neukládá vaši IP adresu a nesleduje vás napříč weby ani v čase.
+
+Zaznamenáváme pouze souhrnné údaje o používání webu, například kolik lidí navštívilo jednotlivé stránky, z jakého zdroje na web přišli, jaký typ zařízení použili nebo zda klikli na některý z odkazů – třeba na odkaz pro darování, u kterého evidujeme i zvolenou částku. Tyto údaje jsou vždy agregované a není možné je spojit s vaší osobou.
 
 ## Z jakých zdrojů osobní údaje získáváme?
 

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/(pages)/soukromi/page.mdx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/(pages)/soukromi/page.mdx
@@ -13,7 +13,7 @@ V tomto dokumentu naleznete informace o tom, jaké údaje o vás zpracovává Vo
 
 ## Cookies
 
-Volební kalkulačka používá pouze **nezbytné cookies**, které slouží k technickému fungování aplikace, zabezpečení a uložení vašeho postupu, abyste nepřišli o rozpracované odpovědi. Tyto cookies se uchovávají maximálně 90 dní. Nepoužíváme žádné analytické ani marketingové cookies.
+Volební kalkulačka používá pouze **nezbytné cookies**, které slouží k technickému fungování aplikace, zabezpečení a uložení vašeho postupu, abyste nepřišli o rozpracované odpovědi. Tyto cookies se uchovávají maximálně 90 dní. Nepoužíváme žádné analytické ani marketingové cookies – nástroj, kterým [měříme návštěvnost](#měření-návštěvnosti), cookies nepoužívá.
 
 ## Jaké osobní údaje zpracováváme, za jakými účely a jak dlouho?
 
@@ -44,6 +44,12 @@ Vaše odpovědi dále využíváme v anonymizované a agregované podobě pro st
 - jak se mění odpovědi na otázky v čase.
 
 Takové informace zveřejňujeme výhradně v agregované podobě, nikdy ne jednotlivě, a není je možné spojit s vaší osobou.
+
+### Měření návštěvnosti
+
+K měření návštěvnosti webu používáme službu [**Plausible**](https://plausible.io), jejíž servery jsou provozovány v Evropské unii. Tato služba je navržena tak, aby nezpracovávala osobní údaje – nepoužívá cookies ani jiné úložiště ve vašem prohlížeči, neukládá vaši IP adresu a nesleduje vás napříč weby ani v čase.
+
+Zaznamenáváme pouze souhrnné údaje o používání webu, například kolik lidí navštívilo jednotlivé stránky, z jakého zdroje na web přišli, jaký typ zařízení použili nebo zda klikli na některý z odkazů – třeba na odkaz pro darování, u kterého evidujeme i zvolenou částku. Tyto údaje jsou vždy agregované a není možné je spojit s vaší osobou.
 
 ## Z jakých zdrojů osobní údaje získáváme?
 


### PR DESCRIPTION
Closes a pre-existing gap: the privacy policy never mentioned Plausible, which has been running in production on the CZ and SK apps (`components/server/plausible.tsx`, enabled by default on Vercel prod). The "Statistiky a analytika" section only covers aggregated *answers*, not web analytics.

- New **"Měření návštěvnosti"** subsection: names Plausible, states EU-hosted, no cookies or browser storage, no IP stored, no cross-site or cross-session tracking, and lists what is actually recorded — pages, referrer, device type, and link clicks including the donate amount (see #495).
- The cookies section now cross-references it, so *"Nepoužíváme žádné analytické ani marketingové cookies"* reads as a deliberate statement rather than an omission.

Applied to CZ and SK. MK has `ENABLE_ANALYTICS=false` and no privacy page, so nothing to disclose there.

### ⚠️ Needs review before merge
This is a legal document and I drafted it — please have whoever handles this for KohoVolit.eu check it. Two specifics I deliberately left soft because I could not verify them from the repo:

1. **No processor entity named.** I wrote "jejíž servery jsou provozovány v Evropské unii" rather than naming Plausible's legal entity and country. If you have that from the DPA, it belongs here, and probably also in the "Komu osobní údaje předáváme?" processor list.
2. **`ANALYTICS_PROXY`** — when enabled, requests are proxied through your own domain first. Not described; add a sentence if you consider it material.

The SK page carries `TODO [TENANT-004/010]` and is still entirely in Czech — this section is added in Czech to match. It will need translating with the rest of that page.

### Checks
`lint:fix` passes; MDX content only, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EQyRaMuaD6oCzGHnMLyNLq