### PR TITLE
Support district and round based elections in the schema

### DIFF
--- a/packages/schema/schemas/calculator-group.schema.json
+++ b/packages/schema/schemas/calculator-group.schema.json
@@ -47,7 +47,7 @@
       "examples": ["Prezidentské volby 2023"]
     },
     "shortTitle": {
-      "title": "shortTitle",
+      "title": "Short title",
       "description": "Short title of a calculator group with a maximum of 25 characters",
       "type": "string",
       "maxLength": 25,
@@ -61,7 +61,7 @@
     },
     "election": {
       "title": "Election",
-      "description": "Reference to an election the calculator belongs to",
+      "description": "Reference to an election the calculator group belongs to",
       "type": "object",
       "properties": {
         "id": {
@@ -89,7 +89,7 @@
       "properties": {
         "title": {
           "title": "Title",
-          "description": "Heading of the calculator picker; overrides the app default for the district kind",
+          "description": "Heading of the calculator picker; overrides the app default",
           "type": "string",
           "examples": ["Zvolte své město"]
         },
@@ -100,13 +100,13 @@
         },
         "searchPlaceholder": {
           "title": "Search placeholder",
-          "description": "Placeholder of the search field in the calculator picker",
+          "description": "Placeholder of the calculator picker search field",
           "type": "string",
           "examples": ["Hledat město…"]
         },
         "showCode": {
           "title": "Show code",
-          "description": "Whether to display district codes next to district names; overrides the app default for the district kind",
+          "description": "Whether to display district codes next to district names; overrides the app default",
           "type": "boolean"
         }
       },
@@ -166,7 +166,7 @@
               },
               "key": {
                 "title": "Key",
-                "description": "Key of the calculator; the last URL segment",
+                "description": "Key of the calculator; forms the last URL segment",
                 "$ref": "./calculator.schema.json#/$defs/key"
               },
               "variant": {
@@ -198,7 +198,7 @@
               },
               "key": {
                 "title": "Key",
-                "description": "Key of the calculator; the last URL segment",
+                "description": "Key of the calculator; forms the last URL segment",
                 "$ref": "./calculator.schema.json#/$defs/key"
               },
               "variant": {

--- a/packages/schema/schemas/calculator-group.schema.json
+++ b/packages/schema/schemas/calculator-group.schema.json
@@ -131,12 +131,17 @@
               "id": {
                 "$ref": "./calculator.schema.json#/$defs/id"
               },
+              "key": {
+                "title": "Key",
+                "description": "Key of the calculator; the last URL segment",
+                "$ref": "./calculator.schema.json#/$defs/key"
+              },
               "variant": {
                 "$ref": "./calculator.schema.json#/$defs/variant"
               }
             },
             "unevaluatedProperties": false,
-            "required": ["id", "variant"]
+            "required": ["id", "key", "variant"]
           }
         }
       },
@@ -155,6 +160,11 @@
               "id": {
                 "$ref": "./calculator.schema.json#/$defs/id"
               },
+              "key": {
+                "title": "Key",
+                "description": "Key of the calculator; the last URL segment",
+                "$ref": "./calculator.schema.json#/$defs/key"
+              },
               "variant": {
                 "$ref": "./calculator.schema.json#/$defs/variant"
               },
@@ -166,7 +176,7 @@
               }
             },
             "unevaluatedProperties": false,
-            "required": ["id"],
+            "required": ["id", "key"],
             "anyOf": [
               {
                 "required": ["variant"]

--- a/packages/schema/schemas/calculator-group.schema.json
+++ b/packages/schema/schemas/calculator-group.schema.json
@@ -81,6 +81,36 @@
       "items": {
         "$ref": "./variant.schema.json"
       }
+    },
+    "selection": {
+      "title": "Selection",
+      "description": "Optional copy and display overrides for the calculator picker",
+      "type": "object",
+      "properties": {
+        "title": {
+          "title": "Title",
+          "description": "Heading of the calculator picker; overrides the app default for the district kind",
+          "type": "string",
+          "examples": ["Zvolte své město"]
+        },
+        "description": {
+          "title": "Description",
+          "description": "Description shown in the calculator picker",
+          "type": "string"
+        },
+        "searchPlaceholder": {
+          "title": "Search placeholder",
+          "description": "Placeholder of the search field in the calculator picker",
+          "type": "string",
+          "examples": ["Hledat město…"]
+        },
+        "showCode": {
+          "title": "Show code",
+          "description": "Whether to display district codes next to district names; overrides the app default for the district kind",
+          "type": "boolean"
+        }
+      },
+      "unevaluatedProperties": false
     }
   },
   "properties": {
@@ -113,6 +143,9 @@
     },
     "description": {
       "$ref": "#/$defs/description"
+    },
+    "selection": {
+      "$ref": "#/$defs/selection"
     }
   },
   "unevaluatedProperties": false,

