### PR TITLE
Import themes with their `.css` suffix

### DIFF
--- a/apps/design-system.kalkulacka.one/.storybook/preview.tsx
+++ b/apps/design-system.kalkulacka.one/.storybook/preview.tsx
@@ -6,19 +6,19 @@ import "@kalkulacka-one/design-system/styles";
 const themeLoaders: Record<string, () => Promise<string>> = {
   "Kalkulacka.1": async () =>
     // @ts-expect-error
-    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.kalkulacka.one/default")).default,
+    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.kalkulacka.one/default.css")).default,
   "Volební kalkulačka (CZ)": async () =>
     // @ts-expect-error
-    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/default")).default,
+    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/default.css")).default,
   "Volební kalkulačka (CZ) — Díky, že můžem": async () =>
     // @ts-expect-error
-    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/diky-ze-muzem")).default,
+    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/diky-ze-muzem.css")).default,
   "Volební kalkulačka (CZ) — Alarm": async () =>
     // @ts-expect-error
-    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/alarm")).default,
+    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/alarm.css")).default,
   "Volební kalkulačka (CZ) — Prima": async () =>
     // @ts-expect-error
-    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/prima")).default,
+    (await import("!css-loader!@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/prima.css")).default,
 };
 
 const themeNames = Object.keys(themeLoaders);

--- a/apps/www.izborenkalkulator.mk/components/client/themes/default-theme.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/themes/default-theme.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // TODO [TENANT-008]: Create MK-specific theme
-import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/default";
+import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/default.css";
 
 export const DefaultTheme = ({ children }: { children: React.ReactNode }) => {
   return children;

--- a/apps/www.kalkulacka.one/app/globals.css
+++ b/apps/www.kalkulacka.one/app/globals.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-@import "@kalkulacka-one/design-system/themes/www.kalkulacka.one/default";
+@import "@kalkulacka-one/design-system/themes/www.kalkulacka.one/default.css";
 @import "@kalkulacka-one/design-system/styles";
 
 @theme static {

--- a/apps/www.volebnakalkulacka.sk/components/client/themes/default-theme.tsx
+++ b/apps/www.volebnakalkulacka.sk/components/client/themes/default-theme.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // TODO [TENANT-008]: Create SK-specific theme
-import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/default";
+import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/default.css";
 
 export const DefaultTheme = ({ children }: { children: React.ReactNode }) => {
   return children;

--- a/apps/www.volebnikalkulacka.cz/components/client/themes/alarm-theme.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/themes/alarm-theme.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/alarm";
+import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/alarm.css";
 
 export const AlarmTheme = ({ children }: { children: React.ReactNode }) => {
   return children;

--- a/apps/www.volebnikalkulacka.cz/components/client/themes/default-theme.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/themes/default-theme.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/default";
+import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/default.css";
 
 export const DefaultTheme = ({ children }: { children: React.ReactNode }) => {
   return children;

--- a/apps/www.volebnikalkulacka.cz/components/client/themes/diky-ze-muzem-theme.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/themes/diky-ze-muzem-theme.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/diky-ze-muzem";
+import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/diky-ze-muzem.css";
 
 export const DikyZeMuzemTheme = ({ children }: { children: React.ReactNode }) => {
   return children;

--- a/apps/www.volebnikalkulacka.cz/components/client/themes/prima-theme.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/themes/prima-theme.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/prima";
+import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/prima.css";
 
 export const PrimaTheme = ({ children }: { children: React.ReactNode }) => {
   return children;

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "exports": {
-    "./themes/*": "./src/themes/*.css",
+    "./themes/*.css": "./src/themes/*.css",
     "./styles": "./dist/index.css",
     "./fonts": "./dist/fonts",
     "./server": {


### PR DESCRIPTION
Independent of #506 and mergeable first; it is the prerequisite that lets the TypeScript 7 upgrade land **without** switching `noUncheckedSideEffectImports` off. No stub file, no compiler flag.

**Why:** the design-system `./themes/*` export mapped extension-less specifiers to CSS files, so a side-effect import such as `import "@kalkulacka-one/design-system/themes/www.volebnikalkulacka.cz/prima"` had no type declaration: Next's ambient `declare module "*.css"` never matches a specifier without the suffix. TypeScript 7 checks side-effect imports by default and rejects these six imports.

**Fix:** the export key becomes `./themes/*.css` and the themes are referenced with their suffix (`…/prima.css`), so the standard `*.css` declaration applies. 12 sites in 8 files: the six theme components (CZ ×4, SK, MK), the five Storybook preview loads, and the `@import` in kalkulacka.one's `globals.css`. Bonus over a type stub: a wrong theme path now fails at type-check time too, not only at build time.

On today's TypeScript 5.9 this is a no-op. Bundlers and PostCSS resolve the new key the same way.

**Follow-up:** once this merges, #506 gets rebased and its `noUncheckedSideEffectImports: false` line dropped.

## Verification (on `main`, TypeScript 5.9 + Next 16)

- `npm run typecheck` → 11/11, `npm run lint:fix` → 12/12, `npm run test` → 12/12
- `turbo run build` for all apps (4 Next apps incl. kalkulacka.one with the CSS `@import`, Storybook, schema docs) → 12/12; the kalkulacka.one theme tokens are present in the built CSS
- With TypeScript 7 and no flag: typecheck 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
