### PR TITLE
Fix drift between Zod and JSON schemas

### DIFF
--- a/packages/schema/schemas/calculator-group.schema.json
+++ b/packages/schema/schemas/calculator-group.schema.json
@@ -79,12 +79,7 @@
       "type": "array",
       "minItems": 1,
       "items": {
-        "type": "object",
-        "properties": {
-          "key": {
-            "$ref": "./variant.schema.json#/properties/key"
-          }
-        }
+        "$ref": "./variant.schema.json"
       }
     }
   },

--- a/packages/schema/schemas/calculator-group.schema.ts
+++ b/packages/schema/schemas/calculator-group.schema.ts
@@ -10,10 +10,12 @@ const calculatorGroupKeySchema = z
   .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
   .describe("Human-friendly unique key of a standalone calculator group in the hyphen-separated lowercased format");
 
-export const calculatorGroupSchemaReference = z.object({
-  id: calculatorGroupIdSchema,
-  key: calculatorGroupKeySchema,
-});
+export const calculatorGroupSchemaReference = z
+  .object({
+    id: calculatorGroupIdSchema,
+    key: calculatorGroupKeySchema,
+  })
+  .strict();
 
 export const calculatorGroupBaseSchema = z
   .object({

--- a/packages/schema/schemas/calculator.schema.json
+++ b/packages/schema/schemas/calculator.schema.json
@@ -165,7 +165,8 @@
           "unevaluatedProperties": false
         }
       },
