### PR TITLE
Upgrade to TypeScript 7 and clean up configs

### DIFF
--- a/apps/design-system.kalkulacka.one/package.json
+++ b/apps/design-system.kalkulacka.one/package.json
@@ -26,7 +26,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "storybook": "^10.0.8",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   },
   "overrides": {
     "storybook": "$storybook"

--- a/apps/www.izborenkalkulator.mk/package.json
+++ b/apps/www.izborenkalkulator.mk/package.json
@@ -17,7 +17,7 @@
     "@appsignal/javascript": "^1.6.1",
     "@appsignal/plugin-breadcrumbs-network": "^1.1.24",
     "@appsignal/plugin-window-events": "^1.0.26",
-    "@hookform/resolvers": "^3.3.4",
+    "@hookform/resolvers": "^5.9.1",
     "@kalkulacka-one/app": "*",
     "@kalkulacka-one/database": "*",
     "@kalkulacka-one/design-system": "*",
@@ -51,6 +51,6 @@
     "autoprefixer": "^10.4.22",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.17",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/apps/www.izborenkalkulator.mk/tsconfig.json
+++ b/apps/www.izborenkalkulator.mk/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@kalkulacka-one/typescript-config/nextjs.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     },

--- a/apps/www.kalkulacka.one/package.json
+++ b/apps/www.kalkulacka.one/package.json
@@ -33,6 +33,6 @@
     "autoprefixer": "^10.4.22",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.17",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/apps/www.voksmonitor.hu/package.json
+++ b/apps/www.voksmonitor.hu/package.json
@@ -28,6 +28,6 @@
     "autoprefixer": "^10.4.22",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.17",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/apps/www.voksmonitor.hu/tsconfig.json
+++ b/apps/www.voksmonitor.hu/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@kalkulacka-one/typescript-config/nextjs.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     },

--- a/apps/www.volebnakalkulacka.sk/package.json
+++ b/apps/www.volebnakalkulacka.sk/package.json
@@ -18,7 +18,7 @@
     "@appsignal/javascript": "^1.6.1",
     "@appsignal/plugin-breadcrumbs-network": "^1.1.24",
     "@appsignal/plugin-window-events": "^1.0.26",
-    "@hookform/resolvers": "^3.3.4",
+    "@hookform/resolvers": "^5.9.1",
     "@kalkulacka-one/app": "*",
     "@kalkulacka-one/database": "*",
     "@kalkulacka-one/design-system": "*",
@@ -52,6 +52,6 @@
     "autoprefixer": "^10.4.22",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.17",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/apps/www.volebnakalkulacka.sk/tsconfig.json
+++ b/apps/www.volebnakalkulacka.sk/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@kalkulacka-one/typescript-config/nextjs.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     },

--- a/apps/www.volebnikalkulacka.cz/package.json
+++ b/apps/www.volebnikalkulacka.cz/package.json
@@ -20,7 +20,7 @@
     "@appsignal/javascript": "^1.6.1",
     "@appsignal/plugin-breadcrumbs-network": "^1.1.24",
     "@appsignal/plugin-window-events": "^1.0.26",
-    "@hookform/resolvers": "^3.3.4",
+    "@hookform/resolvers": "^5.9.1",
     "@kalkulacka-one/app": "*",
     "@kalkulacka-one/database": "*",
     "@kalkulacka-one/design-system": "*",
@@ -54,6 +54,6 @@
     "autoprefixer": "^10.4.22",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.17",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   }
 }

--- a/apps/www.volebnikalkulacka.cz/tsconfig.json
+++ b/apps/www.volebnikalkulacka.cz/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "@kalkulacka-one/typescript-config/nextjs.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "jsdom": "^30.0.1",
         "npm-check-updates": "^18.3.1",
         "turbo": "^2.6.1",
+        "typescript": "^7.0.2",
         "vite": "^8.3.0",
         "vitest": "^5.0.0"
       },