--- a/packages/schema/schemas/calculator-group.schema.json
+++ b/packages/schema/schemas/calculator-group.schema.json
@@ -178,7 +178,10 @@
           }
         }
       },
-      "required": ["shortTitle", "calculators"]
+      "required": ["shortTitle", "calculators"],
+      "not": {
+        "required": ["election"]
+      }
     },
     {
       "properties": {
@@ -224,7 +227,10 @@
           }
         }
       },
-      "required": ["election", "calculators"]
+      "required": ["election", "calculators"],
+      "not": {
+        "required": ["shortTitle"]
+      }
     }
   ]
 }

--- a/packages/schema/schemas/calculator-group.schema.ts
+++ b/packages/schema/schemas/calculator-group.schema.ts
@@ -5,6 +5,11 @@ import * as electionSchema from "./election.schema";
 import { variantSchema } from "./variant.schema";
 
 const calculatorGroupIdSchema = z.string().uuid().describe("Unique identifier of a calculator group in the format of UUID");
+const calculatorKeySchema = z
+  .string()
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
+  .describe("Key of the calculator; the last URL segment");
+
 const calculatorGroupKeySchema = z
   .string()
   .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
@@ -36,6 +41,7 @@ export const calculatorItemSchema = z.lazy(() =>
   calculatorBaseSchema
     .pick({ id: true })
     .extend({
+      key: calculatorKeySchema,
       variant: calculatorVariantSchema,
     })
     .strict(),
@@ -53,6 +59,7 @@ export const electionCalculatorItemSchema = z.lazy(() =>
   calculatorBaseSchema
     .pick({ id: true })
     .extend({
+      key: calculatorKeySchema,
       variant: calculatorVariantSchema.optional(),
       district: calculatorDistrictSchema.optional(),
       round: calculatorRoundSchema.optional(),

--- a/packages/schema/schemas/calculator-group.schema.ts
+++ b/packages/schema/schemas/calculator-group.schema.ts
@@ -45,7 +45,7 @@ export const standaloneCalculatorInGroupSchema = calculatorGroupBaseSchema
   .extend({
     shortTitle: z.string().max(25).describe("Short title of a calculator group with a maximum of 25 characters"),
     calculators: z.array(calculatorItemSchema).min(1).describe("Ordered list of calculators"),
-    election: z.undefined(),
+    election: z.undefined().optional(),
   })
   .strict();
 
@@ -67,7 +67,7 @@ export const electionCalculatorGroupSchema = calculatorGroupBaseSchema
   .extend({
     election: z.lazy((): z.ZodType<electionSchema.ElectionReference> => electionSchema.electionSchemaReference),
     calculators: z.array(electionCalculatorItemSchema).min(1).describe("Ordered list of calculators from an election"),
-    shortTitle: z.undefined(),
+    shortTitle: z.undefined().optional(),
   })
   .strict();
 

--- a/packages/schema/schemas/calculator-group.schema.ts
+++ b/packages/schema/schemas/calculator-group.schema.ts
@@ -10,6 +10,16 @@ const calculatorKeySchema = z
   .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
   .describe("Key of the calculator; the last URL segment");
 
+const selectionSchema = z
+  .object({
+    title: z.string().describe("Heading of the calculator picker; overrides the app default for the district kind").optional(),
+    description: z.string().describe("Description shown in the calculator picker").optional(),
+    searchPlaceholder: z.string().describe("Placeholder of the search field in the calculator picker").optional(),
+    showCode: z.boolean().describe("Whether to display district codes next to district names; overrides the app default for the district kind").optional(),
+  })
+  .strict()
+  .describe("Optional copy and display overrides for the calculator picker");
+
 const calculatorGroupKeySchema = z
   .string()
   .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
@@ -34,6 +44,7 @@ export const calculatorGroupBaseSchema = z
     description: z.string().describe("Description of a calculator group").optional(),
     election: z.lazy((): z.ZodType<electionSchema.ElectionReference> => electionSchema.electionSchemaReference).optional(),
     variants: z.array(variantSchema).min(1).describe("Ordered list of calculator variants").optional(),
+    selection: selectionSchema.optional(),
   })
   .strict();
 

--- a/packages/schema/schemas/calculator-group.schema.ts
+++ b/packages/schema/schemas/calculator-group.schema.ts
@@ -8,14 +8,14 @@ const calculatorGroupIdSchema = z.string().uuid().describe("Unique identifier of
 const calculatorKeySchema = z
   .string()
   .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
-  .describe("Key of the calculator; the last URL segment");
+  .describe("Key of the calculator; forms the last URL segment");
 
 const selectionSchema = z
   .object({
-    title: z.string().describe("Heading of the calculator picker; overrides the app default for the district kind").optional(),
+    title: z.string().describe("Heading of the calculator picker; overrides the app default").optional(),
     description: z.string().describe("Description shown in the calculator picker").optional(),
-    searchPlaceholder: z.string().describe("Placeholder of the search field in the calculator picker").optional(),
-    showCode: z.boolean().describe("Whether to display district codes next to district names; overrides the app default for the district kind").optional(),
+    searchPlaceholder: z.string().describe("Placeholder of the calculator picker search field").optional(),
+    showCode: z.boolean().describe("Whether to display district codes next to district names; overrides the app default").optional(),
   })
   .strict()
   .describe("Optional copy and display overrides for the calculator picker");
@@ -23,7 +23,7 @@ const selectionSchema = z
 const calculatorGroupKeySchema = z
   .string()
   .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
-  .describe("Human-friendly unique key of a standalone calculator group in the hyphen-separated lowercased format");
+  .describe("Human-friendly unique key of a calculator group in the hyphen-separated lowercased format");
 
 export const calculatorGroupSchemaReference = z
   .object({

--- a/packages/schema/schemas/calculator.schema.json
+++ b/packages/schema/schemas/calculator.schema.json
@@ -238,22 +238,18 @@
   "oneOf": [
     {
       "title": "Standalone calculator",
-      "description": "Standalone calculator is a calculator that is not part of a calculator group",
+      "description": "Standalone calculator is a calculator that is not part of a calculator group, optionally referencing an election",
       "properties": {
         "key": {
           "$ref": "#/$defs/key"
+        },
+        "election": {
+          "$ref": "#/$defs/election"
         }
       },
       "required": ["key", "shortTitle"],
       "not": {
-        "anyOf": [
-          {
-            "required": ["calculatorGroup"]
-          },
-          {
-            "required": ["election"]
-          }
-        ]
+        "required": ["calculatorGroup"]
       }
     },
     {

--- a/packages/schema/schemas/calculator.schema.json
+++ b/packages/schema/schemas/calculator.schema.json
@@ -123,24 +123,14 @@
       "required": ["key"]
     },
     "district": {
-      "type": "object",
-      "properties": {
-        "key": {
-          "$ref": "./district.schema.json#/properties/key"
-        }
-      },
-      "unevaluatedProperties": false,
-      "required": ["key"]
+      "title": "District",
+      "description": "Reference to a district of the election the calculator belongs to",
+      "$ref": "./district.schema.json#/$defs/reference"
     },
     "round": {
-      "type": "object",
-      "properties": {
-        "number": {
-          "$ref": "./round.schema.json#/properties/number"
-        }
-      },
-      "unevaluatedProperties": false,
-      "required": ["number"]
+      "title": "Round",
+      "description": "Reference to a round of the election the calculator belongs to",
+      "$ref": "./round.schema.json#/$defs/reference"
     },
     "checksums": {
       "title": "Checksums",

--- a/packages/schema/schemas/calculator.schema.json
+++ b/packages/schema/schemas/calculator.schema.json
@@ -14,7 +14,7 @@
     },
     "key": {
       "title": "Key",
-      "description": "Human-friendly unique key of a standalone calculator in the hyphen-separated lowercased format",
+      "description": "Human-friendly unique key of a calculator in the hyphen-separated lowercased format; for calculators in a group it is the last URL segment",
       "type": "string",
       "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
       "examples": ["doprava-v-praze"]
@@ -246,13 +246,23 @@
       },
       "required": ["key", "shortTitle"],
       "not": {
-        "required": ["calculatorGroup", "election"]
+        "anyOf": [
+          {
+            "required": ["calculatorGroup"]
+          },
+          {
+            "required": ["election"]
+          }
+        ]
       }
     },
     {
       "title": "Calculator from a group",
       "description": "Calculator that is part of a calculator group",
       "properties": {
+        "key": {
+          "$ref": "#/$defs/key"
+        },
         "calculatorGroup": {
           "$ref": "#/$defs/calculatorGroup"
         },
@@ -269,6 +279,9 @@
       "title": "Calculator from an election",
       "description": "Calculator that is part of an election",
       "properties": {
+        "key": {
+          "$ref": "#/$defs/key"
+        },
         "calculatorGroup": {
           "$ref": "#/$defs/calculatorGroup"
         },

--- a/packages/schema/schemas/calculator.schema.json
+++ b/packages/schema/schemas/calculator.schema.json
@@ -14,7 +14,7 @@
     },
     "key": {
       "title": "Key",
-      "description": "Human-friendly unique key of a calculator in the hyphen-separated lowercased format; for calculators in a group it is the last URL segment",
+      "description": "Human-friendly unique key of a calculator in the hyphen-separated lowercased format; forms the last URL segment",
       "type": "string",
       "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
       "examples": ["doprava-v-praze"]
@@ -54,7 +54,7 @@
       "examples": ["2. kolo prezidentských voleb 2023"]
     },
     "shortTitle": {
-      "title": "shortTitle",
+      "title": "Short title",
       "description": "Short title of a calculator with a maximum of 25 characters",
       "type": "string",
       "maxLength": 25,

--- a/packages/schema/schemas/calculator.schema.ts
+++ b/packages/schema/schemas/calculator.schema.ts
@@ -69,6 +69,7 @@ const standaloneCalculatorSchema = calculatorBaseSchema
   .extend({
     key: keySchema,
     shortTitle: z.string().max(25).describe("Short title of a calculator with a maximum of 25 characters"),
+    election: election.optional(),
   })
 
   .strict();

--- a/packages/schema/schemas/calculator.schema.ts
+++ b/packages/schema/schemas/calculator.schema.ts
@@ -11,6 +11,11 @@ import { variantReferenceSchema } from "./variant.schema";
 const calculatorGroup = z.lazy(() => calculatorGroupSchema.calculatorGroupSchemaReference).describe("Reference to a calculator group the calculator belongs to");
 const election = z.lazy(() => electionSchema.electionSchemaReference).describe("Reference to an election the calculator belongs to");
 
+const keySchema = z
+  .string()
+  .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
+  .describe("Human-friendly unique key of a calculator in the hyphen-separated lowercased format; for calculators in a group it is the last URL segment");
+
 const versionSchema = z
   .string()
   .regex(/^\d+\.\d+\.\d+$/)
@@ -62,10 +67,7 @@ export const calculatorBaseSchema = z.object({
 
 const standaloneCalculatorSchema = calculatorBaseSchema
   .extend({
-    key: z
-      .string()
-      .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
-      .describe("Human-friendly unique key of a standalone calculator in the hyphen-separated lowercased format"),
+    key: keySchema,
     shortTitle: z.string().max(25).describe("Short title of a calculator with a maximum of 25 characters"),
   })
 
@@ -73,6 +75,7 @@ const standaloneCalculatorSchema = calculatorBaseSchema
 
 const groupCalculatorSchema = calculatorBaseSchema
   .extend({
+    key: keySchema.optional(),
     calculatorGroup: calculatorGroup,
     variant: variantReferenceSchema,
     shortTitle: z.string().max(25).describe("Short title of a calculator with a maximum of 25 characters").optional(),
@@ -81,6 +84,7 @@ const groupCalculatorSchema = calculatorBaseSchema
 
 const electionCalculatorSchema = calculatorBaseSchema
   .extend({
+    key: keySchema.optional(),
     calculatorGroup: calculatorGroup,
     election: election,
     shortTitle: z.string().max(25).describe("Short title of a calculator with a maximum of 25 characters").optional(),

--- a/packages/schema/schemas/calculator.schema.ts
+++ b/packages/schema/schemas/calculator.schema.ts
@@ -14,7 +14,7 @@ const election = z.lazy(() => electionSchema.electionSchemaReference).describe("
 const keySchema = z
   .string()
   .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/)
-  .describe("Human-friendly unique key of a calculator in the hyphen-separated lowercased format; for calculators in a group it is the last URL segment");
+  .describe("Human-friendly unique key of a calculator in the hyphen-separated lowercased format; forms the last URL segment");
 
 const versionSchema = z
   .string()

--- a/packages/schema/schemas/candidate.schema.json
+++ b/packages/schema/schemas/candidate.schema.json
@@ -74,6 +74,22 @@
       "items": {
         "$ref": "#"
       }
+    },
+    "rounds": {
+      "title": "Rounds",
+      "description": "Round numbers the candidate takes part in; omitted means all rounds of the election",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "examples": [[1], [1, 2]]
+    },
+    "elected": {
+      "title": "Elected",
+      "description": "Whether the candidate has already been elected (e.g. in the first round)",
+      "type": "boolean"
     }
   },
   "unevaluatedProperties": false,

--- a/packages/schema/schemas/candidate.schema.json
+++ b/packages/schema/schemas/candidate.schema.json
@@ -77,18 +77,19 @@
     },
     "rounds": {
       "title": "Rounds",
-      "description": "Round numbers the candidate takes part in; omitted means all rounds of the election",
+      "description": "Round numbers the candidate takes part in; omitted means all rounds",
       "type": "array",
       "minItems": 1,
       "items": {
         "type": "integer",
         "minimum": 1
       },
-      "examples": [[1], [1, 2]]
+      "examples": [[1], [1, 2]],
+      "uniqueItems": true
     },
     "elected": {
       "title": "Elected",
-      "description": "Whether the candidate has already been elected (e.g. in the first round)",
+      "description": "Whether the candidate has already won the seat (e.g. in the first round)",
       "type": "boolean"
     }
   },

--- a/packages/schema/schemas/candidate.schema.ts
+++ b/packages/schema/schemas/candidate.schema.ts
@@ -21,8 +21,13 @@ export const candidateBaseSchema = z
     images: imagesSchema.optional(),
     motto: z.string().describe("Motto of a candidate").optional(),
     number: z.number().int().describe("Official candidate list (usually drawn) number assigned by a public authority").optional(),
-    rounds: z.array(z.number().int().min(1)).min(1).describe("Round numbers the candidate takes part in; omitted means all rounds of the election").optional(),
-    elected: z.boolean().describe("Whether the candidate has already been elected (e.g. in the first round)").optional(),
+    rounds: z
+      .array(z.number().int().min(1))
+      .min(1)
+      .refine((rounds) => new Set(rounds).size === rounds.length, { message: "Round numbers must be unique" })
+      .describe("Round numbers the candidate takes part in; omitted means all rounds")
+      .optional(),
+    elected: z.boolean().describe("Whether the candidate has already won the seat (e.g. in the first round)").optional(),
   })
   .strict()
   .describe("Candidate for a calculator");

--- a/packages/schema/schemas/candidate.schema.ts
+++ b/packages/schema/schemas/candidate.schema.ts
@@ -21,6 +21,8 @@ export const candidateBaseSchema = z
     images: imagesSchema.optional(),
     motto: z.string().describe("Motto of a candidate").optional(),
     number: z.number().int().describe("Official candidate list (usually drawn) number assigned by a public authority").optional(),
+    rounds: z.array(z.number().int().min(1)).min(1).describe("Round numbers the candidate takes part in; omitted means all rounds of the election").optional(),
+    elected: z.boolean().describe("Whether the candidate has already been elected (e.g. in the first round)").optional(),
   })
   .strict()
   .describe("Candidate for a calculator");

--- a/packages/schema/schemas/district.schema.json
+++ b/packages/schema/schemas/district.schema.json
@@ -16,9 +16,33 @@
       "title": "Code",
       "description": "Official district code assigned by the election authority",
       "type": "string",
-      "examples": ["554782"]
+      "examples": ["27", "554782"]
+    },
+    "kind": {
+      "title": "Kind",
+      "description": "Kind of the territorial unit; drives the district picker copy and whether the code is displayed",
+      "type": "string",
+      "enum": ["municipality", "municipal-district", "electoral-district", "region"]
+    },
+    "title": {
+      "title": "Title",
+      "description": "Human-readable name of the district",
+      "type": "string",
+      "examples": ["Praha 6", "Cheb"]
+    },
+    "shortTitle": {
+      "title": "Short title",
+      "description": "Short name of the district with a maximum of 25 characters",
+      "type": "string",
+      "maxLength": 25,
+      "examples": ["Praha 6"]
+    },
+    "parent": {
+      "title": "Parent",
+      "description": "Key of the parent district (e.g. a city for its city district)",
+      "$ref": "#/properties/key"
     }
   },
   "unevaluatedProperties": false,
-  "required": ["key"]
+  "required": ["key", "kind", "title"]
 }

--- a/packages/schema/schemas/district.schema.json
+++ b/packages/schema/schemas/district.schema.json
@@ -20,7 +20,7 @@
     },
     "kind": {
       "title": "Kind",
-      "description": "Kind of the territorial unit; drives the district picker copy and whether the code is displayed",
+      "description": "Kind of the territorial unit: municipality (e.g. Brno), municipal-district (e.g. Praha 6), electoral-district (purpose-drawn, e.g. a Senate constituency), or region (e.g. kraj)",
       "type": "string",
       "enum": ["municipality", "municipal-district", "electoral-district", "region"]
     },
@@ -39,7 +39,7 @@
     },
     "parent": {
       "title": "Parent",
-      "description": "Key of the parent district (e.g. a city for its city district)",
+      "description": "Key of the parent district within the same election",
       "$ref": "#/properties/key"
     }
   },

