### PR TITLE
Run typecheck in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,8 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Typecheck
+        run: npm run typecheck
       - name: Build
         run: npm run build
       - name: Test

--- a/turbo.json
+++ b/turbo.json
@@ -73,7 +73,7 @@
       "cache": false
     },
     "typecheck": {
-      "dependsOn": ["^typecheck"]
+      "dependsOn": ["^build"]
     }
   },
   "ui": "tui"


### PR DESCRIPTION
`typecheck` exists as a turbo task and a `tsc --noEmit` script in every package, and CLAUDE.md mandates it as the first local post-task check, but CI never ran it.

This revives #490 with the fix it was missing. That PR failed in CI with `TS2307: Cannot find module '@kalkulacka-one/design-system/server'`: apps resolve package types from `packages/*/dist`, and nothing had built `dist` before the Typecheck step ran because the task only depended on `^typecheck`.

## Changes

- `.github/workflows/build.yaml`: a `Typecheck` step between Lint and Build, so type errors fail fast before the expensive build.
- `turbo.json`: the `typecheck` task now depends on `^build` (same as `test`), so upstream packages are built before an app is typechecked. The later Build step reuses those builds from the Turbo cache.

## Verification

- Fresh `npm ci` in a throwaway worktree with no `dist` and cache reads disabled: 16/16 tasks pass.
- `npm run typecheck`, `npm run lint:fix`, `npm run test` from the repo root: all green, no reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