@@ -42,7 +43,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "storybook": "^10.0.8",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
       }
     },
     "apps/design-system.kalkulacka.one/node_modules/@storybook/addon-docs": {
@@ -260,42 +261,6 @@
         "webpack": "^5.27.0"
       }
     },
-    "apps/design-system.kalkulacka.one/node_modules/@storybook/builder-webpack5/node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc"
-      },
-      "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
-      }
-    },
     "apps/design-system.kalkulacka.one/node_modules/@storybook/core-webpack": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/@storybook/core-webpack/-/core-webpack-10.6.0.tgz",
@@ -428,42 +393,6 @@
         "typescript": ">= 4.3.x"
       }
     },
-    "apps/design-system.kalkulacka.one/node_modules/@storybook/nextjs/node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc"
-      },
-      "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
-      }
-    },
     "apps/design-system.kalkulacka.one/node_modules/@storybook/preset-react-webpack": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/@storybook/preset-react-webpack/-/preset-react-webpack-10.6.0.tgz",
@@ -524,42 +453,6 @@
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">= 4.3.x"
-      }
-    },
-    "apps/design-system.kalkulacka.one/node_modules/@storybook/preset-react-webpack/node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc"
-      },
-      "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "apps/design-system.kalkulacka.one/node_modules/@storybook/react-dom-shim": {
@@ -842,7 +735,7 @@
         "@appsignal/javascript": "^1.6.1",
         "@appsignal/plugin-breadcrumbs-network": "^1.1.24",
         "@appsignal/plugin-window-events": "^1.0.26",
-        "@hookform/resolvers": "^3.3.4",
+        "@hookform/resolvers": "^5.9.1",
         "@kalkulacka-one/app": "*",
         "@kalkulacka-one/database": "*",
         "@kalkulacka-one/design-system": "*",
@@ -876,7 +769,117 @@
         "autoprefixer": "^10.4.22",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.17",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