--- a/packages/schema/schemas/district.schema.json
+++ b/packages/schema/schemas/district.schema.json
@@ -44,5 +44,19 @@
     }
   },
   "unevaluatedProperties": false,
-  "required": ["key", "kind", "title"]
+  "required": ["key", "kind", "title"],
+  "$defs": {
+    "reference": {
+      "title": "District reference",
+      "description": "Reference to a district of an election",
+      "type": "object",
+      "properties": {
+        "key": {
+          "$ref": "#/properties/key"
+        }
+      },
+      "unevaluatedProperties": false,
+      "required": ["key"]
+    }
+  }
 }

--- a/packages/schema/schemas/district.schema.ts
+++ b/packages/schema/schemas/district.schema.ts
@@ -11,6 +11,10 @@ export const districtSchema = z
   .object({
     key: districtKeySchema,
     code: z.string().describe("Official district code assigned by the election authority").optional(),
+    kind: z.enum(["municipality", "municipal-district", "electoral-district", "region"]).describe("Kind of the territorial unit; drives the district picker copy and whether the code is displayed"),
+    title: z.string().describe("Human-readable name of the district"),
+    shortTitle: z.string().max(25).describe("Short name of the district with a maximum of 25 characters").optional(),
+    parent: districtKeySchema.describe("Key of the parent district (e.g. a city for its city district)").optional(),
   })
   .strict()
   .describe("Geographical area of an election");

