### PR TITLE
Restyle Button to the new design, extend Icon and add IconButton

### DIFF
--- a/apps/design-system.kalkulacka.one/stories/Button.stories.ts
+++ b/apps/design-system.kalkulacka.one/stories/Button.stories.ts
@@ -1,4 +1,5 @@
 import { Button, Icon } from "@kalkulacka-one/design-system/client";
+import { icons } from "@kalkulacka-one/design-system/icons";
 
 import { mdiClose, mdiCog, mdiMagnify } from "@mdi/js";
 import type { Meta, StoryObj } from "@storybook/nextjs";
@@ -15,18 +16,19 @@ const meta: Meta<typeof Button> = {
     size: "medium",
     type: "button",
     disabled: false,
+    fullWidth: false,
   },
   argTypes: {
     size: {
       control: "select",
-      options: ["small", "medium"],
+      options: ["small", "medium", "large"],
       defaultValue: {
         summary: "medium",
       },
     },
     variant: {
       control: "select",
-      options: ["fill", "outline", "link", "answer"],
+      options: ["fill", "outline", "link", "answer", "solid", "ghost", "surface", "plate"],
       defaultValue: {
         summary: "fill",
       },
@@ -50,6 +52,22 @@ const meta: Meta<typeof Button> = {
       defaultValue: {
         summary: false,
       },
+    },
+    fullWidth: {
+      control: "boolean",
+      defaultValue: {
+        summary: false,
+      },
+    },
+    iconStart: {
+      control: "select",
+      options: Object.keys(icons),
+      mapping: icons,
+    },
+    iconEnd: {
+      control: "select",
+      options: Object.keys(icons),
+      mapping: icons,
     },
   },
 };
@@ -87,6 +105,60 @@ export const Answer: ButtonStory = {
     children: "Answer",
     variant: "answer",
     color: "primary",
+  },
+};
+
+export const Solid: ButtonStory = {
+  args: {
+    children: "Pokračovat",
+    variant: "solid",
+    color: "neutral",
+  },
+};
+
+export const Ghost: ButtonStory = {
+  args: {
+    children: "Přeskočit",
+    variant: "ghost",
+    color: "neutral",
+  },
+};
+
+export const Surface: ButtonStory = {
+  args: {
+    children: "Zobrazit další",
+    variant: "surface",
+    color: "neutral",
+  },
+};
+
+export const Plate: ButtonStory = {
+  args: {
+    children: "Zpět",
+    variant: "plate",
+    color: "neutral",
+    iconStart: icons.arrowLeft,
+  },
+  decorators: [(Story) => createElement("div", { style: { padding: "2rem", background: "linear-gradient(135deg, var(--ko-color-agree-soft), var(--ko-color-disagree-soft))" } }, Story())],
+};
+
+export const WithIcons: ButtonStory = {
+  args: {
+    children: "Sdílet výsledek",
+    variant: "solid",
+    color: "primary",
+    iconStart: icons.share,
+    iconEnd: icons.arrowRight,
+  },
+};
+
+export const FullWidth: ButtonStory = {
+  args: {
+    children: "Zobrazit výsledky",
+    variant: "solid",
+    color: "neutral",
+    size: "large",
+    fullWidth: true,
   },
 };
 

--- a/apps/design-system.kalkulacka.one/stories/Button.stories.ts
+++ b/apps/design-system.kalkulacka.one/stories/Button.stories.ts
@@ -1,7 +1,6 @@
 import { Button, Icon } from "@kalkulacka-one/design-system/client";
 import { icons } from "@kalkulacka-one/design-system/icons";
 
-import { mdiClose, mdiCog, mdiMagnify } from "@mdi/js";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 import { createElement } from "react";
 