+      }
+    },
+    "apps/www.izborenkalkulator.mk/node_modules/@hookform/resolvers": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.9.1.tgz",
+      "integrity": "sha512-7b7vsbraJxKgjVSA1Nur9tLwj539WGJUBLA7QNvXnFoT2pM5Z7G+6rlukk4B2/QrTZy6huRtH6wKeESPKuIr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@sinclair/typebox": ">=0.25.24",
+        "@standard-schema/spec": "^1.0.0",
+        "@typeschema/main": ">=0.13.7",
+        "@vinejs/vine": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "ajv": "^8.12.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "arktype": "^2.0.0",
+        "ata-validator": "^1.2.0",
+        "class-transformer": ">=0.4.0",
+        "class-validator": ">=0.12.0",
+        "computed-types": "^1.0.0",
+        "effect": "^3.10.3",
+        "fluentvalidation-ts": "^3.0.0",
+        "fp-ts": "^2.7.0",
+        "io-ts": "^2.0.0",
+        "joi": "^17.0.0 || ^18.0.0",
+        "nope-validator": ">=0.12.0",
+        "react-hook-form": "^7.55.0",
+        "superstruct": ">=0.12.0",
+        "typanion": "^3.3.2",
+        "valibot": ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc",
+        "vest": ">=6.0.0",
+        "yup": "^1.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sinclair/typebox": {
+          "optional": true
+        },
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "@typeschema/main": {
+          "optional": true
+        },
+        "@vinejs/vine": {
+          "optional": true
+        },
+        "ajv": {
+          "optional": true
+        },
+        "ajv-errors": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "ata-validator": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        },
+        "computed-types": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "fluentvalidation-ts": {
+          "optional": true
+        },
+        "fp-ts": {
+          "optional": true
+        },
+        "io-ts": {
+          "optional": true
+        },
+        "joi": {
+          "optional": true
+        },
+        "nope-validator": {
+          "optional": true
+        },
+        "superstruct": {
+          "optional": true
+        },
+        "typanion": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "vest": {
+          "optional": true
+        },
+        "yup": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "apps/www.izborenkalkulator.mk/node_modules/@opentelemetry/api-logs": {
@@ -1022,7 +1025,7 @@
         "autoprefixer": "^10.4.22",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.17",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
       }
     },
     "apps/www.kalkulacka.one/node_modules/@testing-library/jest-dom": {
@@ -1081,7 +1084,7 @@
         "autoprefixer": "^10.4.22",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.17",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
       }
     },
     "apps/www.volebnakalkulacka.sk": {
@@ -1090,7 +1093,7 @@
         "@appsignal/javascript": "^1.6.1",
         "@appsignal/plugin-breadcrumbs-network": "^1.1.24",
         "@appsignal/plugin-window-events": "^1.0.26",
-        "@hookform/resolvers": "^3.3.4",
+        "@hookform/resolvers": "^5.9.1",
         "@kalkulacka-one/app": "*",
         "@kalkulacka-one/database": "*",
         "@kalkulacka-one/design-system": "*",
@@ -1124,7 +1127,117 @@
         "autoprefixer": "^10.4.22",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.17",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
+      }
+    },
+    "apps/www.volebnakalkulacka.sk/node_modules/@hookform/resolvers": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.9.1.tgz",
+      "integrity": "sha512-7b7vsbraJxKgjVSA1Nur9tLwj539WGJUBLA7QNvXnFoT2pM5Z7G+6rlukk4B2/QrTZy6huRtH6wKeESPKuIr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@sinclair/typebox": ">=0.25.24",
+        "@standard-schema/spec": "^1.0.0",
+        "@typeschema/main": ">=0.13.7",
+        "@vinejs/vine": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "ajv": "^8.12.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "arktype": "^2.0.0",
+        "ata-validator": "^1.2.0",
+        "class-transformer": ">=0.4.0",
+        "class-validator": ">=0.12.0",
+        "computed-types": "^1.0.0",
+        "effect": "^3.10.3",
+        "fluentvalidation-ts": "^3.0.0",
+        "fp-ts": "^2.7.0",
+        "io-ts": "^2.0.0",
+        "joi": "^17.0.0 || ^18.0.0",
+        "nope-validator": ">=0.12.0",
+        "react-hook-form": "^7.55.0",
+        "superstruct": ">=0.12.0",
+        "typanion": "^3.3.2",
+        "valibot": ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc",
+        "vest": ">=6.0.0",
+        "yup": "^1.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sinclair/typebox": {
+          "optional": true
+        },
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "@typeschema/main": {
+          "optional": true
+        },
+        "@vinejs/vine": {
+          "optional": true
+        },
+        "ajv": {
+          "optional": true
+        },
+        "ajv-errors": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "ata-validator": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        },
+        "computed-types": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "fluentvalidation-ts": {
+          "optional": true
+        },
+        "fp-ts": {
+          "optional": true
+        },
+        "io-ts": {
+          "optional": true
+        },
+        "joi": {
+          "optional": true
+        },
+        "nope-validator": {
+          "optional": true
+        },
+        "superstruct": {
+          "optional": true
+        },
+        "typanion": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "vest": {
+          "optional": true
+        },
+        "yup": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "apps/www.volebnakalkulacka.sk/node_modules/@opentelemetry/api-logs": {
@@ -1255,7 +1368,7 @@
         "@appsignal/javascript": "^1.6.1",
         "@appsignal/plugin-breadcrumbs-network": "^1.1.24",
         "@appsignal/plugin-window-events": "^1.0.26",
-        "@hookform/resolvers": "^3.3.4",
+        "@hookform/resolvers": "^5.9.1",
         "@kalkulacka-one/app": "*",
         "@kalkulacka-one/database": "*",
         "@kalkulacka-one/design-system": "*",
@@ -1289,7 +1402,117 @@
         "autoprefixer": "^10.4.22",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.17",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
+      }
+    },
+    "apps/www.volebnikalkulacka.cz/node_modules/@hookform/resolvers": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.9.1.tgz",
+      "integrity": "sha512-7b7vsbraJxKgjVSA1Nur9tLwj539WGJUBLA7QNvXnFoT2pM5Z7G+6rlukk4B2/QrTZy6huRtH6wKeESPKuIr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@sinclair/typebox": ">=0.25.24",
+        "@standard-schema/spec": "^1.0.0",
+        "@typeschema/main": ">=0.13.7",
+        "@vinejs/vine": "^2.0.0 || ^3.0.0 || ^4.0.0",
+        "ajv": "^8.12.0",
+        "ajv-errors": "^3.0.0",
+        "ajv-formats": "^2.1.1",
+        "arktype": "^2.0.0",
+        "ata-validator": "^1.2.0",
+        "class-transformer": ">=0.4.0",
+        "class-validator": ">=0.12.0",
+        "computed-types": "^1.0.0",
+        "effect": "^3.10.3",
+        "fluentvalidation-ts": "^3.0.0",
+        "fp-ts": "^2.7.0",
+        "io-ts": "^2.0.0",
+        "joi": "^17.0.0 || ^18.0.0",
+        "nope-validator": ">=0.12.0",
+        "react-hook-form": "^7.55.0",
+        "superstruct": ">=0.12.0",
+        "typanion": "^3.3.2",
+        "valibot": ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc",
+        "vest": ">=6.0.0",
+        "yup": "^1.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sinclair/typebox": {
+          "optional": true
+        },
+        "@standard-schema/spec": {
+          "optional": true
+        },
+        "@typeschema/main": {
+          "optional": true
+        },
+        "@vinejs/vine": {
+          "optional": true
+        },
+        "ajv": {
+          "optional": true
+        },
+        "ajv-errors": {
+          "optional": true
+        },
+        "ajv-formats": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "ata-validator": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        },
+        "computed-types": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "fluentvalidation-ts": {
+          "optional": true
+        },
+        "fp-ts": {
+          "optional": true
+        },
+        "io-ts": {
+          "optional": true
+        },
+        "joi": {
+          "optional": true
+        },
+        "nope-validator": {
+          "optional": true
+        },
+        "superstruct": {
+          "optional": true
+        },
+        "typanion": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "vest": {
+          "optional": true
+        },
+        "yup": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "apps/www.volebnikalkulacka.cz/node_modules/@opentelemetry/api-logs": {
@@ -4456,15 +4679,6 @@
       "peerDependencies": {
         "react": "^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/@hookform/resolvers": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.10.0.tgz",
-      "integrity": "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/momoa": {
@@ -8021,7 +8235,7 @@
       "version": "0.27.12",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
       "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -8049,6 +8263,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@storybook/global": {
@@ -9171,13 +9391,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9189,13 +9407,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9207,13 +9423,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9225,13 +9439,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9243,13 +9455,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9261,13 +9471,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9279,13 +9487,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9297,13 +9503,11 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9315,13 +9519,11 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9333,13 +9535,11 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9351,13 +9551,11 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9369,13 +9567,11 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9387,13 +9583,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9405,13 +9599,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9423,13 +9615,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9441,13 +9631,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9459,13 +9647,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9477,13 +9663,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9495,13 +9679,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -9513,13 +9695,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=16.20.0"
       }
@@ -19935,17 +20115,38 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/uglify-js": {
@@ -21939,7 +22140,7 @@
         "postcss": "^8.5.6",
         "react": "^19.2.3",
         "tsc-alias": "^1.8.16",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
       },
       "peerDependencies": {
         "react": "^19.2.3"
@@ -21993,7 +22194,7 @@
         "@types/node": "^22.19.1",
         "prisma": "^6.19.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
       }
     },
     "packages/design-system": {
@@ -22019,7 +22220,7 @@
         "autoprefixer": "^10.4.22",
         "postcss": "^8.5.6",
         "react": "^19.2.3",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
       }
     },
     "packages/design-system/node_modules/@testing-library/jest-dom": {
@@ -22068,7 +22269,7 @@
         "@kalkulacka-one/typescript-config": "*",
         "@types/node": "^22.19.1",
         "tsc-alias": "^1.8.16",
-        "typescript": "^5.9.3"
+        "typescript": "^7.0.2"
       },
       "peerDependencies": {
         "next": "^16.0.0"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jsdom": "^30.0.1",
     "npm-check-updates": "^18.3.1",
     "turbo": "^2.6.1",
+    "typescript": "^7.0.2",
     "vite": "^8.3.0",
     "vitest": "^5.0.0"
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -41,7 +41,7 @@
     "postcss": "^8.5.6",
     "react": "^19.2.3",
     "tsc-alias": "^1.8.16",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   },
   "dependencies": {
     "@kalkulacka-one/design-system": "*",

--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -4,9 +4,8 @@
     "outDir": "dist",
     "rootDir": "./src",
     "types": ["node", "vitest/globals", "@testing-library/jest-dom/vitest"],
-    "baseUrl": "./src",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -30,7 +30,7 @@
     "@types/node": "^22.19.1",
     "prisma": "^6.19.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   },
   "dependencies": {
     "@prisma/client": "^6.19.0"

--- a/packages/database/tsconfig.json
+++ b/packages/database/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "@kalkulacka-one/typescript-config/base.json",
   "compilerOptions": {
-    "baseUrl": ".",
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "./src",
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -56,7 +56,7 @@
     "autoprefixer": "^10.4.22",
     "postcss": "^8.5.6",
     "react": "^19.2.3",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.9",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -27,7 +27,7 @@
     "@kalkulacka-one/typescript-config": "*",
     "@types/node": "^22.19.1",
     "tsc-alias": "^1.8.16",
-    "typescript": "^5.9.3"
+    "typescript": "^7.0.2"
   },
   "peerDependencies": {
     "next": "^16.0.0"

--- a/packages/next/tsconfig.json
+++ b/packages/next/tsconfig.json
@@ -3,9 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "./src",
-    "baseUrl": "./src",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
Build-time only, no runtime change. Rebased on `main` after #507, which removed the need for any compiler-flag exception.

`typescript` 5.9.3 → 7.0.2, the native Go compiler, in the ten workspaces that declare it, plus a root devDependency so npm keeps **one** copy instead of nesting eleven. TypeScript 6 is skipped: it existed in the plan only because Next 15.5 needed the JS compiler API, which 7 dropped; Next 16 (#505) type-checks through the `tsc` CLI, so `next build` works with 7 directly.

## tsconfig changes TypeScript 7 requires

- **`baseUrl` removed** in the four apps and three packages that had it (hard error in 7). `paths` in `packages/app` and `packages/next` now point at `./src/*` directly; `tsc-alias` still rewrites the emitted imports (verified: 0 unrewritten `@/` imports in `dist`).
- **`packages/database`** declares `rootDir: "./src"` (7 requires it to be explicit) and `types: ["node"]` (the default `types` is now `[]`, and `db.ts` reads `process.env`).
- `noUncheckedSideEffectImports` is on by default in 7 and stays on: the only imports it rejected were the design-system theme imports, fixed properly in #507.

Also included, since it is tiny and build-verified: `@hookform/resolvers` 3.10 → 5.9 in the three apps with forms (proper Zod 4 support; `zodResolver` call sites unchanged).

Editor note: TypeScript 7's language service does not support plugins yet, so the `next` tsconfig plugin (segment-config hints in the IDE) is inert until 7.1. `next build` is unaffected.

## Verification

- `npm run typecheck` → 11/11 in **2 s** (was ~6 s), `npm run lint:fix` → 12/12, `npm run test` → 12/12 (139 tests)
- `turbo run build` for all apps (4 Next apps with Next 16 type-checking via `tsc`, Storybook, schema docs) → 12/12, ~14 s uncached

🤖 Generated with [Claude Code](https://claude.com/claude-code)