--- a/packages/schema/schemas/district.schema.ts
+++ b/packages/schema/schemas/district.schema.ts
@@ -11,10 +11,12 @@ export const districtSchema = z
   .object({
     key: districtKeySchema,
     code: z.string().describe("Official district code assigned by the election authority").optional(),
-    kind: z.enum(["municipality", "municipal-district", "electoral-district", "region"]).describe("Kind of the territorial unit; drives the district picker copy and whether the code is displayed"),
+    kind: z
+      .enum(["municipality", "municipal-district", "electoral-district", "region"])
+      .describe("Kind of the territorial unit: municipality (e.g. Brno), municipal-district (e.g. Praha 6), electoral-district (purpose-drawn, e.g. a Senate constituency), or region (e.g. kraj)"),
     title: z.string().describe("Human-readable name of the district"),
     shortTitle: z.string().max(25).describe("Short name of the district with a maximum of 25 characters").optional(),
-    parent: districtKeySchema.describe("Key of the parent district (e.g. a city for its city district)").optional(),
+    parent: districtKeySchema.describe("Key of the parent district within the same election").optional(),
   })
   .strict()
   .describe("Geographical area of an election");

--- a/packages/schema/schemas/election.schema.json
+++ b/packages/schema/schemas/election.schema.json
@@ -47,7 +47,7 @@
       "examples": ["Prezidentské volby 2023"]
     },
     "shortTitle": {
-      "title": "shortTitle",
+      "title": "Short title",
       "description": "Short title of an election with a maximum of 25 characters",
       "type": "string",
       "maxLength": 25,

--- a/packages/schema/schemas/round.schema.json
+++ b/packages/schema/schemas/round.schema.json
@@ -7,10 +7,10 @@
   "properties": {
     "number": {
       "title": "Number",
-      "description": "Round ordinal number from 0",
+      "description": "Round ordinal number from 1",
       "type": "integer",
-      "minimum": 0,
-      "examples": [0, 1]
+      "minimum": 1,
+      "examples": [1, 2]
     },
     "votingHours": {
       "title": "Voting hours",

--- a/packages/schema/schemas/round.schema.json
+++ b/packages/schema/schemas/round.schema.json
@@ -23,5 +23,19 @@
     }
   },
   "unevaluatedProperties": false,
-  "required": ["number"]
+  "required": ["number"],
+  "$defs": {
+    "reference": {
+      "title": "Round reference",
+      "description": "Reference to a round of an election",
+      "type": "object",
+      "properties": {
+        "number": {
+          "$ref": "#/properties/number"
+        }
+      },
+      "unevaluatedProperties": false,
+      "required": ["number"]
+    }
+  }
 }