@@ -10,34 +9,36 @@ const meta: Meta<typeof Button> = {
   component: Button,
   tags: ["autodocs"],
   args: {
-    children: "Button",
-    variant: "fill",
-    color: "primary",
+    children: "Pokračovat",
+    variant: "solid",
+    color: "neutral",
     size: "medium",
     type: "button",
     disabled: false,
     fullWidth: false,
   },
   argTypes: {
+    variant: {
+      control: "select",
+      options: ["solid", "ghost", "surface", "plate", "answer"],
+      description: "`answer` is deprecated: it only backs the legacy question page's answer toggle. `fill`, `outline` and `link` are still accepted as aliases of `solid`, `surface` and `ghost`.",
+      defaultValue: {
+        summary: "solid",
+      },
+    },
+    color: {
+      control: "select",
+      options: ["neutral", "primary", "secondary"],
+      description: "Applies to `solid` (and the legacy `answer`); `ghost`, `surface` and `plate` are neutral regardless.",
+      defaultValue: {
+        summary: "neutral",
+      },
+    },
     size: {
       control: "select",
       options: ["small", "medium", "large"],
       defaultValue: {
         summary: "medium",
-      },
-    },
-    variant: {
-      control: "select",
-      options: ["fill", "outline", "link", "answer", "solid", "ghost", "surface", "plate"],
-      defaultValue: {
-        summary: "fill",
-      },
-    },
-    color: {
-      control: "select",
-      options: ["primary", "secondary", "neutral"],
-      defaultValue: {
-        summary: "primary",
       },
     },
     type: {
@@ -76,80 +77,66 @@ type ButtonStory = StoryObj<typeof meta>;
 
 export const Default: ButtonStory = {
   args: {
-    children: "Button",
-    variant: "fill",
-    color: "primary",
-    type: "button",
-    disabled: false,
-  },
-};
-
-export const Outline: ButtonStory = {
-  args: {
-    children: "Outline",
-    variant: "outline",
-    color: "primary",
-  },
-};
-
-export const Link: ButtonStory = {
-  args: {
-    children: "Link",
-    variant: "link",
-    color: "primary",
-  },
-};
-
-export const Answer: ButtonStory = {
-  args: {
-    children: "Answer",
-    variant: "answer",
-    color: "primary",
-  },
-};
-
-export const Solid: ButtonStory = {
-  args: {
     children: "Pokračovat",
     variant: "solid",
     color: "neutral",
   },
 };
 
+export const Agree: ButtonStory = {
+  args: {
+    children: "Ano",
+    variant: "solid",
+    color: "primary",
+    iconStart: icons.check,
+  },
+};
+
+export const Disagree: ButtonStory = {
+  args: {
+    children: "Ne",
+    variant: "solid",
+    color: "secondary",
+    iconStart: icons.cross,
+  },
+};
+
 export const Ghost: ButtonStory = {
   args: {
-    children: "Přeskočit",
+    children: "Zrušit",
     variant: "ghost",
-    color: "neutral",
   },
 };
 
 export const Surface: ButtonStory = {
   args: {
-    children: "Zobrazit další",
+    children: "Stáhnout",
     variant: "surface",
-    color: "neutral",
+    iconStart: icons.download,
   },
 };
 
 export const Plate: ButtonStory = {
   args: {
-    children: "Zpět",
+    children: "Zpět na rekapitulaci",
     variant: "plate",
-    color: "neutral",
-    iconStart: icons.arrowLeft,
+    iconStart: icons.chevronLeftThin,
   },
   decorators: [(Story) => createElement("div", { style: { padding: "2rem", background: "linear-gradient(135deg, var(--ko-color-agree-soft), var(--ko-color-disagree-soft))" } }, Story())],
 };
 
-export const WithIcons: ButtonStory = {
+export const Sizes: ButtonStory = {
   args: {
-    children: "Sdílet výsledek",
-    variant: "solid",
-    color: "primary",
-    iconStart: icons.share,
-    iconEnd: icons.arrowRight,
+    children: "Pokračovat",
   },
+  render: (args) =>
+    createElement(
+      "div",
+      { style: { display: "flex", alignItems: "center", gap: "1rem", flexWrap: "wrap" } },
+      createElement(Button, { ...args, size: "small" }),
+      createElement(Button, { ...args, size: "medium" }),
+      createElement(Button, { ...args, size: "large" }),
+    ),
 };
 
 export const FullWidth: ButtonStory = {
@@ -164,31 +151,27 @@ export const FullWidth: ButtonStory = {
 
 export const IconOnly: ButtonStory = {
   args: {
-    children: createElement(Icon, { icon: mdiMagnify, decorative: true }),
-    variant: "fill",
+    children: createElement(Icon, { icon: icons.close, decorative: true }),
+    variant: "ghost",
+    "aria-label": "Zavřít",
+  },
+};
+
+/** The outlined answer toggle of the legacy question page. Deprecated; goes away with that page. */
+export const LegacyAnswer: ButtonStory = {
+  name: "Legacy: answer (deprecated)",
+  args: {
+    children: "Ano",
+    variant: "answer",
     color: "primary",
-    type: "button",
-    disabled: false,
   },
-};
-
-export const IconOnlySecondary: ButtonStory = {
-  args: {
-    children: createElement(Icon, { icon: mdiClose, decorative: true }),
-    variant: "outline",
-    color: "secondary",
-    type: "button",
-    disabled: false,
-  },
-};
-
-export const IconOnlyNeutral: ButtonStory = {
-  args: {
-    children: createElement(Icon, { icon: mdiCog, decorative: true }),
-    variant: "fill",
-    color: "neutral",
-    type: "button",
-    disabled: false,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Deprecated. Kept only because the legacy question page\'s `ToggleButton variant="answer"` needs it; it is removed together with that page. New screens use the `solid` pill in the `primary` or `secondary` color instead.',
+      },
+    },
   },
 };
 

--- a/apps/design-system.kalkulacka.one/stories/Icon.stories.ts
+++ b/apps/design-system.kalkulacka.one/stories/Icon.stories.ts
@@ -1,8 +1,9 @@
 import { Icon } from "@kalkulacka-one/design-system/client";
-import { EnvelopeIcon } from "@kalkulacka-one/design-system/icons";
+import { EnvelopeIcon, type IconName, icons } from "@kalkulacka-one/design-system/icons";
 
 import { mdiAccount } from "@mdi/js";
 import type { Meta, StoryObj } from "@storybook/nextjs";
+import { createElement } from "react";
 
 const meta: Meta<typeof Icon> = {
   title: "Components/Icon",
@@ -11,9 +12,10 @@ const meta: Meta<typeof Icon> = {
   argTypes: {
     decorative: { control: "boolean" },
     title: { control: "text", if: { arg: "decorative", eq: false } },
+    filled: { control: "boolean" },
     size: {
       control: "select",
-      options: ["small", "medium", "large"],
+      options: ["xsmall", "small", "regular", "medium", "large"],
     },
   },
 };
@@ -35,6 +37,38 @@ export const NonDecorative: IconStory = {
     icon: EnvelopeIcon,
     size: "medium",
   },
+};
+
+/** The star fills when a question is marked "pro mě důležité". */
+export const Filled: IconStory = {
+  args: {
+    decorative: true,
+    icon: icons.star,
+    filled: true,
+    size: "large",
+  },
+};
+
+/** Every icon in the set, by name. */
+export const Gallery: IconStory = {
+  args: {
+    decorative: true,
+    icon: icons.check,
+    size: "regular",
+  },
+  render: (args) =>
+    createElement(
+      "div",
+      { style: { display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(8rem, 1fr))", gap: "1.5rem 1rem" } },
+      (Object.keys(icons) as IconName[]).map((name) =>
+        createElement(
+          "figure",
+          { key: name, style: { display: "grid", gap: "0.5rem", justifyItems: "center", margin: 0 } },
+          createElement(Icon, { icon: icons[name], decorative: true, size: args.size }),
+          createElement("figcaption", { style: { fontSize: "0.75rem" } }, name),
+        ),
+      ),
+    ),
 };
 
 export default meta;

--- a/apps/design-system.kalkulacka.one/stories/IconButton.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/IconButton.stories.tsx
@@ -1,0 +1,89 @@
+import { IconButton } from "@kalkulacka-one/design-system/client";
+import { icons } from "@kalkulacka-one/design-system/icons";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+const meta: Meta<typeof IconButton> = {
+  title: "Components/IconButton",
+  component: IconButton,
+  tags: ["autodocs"],
+  args: {
+    icon: icons.close,
+    label: "Close",
+    variant: "ghost",
+    size: "medium",
+    disabled: false,
+  },
+  argTypes: {
+    icon: {
+      control: "select",
+      options: Object.keys(icons),
+      mapping: icons,
+    },
+    label: {
+      control: "text",
+    },
+    variant: {
+      control: "select",
+      options: ["ghost", "surface"],
+      defaultValue: {
+        summary: "ghost",
+      },
+    },
+    size: {
+      control: "select",
+      options: ["medium", "large"],
+      defaultValue: {
+        summary: "medium",
+      },
+    },
+    disabled: {
+      control: "boolean",
+      defaultValue: {
+        summary: false,
+      },
+    },
+  },
+};
+
+type IconButtonStory = StoryObj<typeof meta>;
+
+export const Default: IconButtonStory = {
+  args: {
+    icon: icons.close,
+    label: "Close",
+  },
+};
+
+export const Surface: IconButtonStory = {
+  args: {
+    icon: icons.more,
+    label: "Menu",
+    variant: "surface",
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: "2rem", background: "linear-gradient(135deg, var(--ko-color-agree-soft), var(--ko-color-disagree-soft))" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Large: IconButtonStory = {
+  args: {
+    icon: icons.share,
+    label: "Share",
+    size: "large",
+  },
+};
+
+export const Disabled: IconButtonStory = {
+  args: {
+    icon: icons.restart,
+    label: "Start over",
+    disabled: true,
+  },
+};
+
+export default meta;

--- a/packages/design-system/src/components/client/button.test.tsx
+++ b/packages/design-system/src/components/client/button.test.tsx
@@ -1,64 +1,88 @@
 import { icons } from "@kalkulacka-one/design-system/icons";
 import { twMerge } from "@kalkulacka-one/design-system/utilities";
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 import { Button, ButtonVariants } from "./button";
+import { Icon } from "./icon";
+
+const baseClasses = [
+  "ko:inline-flex",
+  "ko:items-center",
+  "ko:justify-center",
+  "ko:gap-2",
+  "ko:rounded-pill",
+  "ko:border-0",
+  "ko:font-sans",
+  "ko:font-semibold",
+  "ko:tracking-[-0.01em]",
+  "ko:whitespace-nowrap",
+  "ko:no-underline",
+  "ko:select-none",
+  "ko:cursor-pointer",
+  "ko:data-active:scale-[0.97]",
+  "ko:data-disabled:opacity-45",
+  "ko:data-disabled:cursor-default",
+  "ko:data-focus:outline-3",
+  "ko:data-focus:outline-offset-2",
+  "ko:data-focus:outline-focus/55",
+];
+
+const retiredClasses = ["ko:rounded-2xl", "ko:rounded-br-none", "ko:border-2", "ko:h-10", "ko:h-12", "ko:h-14", "ko:text-s", "ko:grid", "ko:pt-[1px]"];
+
+const solidNeutral = ["ko:bg-neutral-ink", "ko:text-on-neutral-ink", "ko:data-hover:bg-neutral-ink/90", "ko:data-active:bg-neutral-ink/80"];
+const solidPrimary = ["ko:bg-agree", "ko:text-on-agree", "ko:data-hover:bg-agree-hover", "ko:data-active:bg-agree-active"];
+const solidSecondary = ["ko:bg-disagree", "ko:text-on-disagree", "ko:data-hover:bg-disagree-hover", "ko:data-active:bg-disagree-active"];
+
+const classesOf = (...args: Parameters<typeof ButtonVariants>) => twMerge(ButtonVariants(...args)).split(" ");
 
 describe("Button", () => {
   it("should render a children", () => {
-    render(<Button>Button</Button>);
-    expect(screen.getByRole("button")).toHaveTextContent("Button");
+    render(<Button>Pokračovat</Button>);
+    expect(screen.getByRole("button")).toHaveTextContent("Pokračovat");
   });
 
-  it("should have default style when variant specififed", () => {
-    render(<Button>Button</Button>);
-    expect(screen.getByRole("button")).toHaveClass(twMerge(ButtonVariants()));
-  });
-  describe("when given a specific variant and size prop", () => {
-    it("should render the correct class", () => {
-      render(
-        <Button variant="outline" size="small">
-          Button
-        </Button>,
-      );
-      expect(screen.getByRole("button")).toHaveClass(twMerge(ButtonVariants({ variant: "outline", size: "small" })));
+  describe("by default", () => {
+    it("should have the default style", () => {
+      render(<Button>Pokračovat</Button>);
+      expect(screen.getByRole("button")).toHaveClass(twMerge(ButtonVariants()));
+    });
+
+    it("should be the solid neutral pill at the medium size", () => {
+      expect(ButtonVariants()).toBe(ButtonVariants({ variant: "solid", color: "neutral", size: "medium" }));
+      expect(classesOf()).toEqual(expect.arrayContaining([...baseClasses, ...solidNeutral, "ko:px-6", "ko:py-[0.8125rem]", "ko:text-[0.9375rem]"]));
+    });
+
+    it("should carry nothing of the retired design", () => {
+      const classes = classesOf();
+      for (const retired of retiredClasses) {
+        expect(classes).not.toContain(retired);
+      }
     });
   });
 
-  describe("pill variants", () => {
-    const pillClasses = ["ko:border-0", "ko:rounded-pill", "ko:tracking-[-0.01em]", "ko:whitespace-nowrap", "ko:data-active:scale-[0.97]", "ko:data-disabled:opacity-45", "ko:data-focus:outline-3"];
-
-    it("should render the solid variant in the neutral ink", () => {
-      const classes = ButtonVariants({ variant: "solid", color: "neutral" }).split(" ");
-      expect(classes).toEqual(expect.arrayContaining([...pillClasses, "ko:bg-neutral-ink", "ko:text-on-neutral-ink", "ko:data-hover:bg-neutral-ink/90", "ko:data-active:bg-neutral-ink/80"]));
-    });
-
-    it("should render the solid variant in the answer colors", () => {
-      expect(ButtonVariants({ variant: "solid", color: "primary" }).split(" ")).toEqual(
-        expect.arrayContaining(["ko:bg-agree", "ko:text-on-agree", "ko:data-hover:bg-agree-hover", "ko:data-active:bg-agree-active"]),
-      );
-      expect(ButtonVariants({ variant: "solid", color: "secondary" }).split(" ")).toEqual(
-        expect.arrayContaining(["ko:bg-disagree", "ko:text-on-disagree", "ko:data-hover:bg-disagree-hover", "ko:data-active:bg-disagree-active"]),
-      );
+  describe("variants", () => {
+    it("should render the solid variant", () => {
+      expect(classesOf({ variant: "solid" })).toEqual(expect.arrayContaining([...baseClasses, ...solidNeutral]));
     });
 
     it("should render the ghost variant", () => {
-      const classes = ButtonVariants({ variant: "ghost" }).split(" ");
-      expect(classes).toEqual(expect.arrayContaining([...pillClasses, "ko:bg-transparent", "ko:text-text", "ko:data-hover:bg-neutral-wash", "ko:data-active:bg-neutral-wash-strong"]));
+      expect(classesOf({ variant: "ghost" })).toEqual(
+        expect.arrayContaining([...baseClasses, "ko:bg-transparent", "ko:text-text", "ko:data-hover:bg-neutral-wash", "ko:data-active:bg-neutral-wash-strong"]),
+      );
     });
 
     it("should render the surface variant", () => {
-      const classes = ButtonVariants({ variant: "surface" }).split(" ");
-      expect(classes).toEqual(expect.arrayContaining([...pillClasses, "ko:bg-surface", "ko:text-text", "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]", "ko:data-hover:bg-neutral-wash"]));
+      expect(classesOf({ variant: "surface" })).toEqual(
+        expect.arrayContaining([...baseClasses, "ko:bg-surface", "ko:text-text", "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]", "ko:data-hover:bg-neutral-wash"]),
+      );
     });
 
     it("should render the plate variant", () => {
-      const classes = ButtonVariants({ variant: "plate" }).split(" ");
-      expect(classes).toEqual(
+      expect(classesOf({ variant: "plate" })).toEqual(
         expect.arrayContaining([
-          ...pillClasses,
+          ...baseClasses,
           "ko:bg-surface/72",
           "ko:text-text-muted",
           "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
@@ -71,79 +95,171 @@ describe("Button", () => {
       );
     });
 
-    it("should size by padding instead of a fixed height", () => {
-      expect(ButtonVariants({ variant: "solid", size: "small" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-auto", "ko:px-4", "ko:py-2", "ko:text-sm"]));
-      expect(ButtonVariants({ variant: "ghost", size: "medium" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-auto", "ko:px-6", "ko:py-[0.8125rem]", "ko:text-[0.9375rem]"]));
-      expect(ButtonVariants({ variant: "surface", size: "large" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-auto", "ko:px-7", "ko:py-4", "ko:text-[1.0625rem]"]));
-      expect(ButtonVariants({ variant: "plate", size: "large" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-auto", "ko:px-7", "ko:py-4", "ko:text-[1.0625rem]"]));
-    });
-
-    it("should not apply the pill sizing to the existing variants", () => {
-      expect(ButtonVariants({ variant: "fill", size: "small" }).split(" ")).not.toContain("ko:h-auto");
-      expect(ButtonVariants({ variant: "outline", size: "medium" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-12", "ko:px-3"]));
-    });
-
-    it("should render the merged classes", () => {
+    it("should render the merged classes of a given variant", () => {
       render(
         <Button variant="plate" size="large">
-          Button
+          Zpět na rekapitulaci
         </Button>,
       );
       expect(screen.getByRole("button")).toHaveClass(twMerge(ButtonVariants({ variant: "plate", size: "large" })));
     });
   });
 
-  describe("twMerge", () => {
-    it("should let the pill radius win over the base radius", () => {
-      expect(twMerge("ko:rounded-2xl ko:rounded-br-none ko:rounded-pill")).toBe("ko:rounded-pill");
+  describe("colors", () => {
+    it("should paint the solid variant in the neutral ink by default", () => {
+      expect(classesOf({ variant: "solid" })).toEqual(expect.arrayContaining(solidNeutral));
     });
 
-    it("should let an automatic height win over a fixed height", () => {
-      expect(twMerge("ko:h-12 ko:h-auto")).toBe("ko:h-auto");
+    it("should paint the solid variant in the agree color", () => {
+      const classes = classesOf({ variant: "solid", color: "primary" });
+      expect(classes).toEqual(expect.arrayContaining(solidPrimary));
+      expect(classes).not.toContain("ko:bg-neutral-ink");
     });
 
-    it("should drop the base shape from the pill variants", () => {
-      const merged = twMerge(ButtonVariants({ variant: "solid" })).split(" ");
-      expect(merged).not.toContain("ko:rounded-2xl");
-      expect(merged).not.toContain("ko:rounded-br-none");
-      expect(merged).not.toContain("ko:h-12");
-      expect(merged).not.toContain("ko:px-3");
-      expect(merged).not.toContain("ko:border-2");
-      expect(merged).not.toContain("ko:text-s");
-      expect(merged).toEqual(expect.arrayContaining(["ko:rounded-pill", "ko:h-auto", "ko:px-6", "ko:border-0", "ko:text-[0.9375rem]"]));
+    it("should paint the solid variant in the disagree color", () => {
+      const classes = classesOf({ variant: "solid", color: "secondary" });
+      expect(classes).toEqual(expect.arrayContaining(solidSecondary));
+      expect(classes).not.toContain("ko:bg-neutral-ink");
     });
 
-    it("should keep the existing variants intact", () => {
-      const outline = twMerge(ButtonVariants({ variant: "outline", color: "primary" })).split(" ");
-      expect(outline).toEqual(expect.arrayContaining(["ko:border-2", "ko:rounded-2xl", "ko:rounded-br-none", "ko:h-12", "ko:px-3", "ko:text-s", "ko:text-primary", "ko:border-primary"]));
-
-      const link = twMerge(ButtonVariants({ variant: "link", color: "primary" })).split(" ");
-      expect(link).toEqual(expect.arrayContaining(["ko:border-transparent", "ko:data-disabled:border-transparent", "ko:rounded-br-none"]));
-      expect(link).not.toContain("ko:border-primary");
-
-      const answer = twMerge(ButtonVariants({ variant: "answer", color: "primary" })).split(" ");
-      expect(answer).toEqual(expect.arrayContaining(["ko:px-6", "ko:rounded-br-none"]));
-      expect(answer).not.toContain("ko:px-3");
+    it.each(["ghost", "surface", "plate"] as const)("should keep the %s variant neutral regardless of color", (variant) => {
+      expect(ButtonVariants({ variant, color: "primary" })).toBe(ButtonVariants({ variant, color: "neutral" }));
+      expect(ButtonVariants({ variant, color: "secondary" })).toBe(ButtonVariants({ variant, color: "neutral" }));
+      expect(classesOf({ variant, color: "primary" })).not.toContain("ko:bg-agree");
+      expect(classesOf({ variant, color: "secondary" })).not.toContain("ko:bg-disagree");
     });
   });
 
-  describe("when given fullWidth", () => {
-    it("should stretch to the container", () => {
-      render(<Button fullWidth>Button</Button>);
-      expect(screen.getByRole("button")).toHaveClass("ko:w-full");
+  describe("legacy aliases", () => {
+    it("should map fill to solid", () => {
+      expect(ButtonVariants({ variant: "fill" })).toBe(ButtonVariants({ variant: "solid" }));
+      expect(ButtonVariants({ variant: "fill", color: "primary", size: "small" })).toBe(ButtonVariants({ variant: "solid", color: "primary", size: "small" }));
     });
 
-    it("should not stretch by default", () => {
-      render(<Button>Button</Button>);
-      expect(screen.getByRole("button")).not.toHaveClass("ko:w-full");
+    it("should map outline to surface", () => {
+      expect(ButtonVariants({ variant: "outline" })).toBe(ButtonVariants({ variant: "surface" }));
+      expect(ButtonVariants({ variant: "outline", color: "neutral", size: "large" })).toBe(ButtonVariants({ variant: "surface", color: "neutral", size: "large" }));
+    });
+
+    it("should map link to ghost", () => {
+      expect(ButtonVariants({ variant: "link" })).toBe(ButtonVariants({ variant: "ghost" }));
+      expect(ButtonVariants({ variant: "link", color: "neutral", size: "small" })).toBe(ButtonVariants({ variant: "ghost", color: "neutral", size: "small" }));
+    });
+
+    it("should render an aliased variant with the canonical classes", () => {
+      render(
+        <Button variant="outline" color="neutral" size="small">
+          Kopírovat odkaz
+        </Button>,
+      );
+      expect(screen.getByRole("button")).toHaveClass(twMerge(ButtonVariants({ variant: "surface", color: "neutral", size: "small" })));
+    });
+  });
+
+  describe("legacy answer variant", () => {
+    it("should take the new geometry", () => {
+      const classes = classesOf({ variant: "answer", color: "primary" });
+      expect(classes).toEqual(expect.arrayContaining(["ko:rounded-control", "ko:h-fluid-action", "ko:px-6", "ko:border-2", "ko:bg-transparent"]));
+      expect(classes).not.toContain("ko:rounded-pill");
+      expect(classes).not.toContain("ko:rounded-br-none");
+      expect(classes).not.toContain("ko:border-0");
+    });
+
+    it("should keep its outlined, checked and just-clicked behaviour", () => {
+      expect(classesOf({ variant: "answer", color: "primary" })).toEqual(
+        expect.arrayContaining([
+          "ko:border-primary",
+          "ko:text-primary",
+          "ko:hover:bg-primary",
+          "ko:data-checked:bg-primary",
+          "ko:data-checked:text-on-bg-primary",
+          "ko:data-[just-clicked]:hover:!bg-transparent",
+          "ko:data-active:bg-primary-active",
+        ]),
+      );
+      expect(classesOf({ variant: "answer", color: "secondary" })).toEqual(expect.arrayContaining(["ko:border-secondary", "ko:text-secondary", "ko:data-checked:bg-secondary"]));
+      expect(classesOf({ variant: "answer", color: "neutral" })).toEqual(expect.arrayContaining(["ko:border-neutral", "ko:text-neutral", "ko:data-checked:bg-neutral"]));
+    });
+  });
+
+  describe("sizes", () => {
+    it("should size by padding instead of a fixed height", () => {
+      expect(classesOf({ size: "small" })).toEqual(expect.arrayContaining(["ko:px-4", "ko:py-2", "ko:text-sm"]));
+      expect(classesOf({ size: "medium" })).toEqual(expect.arrayContaining(["ko:px-6", "ko:py-[0.8125rem]", "ko:text-[0.9375rem]"]));
+      expect(classesOf({ size: "large" })).toEqual(expect.arrayContaining(["ko:px-7", "ko:py-4", "ko:text-[1.0625rem]"]));
+    });
+
+    it.each(["solid", "ghost", "surface", "plate"] as const)("should apply the same paddings to the %s variant", (variant) => {
+      expect(classesOf({ variant, size: "small" })).toEqual(expect.arrayContaining(["ko:px-4", "ko:py-2", "ko:text-sm"]));
+      expect(classesOf({ variant, size: "large" })).toEqual(expect.arrayContaining(["ko:px-7", "ko:py-4", "ko:text-[1.0625rem]"]));
+      for (const height of ["ko:h-10", "ko:h-12", "ko:h-14"]) {
+        expect(classesOf({ variant, size: "small" })).not.toContain(height);
+        expect(classesOf({ variant, size: "large" })).not.toContain(height);
+      }
+    });
+
+    it("should render the correct class for a given size", () => {
+      render(
+        <Button variant="ghost" size="small">
+          Zrušit
+        </Button>,
+      );
+      expect(screen.getByRole("button")).toHaveClass(twMerge(ButtonVariants({ variant: "ghost", size: "small" })));
+    });
+  });
+
+  describe("when the only child is an icon", () => {
+    it("should render a round square at the medium size by default", () => {
+      render(
+        <Button aria-label="Zavřít">
+          <Icon icon={icons.close} decorative />
+        </Button>,
+      );
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("ko:size-11", "ko:p-0", "ko:rounded-full");
+      expect(button).not.toHaveClass("ko:px-6", "ko:py-[0.8125rem]", "ko:rounded-pill");
+    });
+
+    it("should render a smaller square for the small size", () => {
+      render(
+        <Button size="small" aria-label="Zavřít">
+          <Icon icon={icons.close} decorative />
+        </Button>,
+      );
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("ko:size-9", "ko:p-0", "ko:rounded-full");
+      expect(button).not.toHaveClass("ko:px-4", "ko:py-2");
+    });
+
+    it("should render a larger square for the large size", () => {
+      render(
+        <Button size="large" aria-label="Zavřít">
+          <Icon icon={icons.close} decorative />
+        </Button>,
+      );
+      const button = screen.getByRole("button");
+      expect(button).toHaveClass("ko:size-12", "ko:p-0", "ko:rounded-full");
+      expect(button).not.toHaveClass("ko:px-7", "ko:py-4");
+    });
+
+    it("should not treat an icon next to a label as icon-only", () => {
+      render(
+        <Button>
+          <Icon icon={icons.close} decorative />
+          Zavřít
+        </Button>,
+      );
+      const button = screen.getByRole("button");
+      expect(button).not.toHaveClass("ko:size-11", "ko:p-0", "ko:rounded-full");
+      expect(button).toHaveClass("ko:px-6", "ko:rounded-pill");
     });
   });
 
   describe("when given icons", () => {
     it("should render a decorative icon before the label", () => {
       render(
-        <Button variant="ghost" iconStart={icons.arrowLeft}>
-          Back
+        <Button variant="solid" color="primary" iconStart={icons.check}>
+          Ano
         </Button>,
       );
       const button = screen.getByRole("button");
@@ -151,18 +267,66 @@ describe("Button", () => {
       expect(svg?.tagName).toBe("svg");
       expect(svg).toHaveAttribute("aria-hidden", "true");
       expect(svg).toHaveClass("ko:size-3.5");
-      expect(button).toHaveTextContent("Back");
+      expect(button).toHaveTextContent("Ano");
     });
 
     it("should render a decorative icon after the label", () => {
       render(
         <Button variant="solid" iconEnd={icons.arrowRight}>
-          Next
+          Pokračovat
         </Button>,
       );
       const button = screen.getByRole("button");
       expect(button.lastElementChild?.tagName).toBe("svg");
       expect(button.querySelectorAll("svg")).toHaveLength(1);
     });
+
+    it("should not treat a button with iconStart as icon-only", () => {
+      render(
+        <Button variant="surface" iconStart={icons.download}>
+          Stáhnout
+        </Button>,
+      );
+      expect(screen.getByRole("button")).not.toHaveClass("ko:size-11", "ko:p-0");
+    });
+  });
+
+  describe("when given fullWidth", () => {
+    it("should stretch to the container", () => {
+      render(<Button fullWidth>Zobrazit výsledky</Button>);
+      expect(screen.getByRole("button")).toHaveClass("ko:w-full");
+    });
+
+    it("should not stretch by default", () => {
+      render(<Button>Zobrazit výsledky</Button>);
+      expect(screen.getByRole("button")).not.toHaveClass("ko:w-full");
+    });
+  });
+
+  describe("when disabled", () => {
+    it("should not be clickable", () => {
+      const onClick = vi.fn();
+      render(
+        <Button onClick={onClick} disabled>
+          Pokračovat
+        </Button>,
+      );
+      const button = screen.getByRole("button");
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute("data-disabled");
+      fireEvent.click(button);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it("should carry the disabled styles", () => {
+      render(<Button disabled>Pokračovat</Button>);
+      expect(screen.getByRole("button")).toHaveClass("ko:data-disabled:opacity-45", "ko:data-disabled:cursor-default");
+    });
+  });
+
+  it("should forward a ref", () => {
+    const ref = { current: null as HTMLButtonElement | null };
+    render(<Button ref={ref}>Pokračovat</Button>);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
   });
 });

--- a/packages/design-system/src/components/client/button.test.tsx
+++ b/packages/design-system/src/components/client/button.test.tsx
@@ -1,3 +1,4 @@
+import { icons } from "@kalkulacka-one/design-system/icons";
 import { twMerge } from "@kalkulacka-one/design-system/utilities";
 
 import { render, screen } from "@testing-library/react";
@@ -23,6 +24,145 @@ describe("Button", () => {
         </Button>,
       );
       expect(screen.getByRole("button")).toHaveClass(twMerge(ButtonVariants({ variant: "outline", size: "small" })));
+    });
+  });
+
+  describe("pill variants", () => {
+    const pillClasses = ["ko:border-0", "ko:rounded-pill", "ko:tracking-[-0.01em]", "ko:whitespace-nowrap", "ko:data-active:scale-[0.97]", "ko:data-disabled:opacity-45", "ko:data-focus:outline-3"];
+
+    it("should render the solid variant in the neutral ink", () => {
+      const classes = ButtonVariants({ variant: "solid", color: "neutral" }).split(" ");
+      expect(classes).toEqual(expect.arrayContaining([...pillClasses, "ko:bg-neutral-ink", "ko:text-on-neutral-ink", "ko:data-hover:bg-neutral-ink/90", "ko:data-active:bg-neutral-ink/80"]));
+    });
+
+    it("should render the solid variant in the answer colors", () => {
+      expect(ButtonVariants({ variant: "solid", color: "primary" }).split(" ")).toEqual(
+        expect.arrayContaining(["ko:bg-agree", "ko:text-on-agree", "ko:data-hover:bg-agree-hover", "ko:data-active:bg-agree-active"]),
+      );
+      expect(ButtonVariants({ variant: "solid", color: "secondary" }).split(" ")).toEqual(
+        expect.arrayContaining(["ko:bg-disagree", "ko:text-on-disagree", "ko:data-hover:bg-disagree-hover", "ko:data-active:bg-disagree-active"]),
+      );
+    });
+
+    it("should render the ghost variant", () => {
+      const classes = ButtonVariants({ variant: "ghost" }).split(" ");
+      expect(classes).toEqual(expect.arrayContaining([...pillClasses, "ko:bg-transparent", "ko:text-text", "ko:data-hover:bg-neutral-wash", "ko:data-active:bg-neutral-wash-strong"]));
+    });
+
+    it("should render the surface variant", () => {
+      const classes = ButtonVariants({ variant: "surface" }).split(" ");
+      expect(classes).toEqual(expect.arrayContaining([...pillClasses, "ko:bg-surface", "ko:text-text", "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]", "ko:data-hover:bg-neutral-wash"]));
+    });
+
+    it("should render the plate variant", () => {
+      const classes = ButtonVariants({ variant: "plate" }).split(" ");
+      expect(classes).toEqual(
+        expect.arrayContaining([
+          ...pillClasses,
+          "ko:bg-surface/72",
+          "ko:text-text-muted",
+          "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
+          "ko:backdrop-blur-[12px]",
+          "ko:backdrop-saturate-[1.4]",
+          "ko:data-hover:bg-surface",
+          "ko:data-hover:text-text-strong",
+          "ko:data-hover:shadow-[inset_0_0_0_1.5px_var(--ko-color-border-strong),var(--ko-shadow-card-back)]",
+        ]),
+      );
+    });
+
+    it("should size by padding instead of a fixed height", () => {
+      expect(ButtonVariants({ variant: "solid", size: "small" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-auto", "ko:px-4", "ko:py-2", "ko:text-sm"]));
+      expect(ButtonVariants({ variant: "ghost", size: "medium" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-auto", "ko:px-6", "ko:py-[0.8125rem]", "ko:text-[0.9375rem]"]));
+      expect(ButtonVariants({ variant: "surface", size: "large" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-auto", "ko:px-7", "ko:py-4", "ko:text-[1.0625rem]"]));
+      expect(ButtonVariants({ variant: "plate", size: "large" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-auto", "ko:px-7", "ko:py-4", "ko:text-[1.0625rem]"]));
+    });
+
+    it("should not apply the pill sizing to the existing variants", () => {
+      expect(ButtonVariants({ variant: "fill", size: "small" }).split(" ")).not.toContain("ko:h-auto");
+      expect(ButtonVariants({ variant: "outline", size: "medium" }).split(" ")).toEqual(expect.arrayContaining(["ko:h-12", "ko:px-3"]));
+    });
+
+    it("should render the merged classes", () => {
+      render(
+        <Button variant="plate" size="large">
+          Button
+        </Button>,
+      );
+      expect(screen.getByRole("button")).toHaveClass(twMerge(ButtonVariants({ variant: "plate", size: "large" })));
+    });
+  });
+
+  describe("twMerge", () => {
+    it("should let the pill radius win over the base radius", () => {
+      expect(twMerge("ko:rounded-2xl ko:rounded-br-none ko:rounded-pill")).toBe("ko:rounded-pill");
+    });
+
+    it("should let an automatic height win over a fixed height", () => {
+      expect(twMerge("ko:h-12 ko:h-auto")).toBe("ko:h-auto");
+    });
+
+    it("should drop the base shape from the pill variants", () => {
+      const merged = twMerge(ButtonVariants({ variant: "solid" })).split(" ");
+      expect(merged).not.toContain("ko:rounded-2xl");
+      expect(merged).not.toContain("ko:rounded-br-none");
+      expect(merged).not.toContain("ko:h-12");
+      expect(merged).not.toContain("ko:px-3");
+      expect(merged).not.toContain("ko:border-2");
+      expect(merged).not.toContain("ko:text-s");
+      expect(merged).toEqual(expect.arrayContaining(["ko:rounded-pill", "ko:h-auto", "ko:px-6", "ko:border-0", "ko:text-[0.9375rem]"]));
+    });
+
+    it("should keep the existing variants intact", () => {
+      const outline = twMerge(ButtonVariants({ variant: "outline", color: "primary" })).split(" ");
+      expect(outline).toEqual(expect.arrayContaining(["ko:border-2", "ko:rounded-2xl", "ko:rounded-br-none", "ko:h-12", "ko:px-3", "ko:text-s", "ko:text-primary", "ko:border-primary"]));
+
+      const link = twMerge(ButtonVariants({ variant: "link", color: "primary" })).split(" ");
+      expect(link).toEqual(expect.arrayContaining(["ko:border-transparent", "ko:data-disabled:border-transparent", "ko:rounded-br-none"]));
+      expect(link).not.toContain("ko:border-primary");
+
+      const answer = twMerge(ButtonVariants({ variant: "answer", color: "primary" })).split(" ");
+      expect(answer).toEqual(expect.arrayContaining(["ko:px-6", "ko:rounded-br-none"]));
+      expect(answer).not.toContain("ko:px-3");
+    });
+  });
+
+  describe("when given fullWidth", () => {
+    it("should stretch to the container", () => {
+      render(<Button fullWidth>Button</Button>);
+      expect(screen.getByRole("button")).toHaveClass("ko:w-full");
+    });
+
+    it("should not stretch by default", () => {
+      render(<Button>Button</Button>);
+      expect(screen.getByRole("button")).not.toHaveClass("ko:w-full");
+    });
+  });
+
+  describe("when given icons", () => {
+    it("should render a decorative icon before the label", () => {
+      render(
+        <Button variant="ghost" iconStart={icons.arrowLeft}>
+          Back
+        </Button>,
+      );
+      const button = screen.getByRole("button");
+      const svg = button.firstElementChild;
+      expect(svg?.tagName).toBe("svg");
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+      expect(svg).toHaveClass("ko:size-3.5");
+      expect(button).toHaveTextContent("Back");
+    });
+
+    it("should render a decorative icon after the label", () => {
+      render(
+        <Button variant="solid" iconEnd={icons.arrowRight}>
+          Next
+        </Button>,
+      );
+      const button = screen.getByRole("button");
+      expect(button.lastElementChild?.tagName).toBe("svg");
+      expect(button.querySelectorAll("svg")).toHaveLength(1);
     });
   });
 });

--- a/packages/design-system/src/components/client/button.tsx
+++ b/packages/design-system/src/components/client/button.tsx
@@ -7,65 +7,39 @@ import React from "react";
 
 import { Icon } from "./icon";
 
-export type Button = {
-  children: React.ReactNode;
-  /** Icon shown before the label. */
-  iconStart?: IconDefinition | string;
-  /** Icon shown after the label. */
-  iconEnd?: IconDefinition | string;
-  fullWidth?: boolean;
-} & Omit<ButtonPropsHeadless, "className" | "as"> &
-  VariantProps<typeof ButtonVariants>;
-
-/*
- * Shared by the pill-shaped variants (`solid`, `ghost`, `surface`, `plate`).
- * They replace the base's border, corner radius, tracking and fixed heights,
- * which `twMerge` resolves in their favour because they come later.
- */
-const pillVariant = [
-  "ko:border-0 ko:rounded-pill",
-  "ko:font-semibold ko:tracking-[-0.01em] ko:whitespace-nowrap",
-  "ko:gap-2 ko:[&>svg]:translate-y-0",
-  "ko:transition-[background-color,color,transform] ko:duration-[var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-fast)]",
-  "ko:data-active:scale-[0.97]",
-  "ko:data-disabled:opacity-45 ko:data-disabled:cursor-default",
-  "ko:data-focus:outline-3 ko:data-focus:outline-offset-2 ko:data-focus:outline-focus/55",
-];
-
-const pillVariants = ["solid", "ghost", "surface", "plate"] as const;
-
-export const ButtonVariants = cva(
+const buttonVariants = cva(
   [
-    "ko:border-2",
-    "ko:select-none ko:data-hover:cursor-pointer",
-    "ko:font-semibold ko:tracking-[.01em]",
-    "ko:rounded-2xl ko:rounded-br-none",
-    "ko:text-s",
-    "ko:data-disabled:cursor-not-allowed",
-    "ko:grid ko:grid-flow-col ko:place-items-center ko:place-content-center ko:gap-1",
-    "ko:pt-[1px] ko:[&>svg]:translate-y-[-1px]",
+    "ko:inline-flex ko:items-center ko:justify-center ko:gap-2",
+    "ko:rounded-pill ko:border-0",
+    "ko:font-sans ko:font-semibold ko:tracking-[-0.01em] ko:whitespace-nowrap ko:no-underline",
+    "ko:select-none ko:cursor-pointer",
+    "ko:transition-[background-color,color,transform] ko:duration-[var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-fast)]",
+    "ko:data-active:scale-[0.97]",
+    "ko:data-disabled:opacity-45 ko:data-disabled:cursor-default",
+    "ko:data-focus:outline-3 ko:data-focus:outline-offset-2 ko:data-focus:outline-focus/55",
   ],
   {
     variants: {
+      /* Padding rather than a fixed height, so the pill grows with its label. */
       size: {
-        small: "ko:h-10 ko:px-2",
-        medium: "ko:h-12 ko:px-3",
-        large: "ko:h-14 ko:px-4",
+        small: "ko:px-4 ko:py-2 ko:text-sm",
+        medium: "ko:px-6 ko:py-[0.8125rem] ko:text-[0.9375rem]",
+        large: "ko:px-7 ko:py-4 ko:text-[1.0625rem]",
       },
-      /* Listed before `variant` so a variant's own border (link's transparent one) wins the merge. */
+      /*
+       * Colour only reaches `solid` (and the legacy `answer`) through the
+       * compound variants below; `ghost`, `surface` and `plate` are neutral
+       * whatever is passed.
+       */
       color: {
-        primary: ["ko:border-primary", "ko:data-disabled:border-primary-disabled"],
-        secondary: ["ko:border-secondary", "ko:data-disabled:border-secondary-disabled"],
-        neutral: ["ko:border-neutral", "ko:data-disabled:border-neutral-disabled"],
+        neutral: "",
+        primary: "",
+        secondary: "",
       },
       variant: {
-        fill: [""],
-        outline: ["ko:bg-transparent"],
-        link: ["ko:bg-transparent", "ko:border-transparent", "ko:data-disabled:border-transparent"],
-        answer: ["ko:px-6"],
-        solid: pillVariant,
-        ghost: [...pillVariant, "ko:bg-transparent ko:text-text", "ko:data-hover:bg-neutral-wash", "ko:data-active:bg-neutral-wash-strong"],
-        surface: [...pillVariant, "ko:bg-surface ko:text-text ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]", "ko:data-hover:bg-neutral-wash"],
+        solid: "",
+        ghost: ["ko:bg-transparent ko:text-text", "ko:data-hover:bg-neutral-wash", "ko:data-active:bg-neutral-wash-strong"],
+        surface: ["ko:bg-surface ko:text-text ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]", "ko:data-hover:bg-neutral-wash"],
         /*
          * Chrome that floats over the animated backdrop: the back link, the
          * share action. Deliberately the same values as IconButton's `surface`
@@ -75,162 +49,32 @@ export const ButtonVariants = cva(
          * the contrast behind them is never the same two frames running.
          */
         plate: [
-          ...pillVariant,
           "ko:bg-surface/72 ko:text-text-muted ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
           "ko:backdrop-blur-[12px] ko:backdrop-saturate-[1.4]",
           "ko:data-hover:bg-surface ko:data-hover:text-text-strong ko:data-hover:shadow-[inset_0_0_0_1.5px_var(--ko-color-border-strong),var(--ko-shadow-card-back)]",
         ],
+        /**
+         * The outlined answer toggle of the legacy question page, kept only
+         * because `ToggleButton variant="answer"` needs it until that page is
+         * replaced. It keeps its outlined, checked and just-clicked behaviour
+         * but takes the new geometry: control radius, fluid action height, no
+         * square corner.
+         *
+         * @deprecated Removed together with the legacy question page.
+         */
+        answer: ["ko:rounded-control ko:h-fluid-action ko:px-6", "ko:border-2 ko:bg-transparent"],
       },
     },
     defaultVariants: {
       size: "medium",
-      variant: "fill",
-      color: "primary",
+      variant: "solid",
+      color: "neutral",
     },
     compoundVariants: [
       {
-        variant: "fill",
-        color: "primary",
-        class: [
-          "ko:bg-primary",
-          "ko:text-on-bg-primary",
-          "ko:data-hover:bg-primary-hover ko:data-hover:border-primary-hover",
-          "ko:data-focus:bg-primary-hover ko:data-focus:border-primary-hover",
-          "ko:data-active:bg-primary-active ko:data-active:border-primary-active",
-          "ko:data-hover:data-active:bg-primary-active ko:data-hover:data-active:border-primary-active",
-          "ko:data-disabled:bg-primary-disabled",
-        ],
-      },
-      {
-        variant: "fill",
-        color: "secondary",
-        class: [
-          "ko:bg-secondary",
-          "ko:text-on-bg-secondary",
-          "ko:data-hover:bg-secondary-hover ko:data-hover:border-secondary-hover",
-          "ko:data-focus:bg-secondary-hover ko:data-focus:border-secondary-hover",
-          "ko:data-active:bg-secondary-active ko:data-active:border-secondary-active",
-          "ko:data-hover:data-active:bg-secondary-active ko:data-hover:data-active:border-secondary-active",
-          "ko:data-disabled:bg-secondary-disabled",
-        ],
-      },
-      {
-        variant: "fill",
+        variant: "solid",
         color: "neutral",
-        class: [
-          "ko:bg-neutral",
-          "ko:text-on-bg-neutral",
-          "ko:data-hover:bg-neutral-hover ko:data-hover:border-neutral-hover",
-          "ko:data-focus:bg-neutral-hover ko:data-focus:border-neutral-hover",
-          "ko:data-active:bg-neutral-active ko:data-active:border-neutral-active",
-          "ko:data-hover:data-active:bg-neutral-active ko:data-hover:data-active:border-neutral-active",
-          "ko:data-disabled:bg-neutral-disabled",
-        ],
-      },
-      {
-        variant: "outline",
-        color: "primary",
-        class: [
-          "ko:text-primary",
-          "ko:data-hover:bg-primary-hover/10 ko:data-focus:bg-primary-hover/10",
-          "ko:data-active:bg-primary-active/10",
-          "ko:data-hover:data-active:bg-primary-active/10",
-          "ko:data-disabled:text-primary-disabled",
-        ],
-      },
-      {
-        variant: "outline",
-        color: "secondary",
-        class: [
-          "ko:text-secondary",
-          "ko:data-hover:bg-secondary-hover/10 ko:data-focus:bg-secondary-hover/10",
-          "ko:data-active:bg-secondary-active/10",
-          "ko:data-hover:data-active:bg-secondary-active/10",
-          "ko:data-disabled:text-secondary-disabled",
-        ],
-      },
-      {
-        variant: "outline",
-        color: "neutral",
-        class: [
-          "ko:text-neutral",
-          "ko:data-hover:bg-neutral-hover/10 ko:data-focus:bg-neutral-hover/10",
-          "ko:data-active:bg-neutral-active/10",
-          "ko:data-hover:data-active:bg-neutral-active/10",
-          "ko:data-disabled:text-neutral-disabled",
-        ],
-      },
-      {
-        variant: "link",
-        color: "primary",
-        class: [
-          "ko:text-primary",
-          "ko:data-hover:bg-primary/10 ko:data-hover:text-primary-hover ko:data-focus:text-primary-hover",
-          "ko:data-active:text-primary-active ko:data-active:bg-primary/10",
-          "ko:data-hover:data-active:text-primary-active",
-          "ko:data-disabled:text-primary-disabled",
-        ],
-      },
-      {
-        variant: "link",
-        color: "secondary",
-        class: [
-          "ko:text-secondary",
-          "ko:data-hover:bg-secondary/10 ko:data-hover:text-secondary-hover ko:data-focus:text-secondary-hover",
-          "ko:data-active:text-secondary-active ko:data-active:bg-secondary/10",
-          "ko:data-hover:data-active:text-secondary-active",
-          "ko:data-disabled:text-secondary-disabled",
-        ],
-      },
-      {
-        variant: "link",
-        color: "neutral",
-        class: [
-          "ko:text-neutral",
-          "ko:data-hover:bg-neutral/10 ko:data-hover:text-neutral-hover ko:data-focus:text-neutral-hover",
-          "ko:data-active:text-neutral-active ko:data-active:bg-neutral/10",
-          "ko:data-hover:data-active:text-neutral-active",
-          "ko:data-disabled:text-neutral-disabled",
-        ],
-      },
-      {
-        variant: "answer",
-        color: "primary",
-        class: [
-          "ko:text-primary",
-          "ko:hover:bg-primary ko:hover:text-on-bg-primary",
-          "ko:data-[just-clicked]:hover:!bg-transparent ko:data-[just-clicked]:hover:!text-primary",
-          "ko:data-checked:bg-primary ko:data-checked:text-on-bg-primary",
-          "ko:data-checked:hover:bg-transparent ko:data-checked:hover:text-primary ko:data-checked:active:bg-primary-active/10 ko:data-checked:active:border-primary",
-          "ko:data-checked:data-[just-clicked]:hover:!bg-primary ko:data-checked:data-[just-clicked]:hover:!text-on-bg-primary",
-          "ko:data-active:bg-primary-active ko:data-active:border-primary-active ko:data-active:hover:bg-primary-active ko:data-active:text-on-bg-primary",
-        ],
-      },
-      {
-        variant: "answer",
-        color: "secondary",
-        class: [
-          "ko:text-secondary",
-          "ko:hover:bg-secondary ko:hover:text-on-bg-secondary",
-          "ko:data-[just-clicked]:hover:!bg-transparent ko:data-[just-clicked]:hover:!text-secondary",
-          "ko:data-checked:bg-secondary ko:data-checked:text-on-bg-secondary",
-          "ko:data-checked:hover:bg-transparent ko:data-checked:hover:text-secondary ko:data-checked:active:bg-secondary-active/10 ko:data-checked:active:border-secondary",
-          "ko:data-checked:data-[just-clicked]:hover:!bg-secondary ko:data-checked:data-[just-clicked]:hover:!text-on-bg-secondary",
-          "ko:data-active:bg-secondary-active ko:data-active:border-secondary-active ko:data-active:hover:bg-secondary-active ko:data-active:text-on-bg-secondary",
-        ],
-      },
-      {
-        variant: "answer",
-        color: "neutral",
-        class: [
-          "ko:text-neutral",
-          "ko:hover:bg-neutral ko:hover:text-on-bg-neutral",
-          "ko:data-[just-clicked]:hover:!bg-transparent ko:data-[just-clicked]:hover:!text-neutral",
-          "ko:data-checked:bg-neutral ko:data-checked:text-on-bg-neutral",
-          "ko:data-checked:hover:bg-transparent ko:data-checked:hover:text-neutral ko:data-checked:active:bg-neutral-active/10 ko:data-checked:active:border-neutral",
-          "ko:data-checked:data-[just-clicked]:hover:!bg-neutral ko:data-checked:data-[just-clicked]:hover:!text-on-bg-neutral",
-          "ko:data-active:bg-neutral-active ko:data-active:border-neutral-active ko:data-active:hover:bg-neutral-active ko:data-active:text-on-bg-neutral",
-        ],
+        class: ["ko:bg-neutral-ink ko:text-on-neutral-ink", "ko:data-hover:bg-neutral-ink/90", "ko:data-active:bg-neutral-ink/80"],
       },
       {
         variant: "solid",
@@ -243,34 +87,106 @@ export const ButtonVariants = cva(
         class: ["ko:bg-disagree ko:text-on-disagree", "ko:data-hover:bg-disagree-hover", "ko:data-active:bg-disagree-active"],
       },
       {
-        variant: "solid",
+        variant: "answer",
+        color: "primary",
+        class: [
+          "ko:border-primary ko:text-primary",
+          "ko:hover:bg-primary ko:hover:text-on-bg-primary",
+          "ko:data-[just-clicked]:hover:!bg-transparent ko:data-[just-clicked]:hover:!text-primary",
+          "ko:data-checked:bg-primary ko:data-checked:text-on-bg-primary",
+          "ko:data-checked:hover:bg-transparent ko:data-checked:hover:text-primary ko:data-checked:active:bg-primary-active/10 ko:data-checked:active:border-primary",
+          "ko:data-checked:data-[just-clicked]:hover:!bg-primary ko:data-checked:data-[just-clicked]:hover:!text-on-bg-primary",
+          "ko:data-active:bg-primary-active ko:data-active:border-primary-active ko:data-active:hover:bg-primary-active ko:data-active:text-on-bg-primary",
+        ],
+      },
+      {
+        variant: "answer",
+        color: "secondary",
+        class: [
+          "ko:border-secondary ko:text-secondary",
+          "ko:hover:bg-secondary ko:hover:text-on-bg-secondary",
+          "ko:data-[just-clicked]:hover:!bg-transparent ko:data-[just-clicked]:hover:!text-secondary",
+          "ko:data-checked:bg-secondary ko:data-checked:text-on-bg-secondary",
+          "ko:data-checked:hover:bg-transparent ko:data-checked:hover:text-secondary ko:data-checked:active:bg-secondary-active/10 ko:data-checked:active:border-secondary",
+          "ko:data-checked:data-[just-clicked]:hover:!bg-secondary ko:data-checked:data-[just-clicked]:hover:!text-on-bg-secondary",
+          "ko:data-active:bg-secondary-active ko:data-active:border-secondary-active ko:data-active:hover:bg-secondary-active ko:data-active:text-on-bg-secondary",
+        ],
+      },
+      {
+        variant: "answer",
         color: "neutral",
-        class: ["ko:bg-neutral-ink ko:text-on-neutral-ink", "ko:data-hover:bg-neutral-ink/90", "ko:data-active:bg-neutral-ink/80"],
-      },
-      /* The pill variants size by padding rather than by a fixed height. */
-      {
-        variant: [...pillVariants],
-        size: "small",
-        class: "ko:h-auto ko:px-4 ko:py-2 ko:text-sm",
-      },
-      {
-        variant: [...pillVariants],
-        size: "medium",
-        class: "ko:h-auto ko:px-6 ko:py-[0.8125rem] ko:text-[0.9375rem]",
-      },
-      {
-        variant: [...pillVariants],
-        size: "large",
-        class: "ko:h-auto ko:px-7 ko:py-4 ko:text-[1.0625rem]",
+        class: [
+          "ko:border-neutral ko:text-neutral",
+          "ko:hover:bg-neutral ko:hover:text-on-bg-neutral",
+          "ko:data-[just-clicked]:hover:!bg-transparent ko:data-[just-clicked]:hover:!text-neutral",
+          "ko:data-checked:bg-neutral ko:data-checked:text-on-bg-neutral",
+          "ko:data-checked:hover:bg-transparent ko:data-checked:hover:text-neutral ko:data-checked:active:bg-neutral-active/10 ko:data-checked:active:border-neutral",
+          "ko:data-checked:data-[just-clicked]:hover:!bg-neutral ko:data-checked:data-[just-clicked]:hover:!text-on-bg-neutral",
+          "ko:data-active:bg-neutral-active ko:data-active:border-neutral-active ko:data-active:hover:bg-neutral-active ko:data-active:text-on-bg-neutral",
+        ],
       },
     ],
   },
 );
 
+type ButtonVariantProps = VariantProps<typeof buttonVariants>;
+
+export type ButtonVariant = NonNullable<ButtonVariantProps["variant"]>;
+export type ButtonSize = NonNullable<ButtonVariantProps["size"]>;
+
+/**
+ * Variant names of the retired design, accepted so the screens that have not
+ * been ported yet keep compiling. `fill` is the `solid` pill, `outline` the
+ * `surface` one and `link` the `ghost`.
+ *
+ * @deprecated Removed with the cleanup PR once the last consumer is ported; use `solid`, `surface` or `ghost`.
+ */
+export type LegacyButtonVariant = "fill" | "outline" | "link";
+
+/** @deprecated Removed with the cleanup PR together with `LegacyButtonVariant`. */
+const legacyVariants = {
+  fill: "solid",
+  outline: "surface",
+  link: "ghost",
+} as const satisfies Record<LegacyButtonVariant, ButtonVariant>;
+
+export type ButtonVariantsProps = Omit<ButtonVariantProps, "variant"> & {
+  variant?: ButtonVariant | LegacyButtonVariant | null;
+};
+
+function canonicalVariant(variant: ButtonVariantsProps["variant"]): ButtonVariantProps["variant"] {
+  if (variant === "fill" || variant === "outline" || variant === "link") {
+    return legacyVariants[variant];
+  }
+  return variant;
+}
+
+/** The Button's class list. Legacy variant names resolve to their pill counterpart first, so `fill` and `solid` produce the same classes. */
+export function ButtonVariants({ variant, ...props }: ButtonVariantsProps = {}): string {
+  return buttonVariants({ ...props, variant: canonicalVariant(variant) });
+}
+
+export type Button = {
+  children: React.ReactNode;
+  /** Icon shown before the label. */
+  iconStart?: IconDefinition | string;
+  /** Icon shown after the label. */
+  iconEnd?: IconDefinition | string;
+  fullWidth?: boolean;
+} & Omit<ButtonPropsHeadless, "className" | "as"> &
+  VariantProps<typeof ButtonVariants>;
+
+/* Explicit squares: a pill with no padding would otherwise collapse onto its icon. */
+const iconOnlySizes: Record<ButtonSize, string> = {
+  small: "ko:size-9",
+  medium: "ko:size-11",
+  large: "ko:size-12",
+};
+
 function ButtonComponent({ children, size, variant, color, iconStart, iconEnd, fullWidth = false, ...props }: Button, ref: React.Ref<HTMLButtonElement>) {
   const isIconOnly = React.isValidElement(children) && (children as React.ReactElement).type === Icon;
 
-  const iconOnlyClasses = isIconOnly ? "ko:aspect-square ko:!p-0 ko:!rounded-full ko:grid ko:place-items-center" : "";
+  const iconOnlyClasses = isIconOnly ? [iconOnlySizes[size ?? "medium"], "ko:p-0 ko:rounded-full"] : "";
 
   return (
     <ButtonHeadless className={twMerge(ButtonVariants({ size, variant, color }), fullWidth && "ko:w-full", iconOnlyClasses)} {...props} ref={ref}>

--- a/packages/design-system/src/components/client/button.tsx
+++ b/packages/design-system/src/components/client/button.tsx
@@ -1,3 +1,4 @@
+import type { IconDefinition } from "@kalkulacka-one/design-system/icons";
 import { twMerge } from "@kalkulacka-one/design-system/utilities";
 
 import { Button as ButtonHeadless, type ButtonProps as ButtonPropsHeadless } from "@headlessui/react";
@@ -8,15 +9,37 @@ import { Icon } from "./icon";
 
 export type Button = {
   children: React.ReactNode;
+  /** Icon shown before the label. */
+  iconStart?: IconDefinition | string;
+  /** Icon shown after the label. */
+  iconEnd?: IconDefinition | string;
+  fullWidth?: boolean;
 } & Omit<ButtonPropsHeadless, "className" | "as"> &
   VariantProps<typeof ButtonVariants>;
+
+/*
+ * Shared by the pill-shaped variants (`solid`, `ghost`, `surface`, `plate`).
+ * They replace the base's border, corner radius, tracking and fixed heights,
+ * which `twMerge` resolves in their favour because they come later.
+ */
+const pillVariant = [
+  "ko:border-0 ko:rounded-pill",
+  "ko:font-semibold ko:tracking-[-0.01em] ko:whitespace-nowrap",
+  "ko:gap-2 ko:[&>svg]:translate-y-0",
+  "ko:transition-[background-color,color,transform] ko:duration-[var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-fast)]",
+  "ko:data-active:scale-[0.97]",
+  "ko:data-disabled:opacity-45 ko:data-disabled:cursor-default",
+  "ko:data-focus:outline-3 ko:data-focus:outline-offset-2 ko:data-focus:outline-focus/55",
+];
+
+const pillVariants = ["solid", "ghost", "surface", "plate"] as const;
 
 export const ButtonVariants = cva(
   [
     "ko:border-2",
     "ko:select-none ko:data-hover:cursor-pointer",
     "ko:font-semibold ko:tracking-[.01em]",
-    "ko:rounded-br-none ko:rounded-2xl",
+    "ko:rounded-2xl ko:rounded-br-none",
     "ko:text-s",
     "ko:data-disabled:cursor-not-allowed",
     "ko:grid ko:grid-flow-col ko:place-items-center ko:place-content-center ko:gap-1",
@@ -27,17 +50,36 @@ export const ButtonVariants = cva(
       size: {
         small: "ko:h-10 ko:px-2",
         medium: "ko:h-12 ko:px-3",
+        large: "ko:h-14 ko:px-4",
+      },
+      /* Listed before `variant` so a variant's own border (link's transparent one) wins the merge. */
+      color: {
+        primary: ["ko:border-primary", "ko:data-disabled:border-primary-disabled"],
+        secondary: ["ko:border-secondary", "ko:data-disabled:border-secondary-disabled"],
+        neutral: ["ko:border-neutral", "ko:data-disabled:border-neutral-disabled"],
       },
       variant: {
         fill: [""],
         outline: ["ko:bg-transparent"],
         link: ["ko:bg-transparent", "ko:border-transparent", "ko:data-disabled:border-transparent"],
         answer: ["ko:px-6"],
-      },
-      color: {
-        primary: ["ko:border-primary", "ko:data-disabled:border-primary-disabled"],
-        secondary: ["ko:border-secondary", "ko:data-disabled:border-secondary-disabled"],
-        neutral: ["ko:border-neutral", "ko:data-disabled:border-neutral-disabled"],
+        solid: pillVariant,
+        ghost: [...pillVariant, "ko:bg-transparent ko:text-text", "ko:data-hover:bg-neutral-wash", "ko:data-active:bg-neutral-wash-strong"],
+        surface: [...pillVariant, "ko:bg-surface ko:text-text ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]", "ko:data-hover:bg-neutral-wash"],
+        /*
+         * Chrome that floats over the animated backdrop: the back link, the
+         * share action. Deliberately the same values as IconButton's `surface`
+         * variant — these sit within a few hundred pixels of each other on the
+         * results screen, and any drift between them reads as unrelated
+         * controls rather than one set. Translucent rather than opaque, because
+         * the contrast behind them is never the same two frames running.
+         */
+        plate: [
+          ...pillVariant,
+          "ko:bg-surface/72 ko:text-text-muted ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
+          "ko:backdrop-blur-[12px] ko:backdrop-saturate-[1.4]",
+          "ko:data-hover:bg-surface ko:data-hover:text-text-strong ko:data-hover:shadow-[inset_0_0_0_1.5px_var(--ko-color-border-strong),var(--ko-shadow-card-back)]",
+        ],
       },
     },
     defaultVariants: {
@@ -190,18 +232,51 @@ export const ButtonVariants = cva(
           "ko:data-active:bg-neutral-active ko:data-active:border-neutral-active ko:data-active:hover:bg-neutral-active ko:data-active:text-on-bg-neutral",
         ],
       },
+      {
+        variant: "solid",
+        color: "primary",
+        class: ["ko:bg-agree ko:text-on-agree", "ko:data-hover:bg-agree-hover", "ko:data-active:bg-agree-active"],
+      },
+      {
+        variant: "solid",
+        color: "secondary",
+        class: ["ko:bg-disagree ko:text-on-disagree", "ko:data-hover:bg-disagree-hover", "ko:data-active:bg-disagree-active"],
+      },
+      {
+        variant: "solid",
+        color: "neutral",
+        class: ["ko:bg-neutral-ink ko:text-on-neutral-ink", "ko:data-hover:bg-neutral-ink/90", "ko:data-active:bg-neutral-ink/80"],
+      },
+      /* The pill variants size by padding rather than by a fixed height. */
+      {
+        variant: [...pillVariants],
+        size: "small",
+        class: "ko:h-auto ko:px-4 ko:py-2 ko:text-sm",
+      },
+      {
+        variant: [...pillVariants],
+        size: "medium",
+        class: "ko:h-auto ko:px-6 ko:py-[0.8125rem] ko:text-[0.9375rem]",
+      },
+      {
+        variant: [...pillVariants],
+        size: "large",
+        class: "ko:h-auto ko:px-7 ko:py-4 ko:text-[1.0625rem]",
+      },
     ],
   },
 );
 
-function ButtonComponent({ children, size, variant, color, ...props }: Button, ref: React.Ref<HTMLButtonElement>) {
+function ButtonComponent({ children, size, variant, color, iconStart, iconEnd, fullWidth = false, ...props }: Button, ref: React.Ref<HTMLButtonElement>) {
   const isIconOnly = React.isValidElement(children) && (children as React.ReactElement).type === Icon;
 
   const iconOnlyClasses = isIconOnly ? "ko:aspect-square ko:!p-0 ko:!rounded-full ko:grid ko:place-items-center" : "";
 
   return (
-    <ButtonHeadless className={twMerge(ButtonVariants({ size, variant, color }), iconOnlyClasses)} {...props} ref={ref}>
+    <ButtonHeadless className={twMerge(ButtonVariants({ size, variant, color }), fullWidth && "ko:w-full", iconOnlyClasses)} {...props} ref={ref}>
+      {iconStart && <Icon icon={iconStart} size="xsmall" decorative />}
       {children}
+      {iconEnd && <Icon icon={iconEnd} size="xsmall" decorative />}
     </ButtonHeadless>
   );
 }

--- a/packages/design-system/src/components/client/icon-button.test.tsx
+++ b/packages/design-system/src/components/client/icon-button.test.tsx
@@ -1,0 +1,93 @@
+import { icons } from "@kalkulacka-one/design-system/icons";
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { IconButton, IconButtonVariants } from "./icon-button";
+
+describe("IconButton", () => {
+  it("should render a button named by its label", () => {
+    render(<IconButton icon={icons.close} label="Close" />);
+    expect(screen.getByRole("button", { name: "Close" })).toHaveAttribute("aria-label", "Close");
+  });
+
+  it("should render the icon as decorative", () => {
+    render(<IconButton icon={icons.close} label="Close" />);
+    const svg = screen.getByRole("button").querySelector("svg");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+    expect(svg).toHaveClass("ko:size-5");
+  });
+
+  it("should render a larger icon for the large size", () => {
+    render(<IconButton icon={icons.close} label="Close" size="large" />);
+    expect(screen.getByRole("button").querySelector("svg")).toHaveClass("ko:size-6");
+  });
+
+  it("should have default style", () => {
+    render(<IconButton icon={icons.close} label="Close" />);
+    expect(screen.getByRole("button")).toHaveClass(twMerge(IconButtonVariants()));
+  });
+
+  describe("when given variant and size props", () => {
+    it("should render the ghost variant at the touch-target size by default", () => {
+      expect(IconButtonVariants().split(" ")).toEqual(
+        expect.arrayContaining([
+          "ko:rounded-pill",
+          "ko:size-11",
+          "ko:bg-transparent",
+          "ko:data-hover:bg-neutral-wash",
+          "ko:data-active:scale-[0.94]",
+          "ko:data-disabled:opacity-45",
+          "ko:data-focus:outline-3",
+        ]),
+      );
+    });
+
+    it("should render the surface variant as a plate", () => {
+      const classes = IconButtonVariants({ variant: "surface", size: "large" }).split(" ");
+      expect(classes).toEqual(
+        expect.arrayContaining([
+          "ko:size-12",
+          "ko:bg-surface/72",
+          "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
+          "ko:backdrop-blur-[12px]",
+          "ko:backdrop-saturate-[1.4]",
+          "ko:data-hover:bg-surface",
+          "ko:data-hover:shadow-[inset_0_0_0_1.5px_var(--ko-color-border-strong),var(--ko-shadow-card-back)]",
+        ]),
+      );
+      expect(classes).not.toContain("ko:size-11");
+    });
+
+    it("should render the correct class", () => {
+      render(<IconButton icon={icons.close} label="Close" variant="surface" size="large" />);
+      expect(screen.getByRole("button")).toHaveClass(twMerge(IconButtonVariants({ variant: "surface", size: "large" })));
+    });
+  });
+
+  it("should forward onClick", () => {
+    const onClick = vi.fn();
+    render(<IconButton icon={icons.close} label="Close" onClick={onClick} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should forward a ref", () => {
+    const ref = { current: null as HTMLButtonElement | null };
+    render(<IconButton icon={icons.close} label="Close" ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+  });
+
+  describe("when disabled", () => {
+    it("should not be clickable", () => {
+      const onClick = vi.fn();
+      render(<IconButton icon={icons.close} label="Close" onClick={onClick} disabled />);
+      const button = screen.getByRole("button");
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute("data-disabled");
+      fireEvent.click(button);
+      expect(onClick).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/design-system/src/components/client/icon-button.tsx
+++ b/packages/design-system/src/components/client/icon-button.tsx
@@ -1,0 +1,78 @@
+import type { IconDefinition } from "@kalkulacka-one/design-system/icons";
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { Button as ButtonHeadless, type ButtonProps as ButtonPropsHeadless } from "@headlessui/react";
+import { cva, type VariantProps } from "class-variance-authority";
+import React from "react";
+
+import { Icon } from "./icon";
+
+export type IconButton = {
+  icon: IconDefinition | string;
+  /**
+   * The accessible name. Required rather than optional — an icon-only control
+   * with no label is invisible to a screen reader, and there is no sensible
+   * fallback to derive from a path.
+   */
+  label: string;
+} & Omit<ButtonPropsHeadless, "className" | "as" | "children"> &
+  VariantProps<typeof IconButtonVariants>;
+
+export const IconButtonVariants = cva(
+  [
+    "ko:inline-flex ko:items-center ko:justify-center ko:flex-none",
+    "ko:p-0 ko:border-0 ko:rounded-pill",
+    "ko:text-text ko:cursor-pointer",
+    "ko:transition-[background-color,box-shadow,color,transform] ko:duration-[var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-fast)]",
+    "ko:data-active:scale-[0.94]",
+    "ko:data-disabled:opacity-45 ko:data-disabled:cursor-default",
+    "ko:data-focus:outline-3 ko:data-focus:outline-offset-2 ko:data-focus:outline-focus/55",
+  ],
+  {
+    variants: {
+      variant: {
+        ghost: ["ko:bg-transparent", "ko:data-hover:bg-neutral-wash"],
+        /*
+         * Its own plate, for the shell header — the backdrop drifting underneath
+         * means the contrast behind this button is never the same two frames
+         * running. Deliberately the same values as Button's `plate` variant.
+         */
+        surface: [
+          "ko:bg-surface/72",
+          "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
+          "ko:backdrop-blur-[12px] ko:backdrop-saturate-[1.4]",
+          "ko:data-hover:bg-surface ko:data-hover:shadow-[inset_0_0_0_1.5px_var(--ko-color-border-strong),var(--ko-shadow-card-back)]",
+        ],
+      },
+      size: {
+        /* The 44px touch-target minimum, not a visual size. */
+        medium: "ko:size-11",
+        large: "ko:size-12",
+      },
+    },
+    defaultVariants: {
+      variant: "ghost",
+      size: "medium",
+    },
+  },
+);
+
+/**
+ * A square, icon-only control.
+ *
+ * `surface` is the variant that has to work anywhere: the shell's menu trigger
+ * sits over the animated backdrop on every screen, so it carries its own
+ * translucent plate rather than trusting whatever colour happens to be behind
+ * it that frame.
+ */
+function IconButtonComponent({ icon, label, variant, size, ...props }: IconButton, ref: React.Ref<HTMLButtonElement>) {
+  return (
+    <ButtonHeadless className={twMerge(IconButtonVariants({ variant, size }))} {...props} aria-label={label} ref={ref}>
+      <Icon icon={icon} size={size === "large" ? "medium" : "regular"} decorative />
+    </ButtonHeadless>
+  );
+}
+
+const IconButton = React.forwardRef(IconButtonComponent);
+
+export { IconButton };

--- a/packages/design-system/src/components/client/icon.test.tsx
+++ b/packages/design-system/src/components/client/icon.test.tsx
@@ -1,4 +1,4 @@
-import { EnvelopeIcon } from "@kalkulacka-one/design-system/icons";
+import { EnvelopeIcon, icons } from "@kalkulacka-one/design-system/icons";
 
 import { mdiAccount } from "@mdi/js";
 import { render, screen } from "@testing-library/react";
@@ -34,6 +34,75 @@ describe("Icon", () => {
     it("should render the correct class", () => {
       const { container } = render(<Icon icon={EnvelopeIcon} decorative size="small" data-testid="envelope" />);
       expect(container.firstChild).toHaveClass("ko:size-4 ko:min-w-4");
+    });
+
+    it("should render the xsmall size used inside buttons", () => {
+      const { container } = render(<Icon icon={icons.arrowRight} decorative size="xsmall" />);
+      expect(container.firstChild).toHaveClass("ko:size-3.5 ko:min-w-3.5");
+    });
+
+    it("should render the regular size", () => {
+      const { container } = render(<Icon icon={icons.arrowRight} decorative size="regular" />);
+      expect(container.firstChild).toHaveClass("ko:size-5 ko:min-w-5");
+    });
+  });
+
+  describe("when given an icon definition", () => {
+    it("should outline a stroke icon", () => {
+      const { container } = render(<Icon icon={icons.star} decorative data-testid="star" />);
+      const svg = screen.getByTestId("star");
+      expect(svg).toHaveAttribute("viewBox", "0 0 24 23");
+      expect(svg).toHaveAttribute("fill", "none");
+      expect(svg).toHaveAttribute("stroke", "currentColor");
+      expect(svg).toHaveAttribute("stroke-width", "2");
+      expect(svg).toHaveAttribute("stroke-linejoin", "round");
+      expect(svg).not.toHaveAttribute("stroke-linecap");
+      expect(container.querySelectorAll("path")).toHaveLength(1);
+      expect(container.querySelector("path")).toHaveAttribute("d", icons.star.paths[0]);
+    });
+
+    it("should fill a stroke icon when filled", () => {
+      render(<Icon icon={icons.star} decorative filled data-testid="star" />);
+      const svg = screen.getByTestId("star");
+      expect(svg).toHaveAttribute("fill", "currentColor");
+      expect(svg).toHaveAttribute("stroke", "currentColor");
+      expect(svg).not.toHaveAttribute("filled");
+    });
+
+    it("should fill a fill icon without stroke attributes", () => {
+      render(<Icon icon={icons.check} decorative data-testid="check" />);
+      const svg = screen.getByTestId("check");
+      expect(svg).toHaveAttribute("viewBox", "0 0 23 18");
+      expect(svg).toHaveAttribute("fill", "currentColor");
+      expect(svg).not.toHaveAttribute("stroke");
+      expect(svg).not.toHaveAttribute("stroke-width");
+    });
+
+    it("should render the thin set's stroke settings", () => {
+      render(<Icon icon={icons.arrowLeft} decorative data-testid="arrow" />);
+      const svg = screen.getByTestId("arrow");
+      expect(svg).toHaveAttribute("viewBox", "0 0 24 24");
+      expect(svg).toHaveAttribute("stroke-width", "1.5");
+      expect(svg).toHaveAttribute("stroke-linecap", "butt");
+      expect(svg).toHaveAttribute("stroke-linejoin", "miter");
+    });
+
+    it("should render dots as solid circles", () => {
+      const { container } = render(<Icon icon={icons.more} decorative />);
+      const circles = container.querySelectorAll("circle");
+      expect(container.querySelectorAll("path")).toHaveLength(0);
+      expect(circles).toHaveLength(3);
+      expect(circles[0]).toHaveAttribute("cx", "5");
+      expect(circles[0]).toHaveAttribute("cy", "12");
+      expect(circles[0]).toHaveAttribute("r", "1.6");
+      expect(circles[0]).toHaveAttribute("fill", "currentColor");
+      expect(circles[0]).toHaveAttribute("stroke", "none");
+    });
+
+    it("should keep the accessibility contract", () => {
+      render(<Icon icon={icons.close} decorative={false} title="Close" />);
+      expect(screen.getByRole("img", { name: "Close" })).toBeInTheDocument();
+      expect(screen.getByTitle("Close")).toBeInTheDocument();
     });
   });
 });

--- a/packages/design-system/src/components/client/icon.tsx
+++ b/packages/design-system/src/components/client/icon.tsx
@@ -1,3 +1,4 @@
+import type { IconDefinition } from "@kalkulacka-one/design-system/icons";
 import { twMerge } from "@kalkulacka-one/design-system/utilities";
 
 import { cva, type VariantProps } from "class-variance-authority";
@@ -6,6 +7,7 @@ import { useId } from "react";
 export type Icon = {
   icon:
     | string
+    | IconDefinition
     | React.FunctionComponent<
         {
           title?: string;
@@ -13,6 +15,8 @@ export type Icon = {
           decorative?: boolean;
         } & React.SVGProps<SVGSVGElement>
       >;
+  /** Fill a stroked definition as well as outlining it — used by the active "important" star. */
+  filled?: boolean;
   isIcon?: true;
 } & VariantProps<typeof IconVariants> &
   React.SVGProps<SVGSVGElement> &
@@ -22,7 +26,11 @@ export type Icon = {
 const IconVariants = cva("", {
   variants: {
     size: {
+      xsmall: "ko:size-3.5 ko:min-w-3.5",
+
       small: "ko:size-4 ko:min-w-4",
+
+      regular: "ko:size-5 ko:min-w-5",
 
       medium: "ko:size-6 ko:min-w-6",
 
@@ -35,7 +43,7 @@ const IconVariants = cva("", {
   },
 });
 
-export function Icon({ icon, size, title, decorative, isIcon = true, className, ...props }: Icon) {
+export function Icon({ icon, size, title, decorative, filled = false, isIcon = true, className, ...props }: Icon) {
   const titleId = useId();
 
   // Don't pass isIcon to DOM elements
@@ -56,6 +64,38 @@ export function Icon({ icon, size, title, decorative, isIcon = true, className, 
       >
         {!decorative && title && <title id={titleId}>{title}</title>}
         <path d={icon} fill="currentColor" />
+      </svg>
+    );
+  }
+
+  if (typeof icon === "object") {
+    const stroked = icon.mode === "stroke";
+
+    return (
+      <svg
+        {...domProps}
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden={decorative ? "true" : "false"}
+        aria-labelledby={!decorative ? titleId : undefined}
+        focusable="false"
+        role={decorative ? undefined : "img"}
+        className={twMerge(IconVariants({ size }), className)}
+        viewBox={icon.viewBox}
+        fill={stroked && !filled ? "none" : "currentColor"}
+        stroke={stroked ? "currentColor" : undefined}
+        strokeWidth={stroked ? icon.strokeWidth : undefined}
+        strokeLinejoin={stroked ? icon.strokeLinejoin : undefined}
+        strokeLinecap={stroked ? icon.strokeLinecap : undefined}
+      >
+        {!decorative && title && <title id={titleId}>{title}</title>}
+        {icon.paths.map((d) => (
+          <path key={d} d={d} />
+        ))}
+        {/* Dots are solid regardless of the icon's mode — they're the thin set's
+            one filled element, so they opt out of the stroke attributes above. */}
+        {icon.dots?.map(([cx, cy, r]) => (
+          <circle key={`${cx},${cy}`} cx={cx} cy={cy} r={r} fill="currentColor" stroke="none" />
+        ))}
       </svg>
     );
   }

--- a/packages/design-system/src/components/client/index.ts
+++ b/packages/design-system/src/components/client/index.ts
@@ -6,6 +6,7 @@ export * from "./description";
 export * from "./expandableCard";
 export * from "./field";
 export * from "./icon";
+export * from "./icon-button";
 export * from "./input";
 export * from "./label";
 export * from "./logo";

--- a/packages/design-system/src/components/icons/icon-set.ts
+++ b/packages/design-system/src/components/icons/icon-set.ts
@@ -1,0 +1,277 @@
+/**
+ * The icon set.
+ *
+ * Two families live here, and they are not interchangeable:
+ *
+ *  - The *marks* (`check`, `cross`, `star`) are the heavy prototype shapes the
+ *    answer buttons are built from. Their paths are verbatim from the visual
+ *    spec so the marks stay pixel-identical to it.
+ *  - The *thin set* is everything spread from `THIN` below. It carries the
+ *    logo's geometry — flat-cut ends, mitred corners, 45° diagonals — down to
+ *    a hairline, so an icon reads as the same family as the wordmark without
+ *    competing with the answer buttons for weight.
+ *
+ * Drawing a new thin icon: spread `THIN`, work on the 24 grid with the artwork
+ * inside the middle 20 (terminals on 2/4/6…22), keep every angle a multiple of
+ * 45° unless the shape is genuinely round, and use `dots` for anything solid —
+ * those are the family's only filled elements, and they echo the two dots in
+ * the wordmark.
+ */
+export type IconDefinition = {
+  viewBox: string;
+  /** `fill` uses currentColor as the fill; `stroke` outlines it. */
+  mode: "fill" | "stroke";
+  /** Outline geometry; more than one entry where a mark needs disjoint strokes. */
+  paths: readonly string[];
+  /** Solid circles, `[cx, cy, r]` — always filled, never stroked. */
+  dots?: readonly (readonly [number, number, number])[];
+  strokeWidth?: number;
+  strokeLinejoin?: "round" | "miter";
+  strokeLinecap?: "round" | "butt";
+};
+
+/** Shared geometry for the thin set. See the module comment before changing it. */
+const THIN = {
+  viewBox: "0 0 24 24",
+  mode: "stroke",
+  strokeWidth: 1.5,
+  strokeLinecap: "butt",
+  strokeLinejoin: "miter",
+} as const satisfies Omit<IconDefinition, "paths">;
+
+export const icons = {
+  /** "Ano" — the checkmark. */
+  check: {
+    viewBox: "0 0 23 18",
+    mode: "fill",
+    paths: ["M18.8702 0L22.2876 3.36487L10.8466 14.6297L7.42918 17.9946L0 10.6797L3.41742 7.31483L7.4292 11.2649L18.8702 0Z"],
+  },
+  /** "Ne" — the cross. */
+  cross: {
+    viewBox: "0 0 19 18",
+    mode: "fill",
+    paths: [
+      "M14.8585 3.3987e-05L18.2758 3.36491L12.5553 8.99735L18.2758 14.6298L14.8584 17.9946L9.13789 12.3622L3.4174 17.9946L0 14.6297L5.72047 8.99733L0 3.36485L3.41742 0L9.13792 5.6325L14.8585 3.3987e-05Z",
+    ],
+  },
+  /**
+   * "Nevím" — a position taken that carries no direction.
+   *
+   * On the cross's own 19×18 box so the three marks size identically from one
+   * `size` prop, and cut to the same weight: a bar this heavy sits between a
+   * check and a cross without either looking thin next to it.
+   */
+  neutral: {
+    viewBox: "0 0 19 18",
+    mode: "fill",
+    paths: ["M0 6.8H19V11.2H0V6.8Z"],
+  },
+  /** "Pro mě důležité" — outlined until active, then filled. */
+  star: {
+    viewBox: "0 0 24 23",
+    mode: "stroke",
+    paths: ["M12 1.8 L15.1 8.1 L22 9.1 L17 14 L18.2 20.9 L12 17.6 L5.8 20.9 L7 14 L2 9.1 L8.9 8.1 Z"],
+    strokeWidth: 2,
+    strokeLinejoin: "round",
+  },
+  chevronLeft: {
+    viewBox: "0 0 9 15",
+    mode: "stroke",
+    paths: ["M7.5 1.5 L1.5 7.5 L7.5 13.5"],
+    strokeWidth: 2,
+    strokeLinecap: "round",
+    strokeLinejoin: "round",
+  },
+  chevronRight: {
+    viewBox: "0 0 9 15",
+    mode: "stroke",
+    paths: ["M1.5 1.5 L7.5 7.5 L1.5 13.5"],
+    strokeWidth: 2,
+    strokeLinecap: "round",
+    strokeLinejoin: "round",
+  },
+  close: {
+    viewBox: "0 0 22 22",
+    mode: "stroke",
+    paths: ["M3 3 L19 19 M19 3 L3 19"],
+    strokeWidth: 2,
+    strokeLinecap: "round",
+  },
+
+  /* The thin set — 24 grid, 1.5 stroke, flat ends, mitred corners. */
+
+  /** Arrow keys, with 45° heads so they rhyme with the logo's diagonals. */
+  arrowLeft: { ...THIN, paths: ["M20 12 L4 12 M10 6 L4 12 L10 18"] },
+  arrowRight: { ...THIN, paths: ["M4 12 L20 12 M14 6 L20 12 L14 18"] },
+  arrowUp: { ...THIN, paths: ["M12 20 L12 4 M6 10 L12 4 L18 10"] },
+  arrowDown: { ...THIN, paths: ["M12 4 L12 20 M6 14 L12 20 L18 14"] },
+  /** Hairline counterparts of the answer marks, for inline use at 14–16px. */
+  checkThin: { ...THIN, paths: ["M3.5 12 L9 17.5 L20.5 6"] },
+  crossThin: { ...THIN, paths: ["M5 5 L19 19 M19 5 L5 19"] },
+  starThin: {
+    ...THIN,
+    paths: ["M12 2.5 L14.53 8.52 L21.03 9.06 L16.09 13.33 L17.58 19.69 L12 16.3 L6.42 19.69 L7.91 13.33 L2.97 9.06 L9.47 8.52 Z"],
+  },
+  /**
+   * Punctuation drawn as marks rather than set as type. A `,` or `.` at key-cap
+   * size is a couple of pixels of glyph adrift in a 24px box; built from the
+   * family's own dot and a 45° tail they carry the same weight as the arrows
+   * beside them. The two share a dot radius and centre so they read as a pair.
+   */
+  comma: { ...THIN, paths: ["M12.4 12.8 L8.6 16.6"], dots: [[12, 11, 2.6]] },
+  period: { ...THIN, paths: [], dots: [[12, 13, 2.6]] },
+  chevronLeftThin: { ...THIN, paths: ["M15 4 L7 12 L15 20"] },
+  chevronRightThin: { ...THIN, paths: ["M9 4 L17 12 L9 20"] },
+  chevronDownThin: { ...THIN, paths: ["M4 9 L12 17 L20 9"] },
+  chevronUpThin: { ...THIN, paths: ["M4 15 L12 7 L20 15"] },
+  /**
+   * The lens is one of the few shapes the family allows to be genuinely round;
+   * its handle stays on the 45° diagonal so it still rhymes with the wordmark.
+   */
+  search: {
+    ...THIN,
+    paths: ["M17 10.5 A6.5 6.5 0 1 1 4 10.5 A6.5 6.5 0 1 1 17 10.5", "M15.1 15.1 L20 20"],
+  },
+  info: {
+    ...THIN,
+    paths: ["M21 12 A9 9 0 1 1 3 12 A9 9 0 1 1 21 12", "M12 11.5 L12 17"],
+    dots: [[12, 7.6, 1.15]],
+  },
+  share: {
+    ...THIN,
+    paths: ["M12 3.5 L12 15 M6.5 9 L12 3.5 L17.5 9 M4.5 14 L4.5 20.5 L19.5 20.5 L19.5 14"],
+  },
+  /** Save. `share`'s own tray with the arrow turned around and coming down into it. */
+  download: {
+    ...THIN,
+    paths: ["M12 3.5 L12 15 M6.5 9.5 L12 15 L17.5 9.5 M4.5 14 L4.5 20.5 L19.5 20.5 L19.5 14"],
+  },
+  /** Copy to clipboard. Two overlapping rectangles, corners on the grid. */
+  copy: {
+    ...THIN,
+    paths: ["M9 3.5 L20.5 3.5 L20.5 15 L15 15", "M3.5 9 L15 9 L15 20.5 L3.5 20.5 Z"],
+  },
+  /** A URL. Two hooks on the diagonal the wordmark's cut already runs along. */
+  link: {
+    ...THIN,
+    paths: ["M10.5 7.5 L13.5 4.5 A4.243 4.243 0 0 1 19.5 10.5 L16.5 13.5", "M13.5 16.5 L10.5 19.5 A4.243 4.243 0 0 1 4.5 13.5 L7.5 10.5"],
+  },
+  /** Results — three bars, the progress row's shape at icon scale. */
+  results: { ...THIN, paths: ["M4 20 L4 13 M12 20 L12 5 M20 20 L20 9"] },
+  list: { ...THIN, paths: ["M4 6 L20 6 M4 12 L20 12 M4 18 L20 18"] },
+  plus: { ...THIN, paths: ["M12 4 L12 20 M4 12 L20 12"] },
+  /**
+   * Start over. The ring is one of the shapes the family allows to be round;
+   * the gap and the arrowhead sit on the diagonal so it still reads as drawn
+   * with the same pen as the wordmark.
+   */
+  restart: { ...THIN, paths: ["M12 19 A7 7 0 1 1 19 12", "M16 9 L19 12 L22 9"] },
+  /** Leave — an arrow stepping out through the open side of a frame. */
+  exit: {
+    ...THIN,
+    paths: ["M13 4 L4 4 L4 20 L13 20", "M10 12 L20 12 M15.5 7.5 L20 12 L15.5 16.5"],
+  },
+  more: {
+    ...THIN,
+    paths: [],
+    dots: [
+      [5, 12, 1.6],
+      [12, 12, 1.6],
+      [19, 12, 1.6],
+    ],
+  },
+  /** Light mode. The disc is round like `search`'s lens; the rays stay on 45° diagonals. */
+  sun: {
+    ...THIN,
+    paths: ["M16 12 A4 4 0 1 1 8 12 A4 4 0 1 1 16 12", "M12 2 L12 5", "M12 19 L12 22", "M2 12 L5 12", "M19 12 L22 12", "M4.9 4.9 L7 7", "M17 17 L19.1 19.1", "M4.9 19.1 L7 17", "M17 7 L19.1 4.9"],
+  },
+  /** Dark mode. One circle bitten out of another, same construction as `restart`'s ring. */
+  moon: {
+    ...THIN,
+    paths: ["M21 12.79 A9 9 0 1 1 11.21 3 A7 7 0 0 0 21 12.79 Z"],
+    strokeLinejoin: "round",
+  },
+
+  /*
+   * Topics.
+   *
+   * One per subject the questions are tagged with, so a topic list reads as a
+   * list of *subjects* rather than eleven identical rows of type. They are all
+   * from the thin set — same pen as the rest — and each is a single obvious
+   * object rather than a scene: at 20px a bus with passengers is a smudge, a
+   * bus is a bus. `topicOther` is the fallback for a tag this set has no
+   * drawing for, which is every tag once the real backend supplies its own.
+   */
+  /** Doprava — a tram/bus body over two wheels. */
+  topicTransport: {
+    ...THIN,
+    paths: ["M5 4 L19 4 L19 17 L5 17 Z", "M5 10 L19 10", "M8 13.5 L16 13.5"],
+    dots: [
+      [8, 19.5, 1.4],
+      [16, 19.5, 1.4],
+    ],
+  },
+  /** Bydlení — a house, gable on the 45°. */
+  topicHousing: {
+    ...THIN,
+    paths: ["M3 12 L12 3 L21 12", "M5.5 9.5 L5.5 20 L18.5 20 L18.5 9.5", "M10 20 L10 14 L14 14 L14 20"],
+  },
+  /** Energetika — the bolt, every edge on a 45° or a vertical. */
+  topicEnergy: {
+    ...THIN,
+    paths: ["M13.5 2.5 L5 13 L11 13 L10.5 21.5 L19 11 L13 11 Z"],
+  },
+  /** Školství — a mortarboard over its book block. */
+  topicEducation: {
+    ...THIN,
+    paths: ["M2 9 L12 4 L22 9 L12 14 Z", "M6.5 11.25 L6.5 17 L17.5 17 L17.5 11.25", "M20 10 L20 15"],
+  },
+  /** Sociální politika — care, drawn as a heart on the family's diagonals. */
+  topicSocial: {
+    ...THIN,
+    paths: ["M12 20.5 L4 12.5 A4.5 4.5 0 0 1 12 7.5 A4.5 4.5 0 0 1 20 12.5 Z"],
+  },
+  /** Životní prostředí — a tree, canopy as a triangle. */
+  topicEnvironment: {
+    ...THIN,
+    paths: ["M12 3 L4.5 13 L19.5 13 Z", "M12 8.5 L6.5 16 L17.5 16 Z", "M12 16 L12 21"],
+  },
+  /** Kultura a sport — a note; the stem's head is one of the family's dots. */
+  topicCulture: {
+    ...THIN,
+    paths: ["M9 16 L9 5.5 L19 3 L19 13.5"],
+    dots: [
+      [6.6, 16.4, 2.4],
+      [16.6, 13.9, 2.4],
+    ],
+  },
+  /** Veřejný pořádek — a shield, cut off the diagonals rather than curved. */
+  topicSafety: {
+    ...THIN,
+    paths: ["M12 2.5 L20 5.5 L20 12 L12 21.5 L4 12 L4 5.5 Z"],
+  },
+  /** Rozpočet — a note of money, with the family's dot for its face. */
+  topicBudget: {
+    ...THIN,
+    paths: ["M2.5 6 L21.5 6 L21.5 18 L2.5 18 Z", "M6 9.5 L6 14.5", "M18 9.5 L18 14.5"],
+    dots: [[12, 12, 2.4]],
+  },
+  /** Transparentnost — an eye, drawn as two 45° cuts rather than a lens. */
+  topicTransparency: {
+    ...THIN,
+    paths: ["M2 12 L7 7 L17 7 L22 12 L17 17 L7 17 Z"],
+    dots: [[12, 12, 2.2]],
+  },
+  /** Veřejné služby — the columned institution, distinct from housing's gable. */
+  topicServices: {
+    ...THIN,
+    paths: ["M2.5 9 L12 4 L21.5 9", "M5.5 9 L5.5 18 M10 9 L10 18 M14 9 L14 18 M18.5 9 L18.5 18", "M3 18 L21 18 M2 20.5 L22 20.5"],
+  },
+  /** No drawing for this tag — a bookmark, which claims nothing about the subject. */
+  topicOther: {
+    ...THIN,
+    paths: ["M6 3 L18 3 L18 21 L12 15.5 L6 21 Z"],
+  },
+} as const satisfies Record<string, IconDefinition>;
+
+export type IconName = keyof typeof icons;

--- a/packages/design-system/src/components/icons/index.ts
+++ b/packages/design-system/src/components/icons/index.ts
@@ -1,3 +1,4 @@
 export * from "./envelopeIcon";
+export * from "./icon-set";
 export * from "./icons";
 export * from "./searchIcon";


### PR DESCRIPTION
Part 2 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on the twMerge fix (#513).

Ported from `kalkulacka-2026/packages/ui/src/{button,icon-button,icon}` and re-expressed in this design system's `cva` + `ko:` conventions. Per the roadmap's rule, the 2026 design is the source of truth: **the pill is the Button now**, the old look is retired.

- **Button**: `solid` (default; the dark neutral call to action, or agree / disagree by `color`), `ghost`, `surface` (the prototype's "outline"), `plate` (translucent chrome over the backdrop); sizes `small` / `medium` / `large` with the prototype's paddings; `iconStart` / `iconEnd`, `fullWidth`; icon-only buttons become circles. The old `fill`, `outline` and `link` names are kept as **aliases** (`@deprecated`) so the not-yet-ported screens keep compiling and simply take the new look; the legacy `answer` variant stays only for the old question and review cards and goes with the cleanup PR.
- **Icon** accepts definitions from the new icon set (stroke or fill mode, solid dots, `filled` for the active "important" star) and adds `xsmall` (14 px) and `regular` (20 px).
- **IconButton**: the square icon-only control (44 px touch target, `ghost` and `surface` plates), with a required accessible `label`.
- **Icon set** (`icons/icon-set.ts`): the prototype's 45 marks and thin icons, path data verbatim, exported from `@kalkulacka-one/design-system/icons`.

Stories rewritten with real product copy (Default "Pokračovat", Agree/Disagree, Ghost, Surface, Plate, Sizes, FullWidth, IconOnly, and one clearly marked legacy story).

**Visible change on existing screens:** their buttons take the pill look immediately (a few pixels of spacing in the old bottom navigation cards are off until those screens are replaced later in this stack).

**Checks:** typecheck, lint, tests (design-system 103, app 78, CZ 6, SK 6), design-system and Storybook builds.

**Stack:** based on #513 → next: #515.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
