### PR TITLE
Fix twMerge prefix so conflicting classes actually merge

### DIFF
--- a/packages/design-system/src/components/client/input.test.tsx
+++ b/packages/design-system/src/components/client/input.test.tsx
@@ -21,6 +21,7 @@ describe("Input", () => {
     );
     expect(screen.getByTestId("input")).toBeInTheDocument();
     expect(screen.getByTestId("icon")).toBeInTheDocument();
-    expect(screen.getByTestId("input")).toHaveClass(twMerge("ko:pl-14 ko:p-4"));
+    expect(screen.getByTestId("input")).toHaveClass("ko:p-4 ko:pl-14");
+    expect(twMerge("ko:p-4 ko:pl-14")).toBe("ko:p-4 ko:pl-14");
   });
 });

--- a/packages/design-system/src/components/client/input.tsx
+++ b/packages/design-system/src/components/client/input.tsx
@@ -23,7 +23,7 @@ const InputVariants = cva(
     variants: {
       variant: {
         default: "ko:p-4",
-        icon: "ko:pl-14 ko:p-4",
+        icon: "ko:p-4 ko:pl-14",
       },
     },
   },

--- a/packages/design-system/src/utilities/tailwind.ts
+++ b/packages/design-system/src/utilities/tailwind.ts
@@ -1,5 +1,36 @@
 import { extendTailwindMerge } from "tailwind-merge";
 
+/*
+ * tailwind-merge expects the Tailwind v4 prefix without its separator: `ko`
+ * matches `ko:flex`. Theme tokens declared in `styles.css` are listed so that
+ * a later `ko:rounded-pill` drops an earlier `ko:rounded-2xl` the way built-in
+ * values do. Colors need no listing; any value after `bg-`, `text-` and the
+ * like is treated as a color.
+ */
 export const twMerge = extendTailwindMerge({
-  prefix: "ko:",
+  prefix: "ko",
+  extend: {
+    theme: {
+      radius: ["card", "control", "chip", "pill"],
+      shadow: ["card", "card-next", "card-back", "card-lifted", "sticky", "surface"],
+      "drop-shadow": ["hard"],
+      text: ["s", "fluid-brand", "fluid-question", "fluid-gist", "fluid-chip", "fluid-action-label", "title", "display"],
+      spacing: [
+        "fluid-gutter",
+        "fluid-header-top",
+        "fluid-progress-top",
+        "fluid-card-pad-top",
+        "fluid-card-pad-side",
+        "fluid-card-pad-bottom",
+        "fluid-star",
+        "fluid-action",
+        "fluid-nav",
+        "fade-edge",
+        "fade-action",
+        "scroll-tail",
+      ],
+      ease: ["spring", "exit"],
+      font: ["display", "sans", "mono", "question"],
+    },
+  },
 });


### PR DESCRIPTION
Part 2a of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #511. A bug fix found while extending Button, kept as its own PR because it changes class merging for every component.

`packages/design-system/src/utilities/tailwind.ts` configured tailwind-merge with `prefix: "ko:"`, but tailwind-merge v3 expects the prefix without its separator (`"ko"`). With the old value no class ever matched, so `twMerge("ko:h-12 ko:h-auto")` returned both classes and every `className` override in the design system relied on CSS cascade order instead of merging.

This PR:
- sets `prefix: "ko"` and lists the design-system tokens (radius, shadow, drop-shadow, text, spacing, ease, font) so custom values merge like built-in ones
- reorders Input's icon variant (`ko:p-4 ko:pl-14`) so the merged output keeps the padding the cascade rendered before, and makes its test assert both classes explicitly

A sweep over every `cva` in the package confirmed the merged output of all existing variant combinations is unchanged; the Czech app renders identically.

**Checks:** typecheck, lint, design-system tests.

**Stack:** based on #511 → next: `port/02-button-icon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