--- a/packages/schema/schemas/round.schema.ts
+++ b/packages/schema/schemas/round.schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 import { timePeriodSchema } from "./time-period.schema";
 
-const roundNumberSchema = z.number().int().min(0).describe("Round ordinal number from 0");
+const roundNumberSchema = z.number().int().min(1).describe("Round ordinal number from 1");
 
 export const roundReferenceSchema = z.object({ number: roundNumberSchema }).strict().describe("Reference to a round of an election");
 


### PR DESCRIPTION
## Why

For the October 2026 elections (senate: 27 two-round districts; municipal: many cities, some with several calculators) the site needs a **data-driven calculator picker** — "choose your district / city" — instead of hand-written listing pages. The schema could not express the two things a picker needs: a way to **link** to a calculator from a listing, and a way to **name** the territory it belongs to. This PR adds both, plus first-class support for two-round elections. All changes are made in the Zod schemas and the published JSON Schemas in lockstep.

Nothing here changes URLs, routing, or how existing calculators load. All 131 existing data files validate unchanged under both validators (ajv exactly as the data repo's CI runs it, and Zod as the apps run it).

## 1. Calculators in a group get a `key` — the picker can finally link

The URL key of a group calculator existed only as a *directory name* in the data repo; no JSON file contained it. A listing page reading `calculator-group.json` knew a calculator existed but had no URL to link to.

**Before** (`calculator-group.json` item):
```json
{ "id": "b47b1326-…", "variant": { "key": "expresni" } }
```

**After** — `key` is required on group items and forms the last URL segment (`/volby/<group>/<key>`); `variant`/`district`/`round` stay pure metadata:
```json
{ "id": "b47b1326-…", "key": "praha-doprava", "district": { "key": "praha" }, "variant": { "key": "doprava" } }
```

The calculator document itself may also declare its (optional) `key`. The standalone branch's exclusion in `calculator.schema.json` is fixed from "not both `calculatorGroup` and `election`" to "neither", so a group calculator carrying a `key` no longer matches two union branches.

## 2. Districts become real geography — the picker can name things

`district` used to be `{ key, code? }` — no human-readable name, never used by any dataset (the 2025 regional calculators worked around it by misusing `variant` for regions).

**Before:**
```json
{ "key": "praha", "code": "554782" }
```

**After** (`election.json` → `districts[]`):
```json
{ "key": "praha-6", "code": "500178", "kind": "municipal-district", "title": "Praha 6", "parent": "praha" }
{ "key": "27-praha-1", "code": "27", "kind": "electoral-district", "title": "Praha 1", "shortTitle": "Praha 1" }
```

- `kind` — `municipality` (e.g. Brno) | `municipal-district` (e.g. Praha 6) | `electoral-district` (purpose-drawn, e.g. a Senate constituency) | `region` (e.g. kraj). Drives picker copy and whether the code is shown.
- `title` / `shortTitle` — the display name, defined once on the election, not repeated per calculator.
- `parent` — links a city district to its city, so the picker can group Praha 6 under Praha (or senate obvody under a header). Purely presentational; URLs and data layout stay flat.

A calculator references a district as `{ "key": "praha-6" }` only — full district objects live on the election. The same reference pattern was added for rounds, and both are now shared `$defs/reference` definitions.

## 3. Two-round elections (senate)

One calculator per district serves **both rounds** — same URL, same shared results, no `-2-kolo` clones. After first-round results, the editor updates `candidates.json`:

```json
{ "id": "…", "number": 5, "references": [ … ], "rounds": [1, 2] }   // advanced
{ "id": "…", "number": 2, "references": [ … ], "rounds": [1] }      // eliminated
{ "id": "…", "number": 7, "references": [ … ], "rounds": [1], "elected": true }   // won outright
```

- `candidate.rounds` — round numbers the candidate takes part in; omitted = all rounds; duplicates rejected.
- `candidate.elected` — the candidate already won the seat (e.g. >50 % in round 1); distinguishes the winner from the eliminated in districts where round 2 never happens.
- `round.number` is now **1-based** (was 0-based, documented "from 0", never used by any data — round 2 is `number: 2`).

## 4. Picker copy overrides (`calculator-group.selection`)

Default picker copy comes from app messages keyed by `district.kind`; an editor can override per group with a data change alone:

```json
"selection": { "title": "Zvolte svůj volební obvod", "showCode": true }
```

## 5. Standalone calculators may reference an election

A single-calculator election (e.g. presidential) no longer needs a one-item group just to point at its election and its `rounds`/`votingHours`. Standalone now means only "not part of a calculator group":

```json
{ "id": "…", "key": "prezidentska-2028", "shortTitle": "Prezidentská 2028", "election": { "id": "…", "key": "prezidentske-2028" } }
```

## 6. Contract fixes (Zod ↔ JSON Schema)

- The calculator-group union branches were only *accidentally* disjoint: ajv accepted an election group with `shortTitle` (and a standalone group with `election`) that Zod rejects — a file data CI would merge and the app would then refuse. The exclusions are now declared explicitly in the JSON Schema.
- Under Zod 4, `z.undefined()` exclusion fields in `.strict()` objects rejected even minimal valid calculator groups ("expected nonoptional, received undefined") — now `.optional()`, wrong combinations still fail.
- Description/title clean-ups (district kind values documented, stale "standalone" wording, `Short title` casing).

## Authoring conventions (for data)

- URL = `/volby/<group key>/<item key>`. District, variant, round, parent never appear in URLs.
- A district listed in `election.districts[]` **without** a matching item in `calculators[]` = "not launched yet" — the picker renders it as inactive. Staggered per-city launches need no extra field.
- District/round/variant references from a calculator must point at entries defined on the election / group (referential integrity is planned as a data-repo CI check, not enforceable in the schema itself).

## Verification

- `npm run typecheck`, `npm run lint:fix`, `npm run test` pass on every commit.
- All 131 existing files in `kalkulacka-one/data` + a 36-file senate/municipal dummy tree validate under **both** ajv (data-CI setup) and Zod, before and after.
- Reviewed by three independent passes (adversarial cross-validator probing — 56 probe documents, plus a maintainer/contract review and a Codex review); every confirmed finding is fixed in the last four commits.
- No app code reads the new fields yet; the picker, group data loading, and round filtering are follow-up app work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012k2GxD7g1T9Eh2yVYmhvJt