-      "unevaluatedProperties": false
+      "unevaluatedProperties": false,
+      "required": ["questions"]
     },
     "changes": {
       "title": "Changes",

--- a/packages/schema/schemas/calculator.schema.ts
+++ b/packages/schema/schemas/calculator.schema.ts
@@ -1,12 +1,12 @@
 import { z } from "zod";
 
 import * as calculatorGroupSchema from "./calculator-group.schema";
-import { districtSchema } from "./district.schema";
+import { districtReferenceSchema } from "./district.schema";
 import * as electionSchema from "./election.schema";
 import { imagesSchema } from "./images.schema";
-import { roundSchema } from "./round.schema";
+import { roundReferenceSchema } from "./round.schema";
 import { tagsSchema } from "./tags.schema";
-import { variantSchema } from "./variant.schema";
+import { variantReferenceSchema } from "./variant.schema";
 
 const calculatorGroup = z.lazy(() => calculatorGroupSchema.calculatorGroupSchemaReference).describe("Reference to a calculator group the calculator belongs to");
 const election = z.lazy(() => electionSchema.electionSchemaReference).describe("Reference to an election the calculator belongs to");
@@ -74,8 +74,8 @@ const standaloneCalculatorSchema = calculatorBaseSchema
 const groupCalculatorSchema = calculatorBaseSchema
   .extend({
     calculatorGroup: calculatorGroup,
-    variant: variantSchema,
-    shortTitle: z.string().max(25).describe("Short title of a calculator with a maximum of 25 characters"),
+    variant: variantReferenceSchema,
+    shortTitle: z.string().max(25).describe("Short title of a calculator with a maximum of 25 characters").optional(),
   })
   .strict();
 
@@ -84,9 +84,9 @@ const electionCalculatorSchema = calculatorBaseSchema
     calculatorGroup: calculatorGroup,
     election: election,
     shortTitle: z.string().max(25).describe("Short title of a calculator with a maximum of 25 characters").optional(),
-    variant: variantSchema.optional(),
-    district: districtSchema.optional(),
-    round: roundSchema.optional(),
+    variant: variantReferenceSchema.optional(),
+    district: districtReferenceSchema.optional(),
+    round: roundReferenceSchema.optional(),
   })
   .strict()
   .superRefine((data, ctx) => {
@@ -102,6 +102,6 @@ export const calculatorSchema = standaloneCalculatorSchema.or(groupCalculatorSch
 
 export type Calculator = z.infer<typeof calculatorSchema>;
 
-export const calculatorVariantSchema = variantSchema;
-export const calculatorDistrictSchema = districtSchema;
-export const calculatorRoundSchema = roundSchema;
+export const calculatorVariantSchema = variantReferenceSchema;
+export const calculatorDistrictSchema = districtReferenceSchema;
+export const calculatorRoundSchema = roundReferenceSchema;

--- a/packages/schema/schemas/district.schema.ts
+++ b/packages/schema/schemas/district.schema.ts
@@ -1,14 +1,19 @@
 import { z } from "zod";
 
+const districtKeySchema = z
+  .string()
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
+  .describe("Human-friendly unique key of a district in the hyphen-separated lowercased format");
+
+export const districtReferenceSchema = z.object({ key: districtKeySchema }).strict().describe("Reference to a district of an election");
+
 export const districtSchema = z
   .object({
-    key: z
-      .string()
-      .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
-      .describe("Human-friendly unique key of a district in the hyphen-separated lowercased format"),
+    key: districtKeySchema,
     code: z.string().describe("Official district code assigned by the election authority").optional(),
   })
   .strict()
   .describe("Geographical area of an election");
 
 export type District = z.infer<typeof districtSchema>;
+export type DistrictReference = z.infer<typeof districtReferenceSchema>;

--- a/packages/schema/schemas/election.schema.ts
+++ b/packages/schema/schemas/election.schema.ts
@@ -12,10 +12,12 @@ const electionKeySchema = z
   .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
   .describe("Human-friendly unique key of an election in the hyphen-separated lowercased format");
 
-export const electionSchemaReference = z.object({
-  id: electionIdSchema,
-  key: electionKeySchema,
-});
+export const electionSchemaReference = z
+  .object({
+    id: electionIdSchema,
+    key: electionKeySchema,
+  })
+  .strict();
 
 export const electionBaseSchema = z
   .object({

--- a/packages/schema/schemas/round.schema.ts
+++ b/packages/schema/schemas/round.schema.ts
@@ -2,12 +2,17 @@ import { z } from "zod";
 
 import { timePeriodSchema } from "./time-period.schema";
 
+const roundNumberSchema = z.number().int().min(0).describe("Round ordinal number from 0");
+
+export const roundReferenceSchema = z.object({ number: roundNumberSchema }).strict().describe("Reference to a round of an election");
+
 export const roundSchema = z
   .object({
-    number: z.number().int().min(0).describe("Round ordinal number from 0"),
+    number: roundNumberSchema,
     votingHours: z.array(timePeriodSchema).min(1).describe("One or multiple voting hours for the round").optional(),
   })
   .strict()
   .describe("Round of an election");
 
 export type Round = z.infer<typeof roundSchema>;
+export type RoundReference = z.infer<typeof roundReferenceSchema>;

--- a/packages/schema/schemas/time-period.schema.ts
+++ b/packages/schema/schemas/time-period.schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 // TODO: refine date schema check or zod update (the latest miniflare stil lists zod@3.22 as its dep)
 export const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
-export const dateTimeSchema = z.string().datetime();
+export const dateTimeSchema = z.string().datetime({ offset: true });
 
 export const timePeriodSchema = z
   .object({

--- a/packages/schema/schemas/variant.schema.ts
+++ b/packages/schema/schemas/variant.schema.ts
@@ -1,14 +1,19 @@
 import { z } from "zod";
 
+const variantKeySchema = z
+  .string()
+  .trim()
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
+  .describe("Human-friendly unique key of a variant in the hyphen-separated lowercased format");
+
+export const variantReferenceSchema = z.object({ key: variantKeySchema }).strict().describe("Reference to a variant of a calculator group");
+
 export const variantSchema = z
   .object({
-    key: z
-      .string()
-      .trim()
-      .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
-      .describe("Human-friendly unique key of a variant in the hyphen-separated lowercased format"),
+    key: variantKeySchema,
   })
   .strict()
   .describe("Variant of a calculator");
 
 export type Variant = z.infer<typeof variantSchema>;
+export type VariantReference = z.infer<typeof variantReferenceSchema>;


### PR DESCRIPTION
## Summary

Align the hand-maintained JSON Schemas and the Zod schemas (the ones the apps enforce at request time) where they had drifted. Groundwork for the 2026 senate/municipal schema additions.

- Zod: a calculator's `district` / `round` / `variant` are **references** (`{ key }`, `{ number }`) as the JSON Schema already said; full objects live on the election (`districts`, `rounds`) and the calculator group (`variants`). New `districtReferenceSchema` / `roundReferenceSchema` / `variantReferenceSchema` exports
- Zod: group calculator `shortTitle` optional as in the JSON Schema (derivable from group + variant, same as election calculators)
- `calculator.schema.json`: `checksums.questions` required, as in Zod
- `calculator-group.schema.json`: `variants[]` items are full variant objects (were an unconstrained object)
- Zod: `calculatorGroupSchemaReference` / `electionSchemaReference` are `.strict()` like the JSON
- Zod: `dateTimeSchema` accepts timezone offsets like JSON `format: date-time` (needed for `votingHours`)

## Verification

- `npm run typecheck`, `npm run lint:fix`, `npm run test` pass
- All 131 JSON files in `kalkulacka-one/data` pass **both** ajv (same setup as the data repo's `validate.yaml`) and Zod, before and after
- Probe cases that previously passed one side only (group calculator without `shortTitle`, `district.code` inside `calculator.json`, `checksums: {}`, offset datetimes, extra props on references, `variants: [{}]`) now agree

Not touched (deliberate, semantic drift only): UUID version strictness, `answer.sources[].url` (`.url()` vs `format: uri`), `candidates-answers` `minItems` / `respondent: "user"`, `variant.key` `.trim()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k2GxD7g1T9Eh2yVYmhvJt
