### PR TITLE
Align the Czech theme with the new palette

### DIFF
--- a/packages/design-system/src/themes/www.volebnikalkulacka.cz/default.css
+++ b/packages/design-system/src/themes/www.volebnikalkulacka.cz/default.css
@@ -1,11 +1,45 @@
+/*
+ * The Czech theme, aligned with the 2026 design (kalkulacka-2026/packages/tokens/src/themes/default.theme.ts).
+ *
+ * Only colour varies by light/dark mode; typefaces, radii and motion are
+ * shared across a theme's modes on purpose, so a partner never ends up with a
+ * dark mode that is accidentally a different font.
+ *
+ * The dark accents are capped by contrast, not taste: the filled answer
+ * button pins white ink in dark mode, so agree/disagree can only go as light
+ * as still clears 4.5:1 against white (#2c6cee / #cb463f land at ~4.68:1).
+ * Disagree's chroma is pulled in further than agree's at the same lightness,
+ * because red at blue's chroma reads hotter than blue does.
+ */
 :root {
   --ko-typeface-display: "Radio Canada";
   --ko-typeface-sans: "Geist";
   --ko-typeface-mono: "Geist Mono";
 
-  --ko-palette-primary: rgb(0, 112, 244);
-  --ko-palette-secondary: rgb(208, 70, 70);
-  --ko-palette-neutral: oklch(37.2% 0.044 257.287); /* Tailwind's Slate 700 */
+  /* Brand accents: "Ano" and "Ne". */
+  --ko-palette-primary: #2563eb;
+  --ko-palette-primary-dark: #2c6cee;
+  --ko-palette-secondary: #dc2626;
+  --ko-palette-secondary-dark: #cb463f;
+  --ko-palette-neutral: #334155;
+  --ko-palette-neutral-ink-dark: #f2f5f9;
+
+  /* Surfaces and ink. */
+  --ko-palette-page-light: #f8fafc;
+  --ko-palette-page-dark: #0b1220;
+  --ko-palette-surface-light: #ffffff;
+  --ko-palette-surface-dark: #1b2740;
+  --ko-palette-surface-sunken-light: #f1f5f9;
+  --ko-palette-surface-sunken-dark: #151f30;
+  --ko-palette-text-light: #1e293b;
+  --ko-palette-text-dark: #e8eef7;
+  --ko-palette-text-muted-light: #64748b;
+  --ko-palette-text-muted-dark: #94a3b8;
+  --ko-palette-border-light: #e2e8f0;
+  --ko-palette-border-dark: #2b3648;
+  --ko-palette-focus-light: #2563eb;
+  --ko-palette-focus-dark: #3b82f6;
+
   --ko-palette-red: rgb(253, 36, 62);
   --ko-palette-yellow: rgb(242, 184, 7);
   --ko-palette-green: rgb(33, 150, 83);


### PR DESCRIPTION
Part 4a of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on the shell PR.

One file: `packages/design-system/src/themes/www.volebnikalkulacka.cz/default.css`. The Czech palette moves to the 2026 design's values, which the design owner specifies for the new UI:

- agree `#2563eb` (was `#0070f4`), disagree `#dc2626` (was `#d04646`), neutral `#334155` (unchanged)
- dark counterparts `#2c6cee` / `#cb463f`, capped so white ink still clears 4.5:1 on the filled buttons
- explicit light and dark values for page, surface, sunken surface, text, muted text, border and focus

**Visible change on all Czech screens, including the logo**, since the logo colours derive from primary and secondary. Partner themes (alarm, prima, diky-ze-muzem) keep their brand colours; their surface values are on the roadmap's deferred list.

**Stack:** based on `port/04-shell` → next: `port/05-intro-page` (checkpoint C1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
