### PR TITLE
Add the question card to the design system

### DIFF
--- a/apps/design-system.kalkulacka.one/stories/Card.stories.ts
+++ b/apps/design-system.kalkulacka.one/stories/Card.stories.ts
@@ -22,7 +22,7 @@ const meta: Meta<typeof Card> = {
     },
     corner: {
       control: "select",
-      options: ["topRight", "topLeft", "bottomRight", "bottomLeft"],
+      options: ["topRight", "topLeft", "bottomRight", "bottomLeft", "card"],
     },
     border: {
       control: "boolean",

--- a/apps/design-system.kalkulacka.one/stories/QuestionCard.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/QuestionCard.stories.tsx
@@ -1,0 +1,202 @@
+import { type CardSelection, QuestionCard } from "@kalkulacka-one/design-system/client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useState } from "react";
+
+const content = {
+  id: "q1",
+  topic: "Energetika",
+  title: "Omezení vánoční výzdoby",
+  statement: "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
+  detail:
+    "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec, na dalších místech se bude rozsvěcet o hodinu později než doposud.",
+};
+
+const labels = {
+  agree: "Ano",
+  disagree: "Ne",
+  important: "Pro mě důležité",
+};
+
+const none: CardSelection = { agree: false, disagree: false, important: false };
+
+/**
+ * The card positions itself absolutely, so stories give it a box to fill —
+ * the same job the flow's "stage" element does in the app. Sized so the
+ * answer labels stay hidden on a laptop (the labels appear from a 37.5rem
+ * *card* width, see `Wide`).
+ */
+function Stage({ width = "min(90vw, 34rem)", height = "33.75rem", children }: { width?: string; height?: string; children: React.ReactNode }) {
+  return <div style={{ position: "relative", width, height }}>{children}</div>;
+}
+
+const meta: Meta<typeof QuestionCard> = {
+  title: "Components/QuestionCard",
+  component: QuestionCard,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  args: {
+    content,
+    labels,
+    selection: none,
+    elevation: "active",
+    statementAs: "p",
+    inert: false,
+  },
+  argTypes: {
+    elevation: {
+      control: "select",
+      options: ["active", "next", "back", "lifted"],
+      defaultValue: { summary: "active" },
+    },
+    statementAs: {
+      control: "select",
+      options: ["p", "h1", "h2"],
+      defaultValue: { summary: "p" },
+    },
+    inert: { control: "boolean" },
+    content: { control: "object" },
+    selection: { control: "object" },
+    labels: { control: "object" },
+    close: { control: false },
+    guides: { control: false },
+    ref: { control: false },
+    className: { control: false },
+  },
+  decorators: [
+    (Story) => (
+      <Stage>
+        <Story />
+      </Stage>
+    ),
+  ],
+};
+
+type QuestionCardStory = StoryObj<typeof meta>;
+
+/** Topic and title chips, the statement, its explainer, and the three actions. */
+export const Default: QuestionCardStory = {};
+
+/** The buttons drive the selection here, as the deck drives them in the app. */
+export const Interactive: QuestionCardStory = {
+  render: (args) => {
+    const [selection, setSelection] = useState<CardSelection>(none);
+    return (
+      <QuestionCard
+        {...args}
+        selection={selection}
+        onAgree={() => setSelection((current) => ({ ...current, agree: !current.agree, disagree: false }))}
+        onDisagree={() => setSelection((current) => ({ ...current, disagree: !current.disagree, agree: false }))}
+        onToggleImportant={() => setSelection((current) => ({ ...current, important: !current.important }))}
+      />
+    );
+  },
+};
+
+export const Agreed: QuestionCardStory = {
+  args: { selection: { agree: true, disagree: false, important: false } },
+};
+
+export const Disagreed: QuestionCardStory = {
+  args: { selection: { agree: false, disagree: true, important: false } },
+};
+
+/** The star fills and inverts; the answer keeps its own colour. */
+export const DisagreedAndImportant: QuestionCardStory = {
+  args: { selection: { agree: false, disagree: true, important: true } },
+};
+
+export const Important: QuestionCardStory = {
+  args: { selection: { agree: false, disagree: false, important: true } },
+};
+
+/**
+ * The deck's stack: `back` and `next` behind the active card, scaled and lifted
+ * as the deck lays them out, and a `lifted` copy mid-flight in front of it. The
+ * cards behind are `inert`; only the active one is in the accessibility tree.
+ */
+export const Elevations: QuestionCardStory = {
+  render: (args) => (
+    <>
+      <div style={{ position: "absolute", inset: 0, transform: "translateY(-60px) scale(0.88)", filter: "brightness(0.95)" }}>
+        <QuestionCard {...args} content={{ ...content, id: "back" }} elevation="back" inert />
+      </div>
+      <div style={{ position: "absolute", inset: 0, transform: "translateY(-32px) scale(0.94)", filter: "brightness(0.98)" }}>
+        <QuestionCard {...args} content={{ ...content, id: "next" }} elevation="next" inert />
+      </div>
+      <QuestionCard {...args} elevation="active" statementAs="h1" />
+      <div style={{ position: "absolute", inset: 0, transform: "translate(160px, -12px) rotate(6deg)", pointerEvents: "none" }}>
+        <QuestionCard {...args} content={{ ...content, id: "ghost" }} selection={{ agree: false, disagree: true, important: false }} elevation="lifted" inert />
+      </div>
+    </>
+  ),
+  decorators: [
+    (Story) => (
+      <Stage width="min(90vw, 34rem)" height="38rem">
+        <Story />
+      </Stage>
+    ),
+  ],
+};
+
+/** From a 37.5rem card width the answer buttons spell their labels out next to the marks. */
+export const Wide: QuestionCardStory = {
+  decorators: [
+    (Story) => (
+      <Stage width="min(90vw, 48rem)" height="30rem">
+        <Story />
+      </Stage>
+    ),
+  ],
+};
+
+/** Only the recap's dialog passes this — the deck's own cards never close. */
+export const Closable: QuestionCardStory = {
+  args: { close: { label: "Zavřít", onClose: () => {} } },
+};
+
+/** A card behind the active one: out of the tab order and the accessibility tree, no grab cursor. */
+export const Inert: QuestionCardStory = {
+  args: { inert: true, elevation: "next" },
+};
+
+/** Questions without an explainer are common in the archive data. */
+export const WithoutDetail: QuestionCardStory = {
+  args: {
+    content: {
+      ...content,
+      detail: undefined,
+      title: "Fotovoltaika na městské budovy",
+      statement: "Město má investovat do fotovoltaických panelů na střechách městských budov.",
+    },
+  },
+};
+
+/** Tags are empty for some data sources; the card drops to a single chip. */
+export const WithoutTopic: QuestionCardStory = {
+  args: { content: { ...content, topic: undefined } },
+};
+
+/** The tutorial's practice card: no chips, no statement — the only text is the instruction, centred. */
+export const PracticeCard: QuestionCardStory = {
+  args: {
+    content: { id: "practice", detail: "Zkuste kartu přetáhnout doleva nebo doprava." },
+    onPointerDown: () => {},
+  },
+};
+
+/** The longest statement and explainer in the Pardubice set. */
+export const LongestContent: QuestionCardStory = {
+  args: {
+    content: {
+      id: "q-long",
+      topic: "Bydlení",
+      title: "Podpora družstevního bydlení",
+      statement: "Město má podporovat družstevní a spolkové formy bytové výstavby i subjekty, které budou poskytovat bydlení na neziskovém principu.",
+      detail:
+        "Kritikům vadí, že ekonomické tlaky na původní obyvatele vedou k jejich postupnému vytlačování. Městské části pak ztrácejí pestrost a uzavírají se jen pro vybrané skupiny lidí. Zastánci tvrdí, že to je přirozený proces a že na bydlení v dobré čtvrti si člověk musí vydělat.",
+    },
+  },
+};
+
+export default meta;

--- a/packages/design-system/src/components/client/index.ts
+++ b/packages/design-system/src/components/client/index.ts
@@ -10,5 +10,6 @@ export * from "./icon-button";
 export * from "./input";
 export * from "./label";
 export * from "./logo";
+export * from "./questionCard";
 export * from "./scrollMode";
 export * from "./toggleButton";

--- a/packages/design-system/src/components/client/questionCard.test.tsx
+++ b/packages/design-system/src/components/client/questionCard.test.tsx
@@ -1,0 +1,280 @@
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { QuestionCard, QuestionCardActionVariants, QuestionCardVariants } from "./questionCard";
+
+const content = {
+  id: "q1",
+  topic: "Energetika",
+  title: "Omezení vánoční výzdoby",
+  statement: "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
+  detail: "K podobnému kroku přistoupila například rakouská Vídeň.",
+};
+
+const labels = {
+  agree: "Ano",
+  disagree: "Ne",
+  important: "Pro mě důležité",
+};
+
+const none = { agree: false, disagree: false, important: false };
+
+function card(container: HTMLElement) {
+  const root = container.firstElementChild;
+  if (!(root instanceof HTMLDivElement)) {
+    throw new Error("The card did not render a root div");
+  }
+  return root;
+}
+
+describe("QuestionCard", () => {
+  it("renders the topic as a filled chip and the title as an outlined one", () => {
+    render(<QuestionCard content={content} selection={none} labels={labels} />);
+    expect(screen.getByText("Energetika")).toHaveClass("ko:bg-surface-sunken");
+    expect(screen.getByText("Omezení vánoční výzdoby")).toHaveClass("ko:shadow-[inset_0_0_0_1px_var(--ko-color-border)]");
+  });
+
+  it("renders the statement and the detail", () => {
+    render(<QuestionCard content={content} selection={none} labels={labels} />);
+    const statement = screen.getByText(content.statement);
+    expect(statement.tagName).toBe("P");
+    expect(statement).toHaveClass("ko:font-question", "ko:text-fluid-question", "ko:font-bold", "ko:text-text");
+    expect(screen.getByText(content.detail)).toHaveClass("ko:text-fluid-gist", "ko:text-text-muted", "ko:mt-[1.125rem]");
+  });
+
+  it("skips the chips row when there is neither topic nor title", () => {
+    const { container } = render(<QuestionCard content={{ id: "practice", detail: "Zkuste kartu přetáhnout." }} selection={none} labels={labels} />);
+    expect(container.querySelector(".ko\\:flex-wrap")).toBeNull();
+  });
+
+  it("centres a detail that stands alone", () => {
+    render(<QuestionCard content={{ id: "practice", detail: "Zkuste kartu přetáhnout." }} selection={none} labels={labels} />);
+    const detail = screen.getByText("Zkuste kartu přetáhnout.");
+    expect(detail).toHaveClass("ko:mt-0", "ko:text-center", "ko:text-balance");
+    expect(detail).not.toHaveClass("ko:mt-[1.125rem]");
+  });
+
+  describe("statementAs", () => {
+    it("draws the statement as a heading when asked", () => {
+      render(<QuestionCard content={content} selection={none} labels={labels} statementAs="h1" />);
+      expect(screen.getByRole("heading", { level: 1, name: content.statement })).toBeInTheDocument();
+    });
+
+    it("keeps the same look on either element", () => {
+      const { unmount } = render(<QuestionCard content={content} selection={none} labels={labels} />);
+      const paragraphClasses = screen.getByText(content.statement).className;
+      unmount();
+      render(<QuestionCard content={content} selection={none} labels={labels} statementAs="h2" />);
+      expect(screen.getByRole("heading", { level: 2 })).toHaveClass(paragraphClasses);
+    });
+  });
+
+  describe("the important toggle", () => {
+    it("is a pressable button named by its label", () => {
+      render(<QuestionCard content={content} selection={none} labels={labels} />);
+      const star = screen.getByRole("button", { name: "Pro mě důležité" });
+      expect(star).toHaveAttribute("aria-pressed", "false");
+      expect(star).toHaveClass(twMerge(QuestionCardActionVariants({ action: "important" })));
+      expect(star.querySelector("svg")).toHaveAttribute("fill", "none");
+    });
+
+    it("is pressed with a filled star when important", () => {
+      render(<QuestionCard content={content} selection={{ ...none, important: true }} labels={labels} />);
+      const star = screen.getByRole("button", { name: "Pro mě důležité" });
+      expect(star).toHaveAttribute("aria-pressed", "true");
+      expect(star.querySelector("svg")).toHaveAttribute("fill", "currentColor");
+    });
+
+    it("carries its label as a hidden tooltip", () => {
+      render(<QuestionCard content={content} selection={none} labels={labels} />);
+      const tooltip = screen.getByRole("button", { name: "Pro mě důležité" }).querySelector(".ko-question-card-tooltip");
+      expect(tooltip).toHaveTextContent("Pro mě důležité");
+      expect(tooltip).toHaveAttribute("aria-hidden", "true");
+    });
+  });
+
+  describe("the answer buttons", () => {
+    it("read as unselected by default", () => {
+      render(<QuestionCard content={content} selection={none} labels={labels} />);
+      expect(screen.getByRole("button", { name: "Ano" })).toHaveAttribute("aria-pressed", "false");
+      expect(screen.getByRole("button", { name: "Ne" })).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("read as selected from the selection", () => {
+      const { rerender } = render(<QuestionCard content={content} selection={{ ...none, agree: true }} labels={labels} />);
+      expect(screen.getByRole("button", { name: "Ano" })).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: "Ne" })).toHaveAttribute("aria-pressed", "false");
+
+      rerender(<QuestionCard content={content} selection={{ ...none, disagree: true }} labels={labels} />);
+      expect(screen.getByRole("button", { name: "Ano" })).toHaveAttribute("aria-pressed", "false");
+      expect(screen.getByRole("button", { name: "Ne" })).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("wear the agree and disagree tones", () => {
+      render(<QuestionCard content={content} selection={none} labels={labels} />);
+      expect(screen.getByRole("button", { name: "Ano" })).toHaveClass(twMerge(QuestionCardActionVariants({ action: "agree" })));
+      expect(screen.getByRole("button", { name: "Ne" })).toHaveClass(twMerge(QuestionCardActionVariants({ action: "disagree" })));
+
+      const agree = QuestionCardActionVariants({ action: "agree" }).split(" ");
+      expect(agree).toEqual(
+        expect.arrayContaining(["ko:flex-1", "ko:h-fluid-action", "ko:rounded-control", "ko:bg-surface", "ko:hover:bg-agree-wash", "ko:aria-pressed:bg-agree", "ko:aria-pressed:text-on-agree"]),
+      );
+      const disagree = QuestionCardActionVariants({ action: "disagree" }).split(" ");
+      expect(disagree).toEqual(expect.arrayContaining(["ko:hover:bg-disagree-wash", "ko:aria-pressed:bg-disagree", "ko:aria-pressed:text-on-disagree"]));
+    });
+
+    it("show their text labels only once the card is wide enough", () => {
+      render(<QuestionCard content={content} selection={none} labels={labels} />);
+      const label = screen.getByText("Ano");
+      expect(label).toHaveClass("ko:hidden", "ko:@[37.5rem]/card:inline");
+      expect(screen.getByText("Ne")).toHaveClass("ko:hidden", "ko:@[37.5rem]/card:inline");
+    });
+  });
+
+  describe("callbacks", () => {
+    it("calls onAgree, onDisagree and onToggleImportant", () => {
+      const onAgree = vi.fn();
+      const onDisagree = vi.fn();
+      const onToggleImportant = vi.fn();
+      render(<QuestionCard content={content} selection={none} labels={labels} onAgree={onAgree} onDisagree={onDisagree} onToggleImportant={onToggleImportant} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Ano" }));
+      expect(onAgree).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole("button", { name: "Ne" }));
+      expect(onDisagree).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByRole("button", { name: "Pro mě důležité" }));
+      expect(onToggleImportant).toHaveBeenCalledTimes(1);
+    });
+
+    it("passes a pointer-down on the card itself to onPointerDown", () => {
+      const onPointerDown = vi.fn();
+      render(<QuestionCard content={content} selection={none} labels={labels} onPointerDown={onPointerDown} />);
+      fireEvent.pointerDown(screen.getByText(content.statement));
+      expect(onPointerDown).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not let a pointer-down on a button start a drag", () => {
+      const onPointerDown = vi.fn();
+      render(<QuestionCard content={content} selection={none} labels={labels} onPointerDown={onPointerDown} close={{ label: "Zavřít", onClose: () => {} }} />);
+      fireEvent.pointerDown(screen.getByRole("button", { name: "Ano" }));
+      fireEvent.pointerDown(screen.getByRole("button", { name: "Ne" }));
+      fireEvent.pointerDown(screen.getByRole("button", { name: "Pro mě důležité" }));
+      fireEvent.pointerDown(screen.getByRole("button", { name: "Zavřít" }));
+      expect(onPointerDown).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the grab cursor", () => {
+    it("appears only on a card that can actually be dragged", () => {
+      const { container, rerender } = render(<QuestionCard content={content} selection={none} labels={labels} onAgree={() => {}} />);
+      expect(card(container)).not.toHaveClass("ko:cursor-grab");
+
+      rerender(<QuestionCard content={content} selection={none} labels={labels} onPointerDown={() => {}} />);
+      expect(card(container)).toHaveClass("ko:cursor-grab", "ko:touch-none", "ko:select-none");
+
+      rerender(<QuestionCard content={content} selection={none} labels={labels} onPointerDown={() => {}} inert />);
+      expect(card(container)).not.toHaveClass("ko:cursor-grab");
+    });
+  });
+
+  describe("when inert", () => {
+    it("leaves the accessibility tree and the tab order", () => {
+      const { container } = render(<QuestionCard content={content} selection={none} labels={labels} close={{ label: "Zavřít", onClose: () => {} }} inert />);
+      const root = card(container);
+      expect(root).toHaveAttribute("inert");
+      expect(root).toHaveAttribute("aria-hidden", "true");
+      for (const button of container.querySelectorAll("button")) {
+        expect(button).toHaveAttribute("tabindex", "-1");
+      }
+    });
+
+    it("stays in the tree otherwise", () => {
+      const { container } = render(<QuestionCard content={content} selection={none} labels={labels} />);
+      const root = card(container);
+      expect(root).not.toHaveAttribute("inert");
+      expect(root).not.toHaveAttribute("aria-hidden");
+      for (const button of container.querySelectorAll("button")) {
+        expect(button).not.toHaveAttribute("tabindex");
+      }
+    });
+  });
+
+  describe("the close button", () => {
+    it("is absent unless asked for", () => {
+      render(<QuestionCard content={content} selection={none} labels={labels} />);
+      expect(screen.queryByRole("button", { name: "Zavřít" })).toBeNull();
+    });
+
+    it("is named by its label and calls onClose", () => {
+      const onClose = vi.fn();
+      render(<QuestionCard content={content} selection={none} labels={labels} close={{ label: "Zavřít", onClose }} />);
+      const button = screen.getByRole("button", { name: "Zavřít" });
+      expect(button).toHaveAttribute("title", "Zavřít");
+      expect(button).toHaveClass("ko:absolute", "ko:top-fluid-card-pad-top", "ko:right-fluid-card-pad-side", "ko:size-8", "ko:rounded-pill");
+      fireEvent.click(button);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("reserves room for itself in the chips row", () => {
+      render(<QuestionCard content={content} selection={none} labels={labels} close={{ label: "Zavřít", onClose: () => {} }} />);
+      expect(screen.getByText("Energetika").parentElement).toHaveClass("ko:pr-10");
+    });
+  });
+
+  describe("the guides slot", () => {
+    it("renders the guides inside the card and holds the text clear of them", () => {
+      const { container } = render(<QuestionCard content={content} selection={none} labels={labels} guides={<div data-testid="guides" />} />);
+      expect(card(container)).toContainElement(screen.getByTestId("guides"));
+      expect(screen.getByText(content.statement).parentElement).toHaveClass("ko:py-11");
+      expect(screen.getByText(content.statement).parentElement).not.toHaveClass("ko:py-2");
+    });
+
+    it("keeps the body's own padding without them", () => {
+      render(<QuestionCard content={content} selection={none} labels={labels} />);
+      expect(screen.getByText(content.statement).parentElement).toHaveClass("ko:py-2");
+    });
+  });
+
+  describe("elevation", () => {
+    it("is the active shadow by default", () => {
+      const { container } = render(<QuestionCard content={content} selection={none} labels={labels} />);
+      expect(card(container)).toHaveClass(twMerge(QuestionCardVariants()));
+      expect(card(container)).toHaveClass("ko:shadow-card");
+    });
+
+    it("maps each step to its shadow", () => {
+      expect(QuestionCardVariants({ elevation: "active" }).split(" ")).toContain("ko:shadow-card");
+      expect(QuestionCardVariants({ elevation: "next" }).split(" ")).toContain("ko:shadow-card-next");
+      expect(QuestionCardVariants({ elevation: "back" }).split(" ")).toContain("ko:shadow-card-back");
+      expect(QuestionCardVariants({ elevation: "lifted" }).split(" ")).toContain("ko:shadow-card-lifted");
+      expect(QuestionCardVariants({ elevation: "lifted" }).split(" ")).not.toContain("ko:shadow-card");
+    });
+
+    it("fills its stage as a container named card", () => {
+      expect(QuestionCardVariants().split(" ")).toEqual(
+        expect.arrayContaining([
+          "ko:absolute",
+          "ko:inset-0",
+          "ko:bg-surface",
+          "ko:rounded-card",
+          "ko:@container/card",
+          "ko:pt-fluid-card-pad-top",
+          "ko:px-fluid-card-pad-side",
+          "ko:pb-fluid-card-pad-bottom",
+        ]),
+      );
+    });
+  });
+
+  it("forwards a ref to the root element and merges className", () => {
+    const ref = { current: null as HTMLDivElement | null };
+    const { container } = render(<QuestionCard content={content} selection={none} labels={labels} ref={ref} className="ko:shadow-none" />);
+    expect(ref.current).toBe(card(container));
+    expect(ref.current).toHaveClass("ko:shadow-none");
+    expect(ref.current).not.toHaveClass("ko:shadow-card");
+  });
+});

--- a/packages/design-system/src/components/client/questionCard.tsx
+++ b/packages/design-system/src/components/client/questionCard.tsx
@@ -1,0 +1,350 @@
+"use client";
+
+// Ported from kalkulacka-2026/packages/ui/src/question-card/question-card.tsx and question-card.module.css
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ReactNode, PointerEvent as ReactPointerEvent, Ref } from "react";
+
+import { icons } from "../icons";
+import { Chip } from "../server/chip";
+import { Icon } from "./icon";
+
+/** Everything the card needs to render one question. */
+export type QuestionCardContent = {
+  id: string;
+  /**
+   * The statement being agreed or disagreed with.
+   *
+   * Optional because the tutorial's practice card has nothing to agree with:
+   * it is a surface to put your hands on, and the only text it carries is the
+   * instruction for doing so, which belongs in `detail`. Every card in the
+   * flow itself has one.
+   */
+  statement?: string;
+  /**
+   * Short label for the outlined chip. Optional along with `topic` — the
+   * practice card has neither, so the chips row it would have started can be
+   * skipped instead of rendered empty.
+   */
+  title?: string;
+  /** Optional explainer paragraph. */
+  detail?: string;
+  /** Topic, shown as the filled chip. */
+  topic?: string;
+};
+
+/** Which control reads as selected. */
+export type CardSelection = {
+  agree: boolean;
+  disagree: boolean;
+  important: boolean;
+};
+
+export type QuestionCardLabels = {
+  agree: string;
+  disagree: string;
+  important: string;
+};
+
+export type QuestionCardElevation = NonNullable<VariantProps<typeof QuestionCardVariants>["elevation"]>;
+
+export type QuestionCard = {
+  content: QuestionCardContent;
+  selection: CardSelection;
+  labels: QuestionCardLabels;
+  /** Omitted for the decorative cards stacked behind the active one. */
+  onAgree?: () => void;
+  onDisagree?: () => void;
+  onToggleImportant?: () => void;
+  onPointerDown?: (event: ReactPointerEvent<HTMLDivElement>) => void;
+  /**
+   * A classic corner close control — only ever set by the recap's dialog,
+   * which is the one place a question card is dismissible without being
+   * answered. The deck never passes this: its cards leave by swiping or
+   * answering, not by being closed.
+   */
+  close?: { label: string; onClose: () => void };
+  /**
+   * Decoration drawn over the card's own content — the tutorial's drag
+   * compass, and nothing else so far. Inside the card rather than layered on
+   * the deck above it, so it travels with the card under a drag: an arrow that
+   * stayed behind while the card moved would be pointing at where the card used
+   * to be.
+   */
+  guides?: ReactNode;
+  /**
+   * What element the statement is drawn as.
+   *
+   * A paragraph by default, which is what the stacked, ghosted and practice
+   * cards want — none of them is the thing a reader has arrived at. The card
+   * actually being answered passes a heading instead: on the question flow the
+   * statement *is* the screen's content, and drawn as a `<p>` it left that
+   * screen with no heading at all for a screen reader to navigate by. Styling
+   * lives entirely in the statement's class list, so this changes the
+   * semantics and nothing about how the card looks.
+   */
+  statementAs?: "p" | "h1" | "h2";
+  /** Non-interactive cards are hidden from assistive tech and the tab order. */
+  inert?: boolean;
+  elevation?: QuestionCardElevation;
+  ref?: Ref<HTMLDivElement>;
+  className?: string;
+};
+
+/**
+ * The card's surface. Fills whatever positioned box the caller gives it — the
+ * deck's stage, the recap dialog's frame, a story's decorator.
+ */
+export const QuestionCardVariants = cva(
+  [
+    "ko:absolute ko:inset-0",
+    "ko:flex ko:flex-col ko:overflow-hidden",
+    "ko:bg-surface ko:rounded-card ko:border ko:border-border",
+    "ko:pt-fluid-card-pad-top ko:px-fluid-card-pad-side ko:pb-fluid-card-pad-bottom",
+    /*
+     * Labels on the answer buttons appear once the card itself is wide enough,
+     * not once the window is. Inside an embed the two are very different things.
+     */
+    "ko:@container/card",
+    "ko:origin-center",
+  ],
+  {
+    variants: {
+      elevation: {
+        active: "ko:shadow-card",
+        next: "ko:shadow-card-next",
+        back: "ko:shadow-card-back",
+        lifted: "ko:shadow-card-lifted",
+      },
+      /*
+       * Keyed to `onPointerDown`, which is what actually makes the card draggable —
+       * not to `onAgree`, which only means its buttons work. The recap's dialog
+       * renders an answerable card that is *not* on a deck, and a grab cursor over
+       * something that cannot be grabbed is a promise the card can't keep.
+       */
+      interactive: {
+        true: "ko:cursor-grab ko:active:cursor-grabbing ko:touch-none ko:select-none",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      elevation: "active",
+      interactive: false,
+    },
+  },
+);
+
+/**
+ * The three controls in the action row. The star is a square toggle, the two
+ * answers share the row's remaining width. Selection is read from
+ * `aria-pressed`, so the pressed look can never drift from what a screen
+ * reader is told.
+ */
+export const QuestionCardActionVariants = cva(
+  [
+    "ko:relative ko:flex ko:items-center ko:justify-center ko:gap-3",
+    "ko:border-0 ko:bg-surface ko:text-neutral-ink ko:cursor-pointer",
+    "ko:transition-[background-color,box-shadow,color,transform] ko:duration-[var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-fast)] ko:ease-[ease]",
+    "ko:focus-visible:outline-3 ko:focus-visible:outline-offset-2 ko:focus-visible:outline-focus/55",
+  ],
+  {
+    variants: {
+      action: {
+        important: [
+          /* The hook for the tooltip's hover/focus rules in `styles.css`. */
+          "ko-question-card-important",
+          "ko:size-fluid-star ko:flex-none ko:rounded-pill",
+          "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
+          "ko:hover:bg-neutral-wash ko:active:scale-[0.96]",
+          "ko:aria-pressed:bg-neutral-ink ko:aria-pressed:text-on-neutral-ink ko:aria-pressed:shadow-[inset_0_0_0_1.5px_var(--ko-color-neutral-ink)]",
+        ],
+        agree: [
+          "ko:flex-1 ko:h-fluid-action ko:rounded-control ko:active:scale-[0.985]",
+          "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-agree-soft)]",
+          "ko:hover:bg-agree-wash",
+          "ko:aria-pressed:bg-agree ko:aria-pressed:text-on-agree ko:aria-pressed:shadow-[inset_0_0_0_1.5px_var(--ko-color-agree)]",
+        ],
+        disagree: [
+          "ko:flex-1 ko:h-fluid-action ko:rounded-control ko:active:scale-[0.985]",
+          "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-disagree-soft)]",
+          "ko:hover:bg-disagree-wash",
+          "ko:aria-pressed:bg-disagree ko:aria-pressed:text-on-disagree ko:aria-pressed:shadow-[inset_0_0_0_1.5px_var(--ko-color-disagree)]",
+        ],
+      },
+    },
+  },
+);
+
+/*
+ * A classic modal close — inset by the same padding the chips row starts at,
+ * so its top edge lines up with theirs instead of sitting flush with the
+ * card's literal corner (an absolutely positioned child's containing block is
+ * the padding *box*, not the content box, so that alignment has to be spelled
+ * out explicitly).
+ */
+const closeClasses = [
+  "ko:absolute ko:top-fluid-card-pad-top ko:right-fluid-card-pad-side ko:z-1",
+  "ko:flex ko:flex-none ko:items-center ko:justify-center ko:size-8",
+  "ko:border-0 ko:rounded-pill ko:bg-surface ko:text-neutral-ink ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)] ko:cursor-pointer",
+  "ko:transition-[background-color,box-shadow,transform] ko:duration-[var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-fast)] ko:ease-[ease]",
+  "ko:hover:bg-neutral-wash ko:active:scale-[0.94]",
+  "ko:focus-visible:outline-3 ko:focus-visible:outline-offset-2 ko:focus-visible:outline-focus/55",
+].join(" ");
+
+/*
+ * Centred via auto margins, not `justify-content: center`: with an overflowing
+ * flex container, `justify-content` splits the overflow both ways and the top
+ * half becomes unreachable — a long statement opened mid-sentence with its
+ * beginning clipped above the scroll. Auto margins give the same centring when
+ * the text fits and collapse to zero when it doesn't, so a scrolling card
+ * starts at the top.
+ */
+const bodyClasses = "ko:flex-1 ko:min-h-0 ko:flex ko:flex-col ko:overflow-y-auto ko:[&>:first-child]:mt-auto ko:[&>:last-child]:mb-auto";
+
+/*
+ * Room for the drag compass, which is an overlay — it cannot push text out of
+ * its own way, so the card that carries it holds its own text clear instead.
+ *
+ * Vertical, not horizontal. The pills ring the band's top corners (the two
+ * diagonals) and its bottom edge (left, down, right): two horizontal rows,
+ * with nothing at all at mid-height where this used to reserve a gutter. That
+ * gutter cost the text an extra wrapped line *and* left it colliding with the
+ * row underneath — reserving the wrong axis is worse than reserving nothing.
+ */
+const bodyPadding = { plain: "ko:py-2", guided: "ko:py-11" } as const;
+
+const statementClasses = "ko:m-0 ko:font-question ko:text-fluid-question ko:leading-[1.22] ko:font-bold ko:tracking-[-0.03em] ko:text-text ko:text-pretty";
+
+const detailClasses = "ko:font-sans ko:text-fluid-gist ko:leading-[1.62] ko:text-text-muted";
+
+/*
+ * The only text on the card, which is the tutorial's practice card and nothing
+ * else. It loses the gap that separates it from a statement, and it centres:
+ * as a footnote under a question it is left-aligned prose, but alone in the
+ * middle of a card ringed by direction pills it is a caption for them, and a
+ * ragged block hugging one edge reads as text that lost its heading.
+ */
+const detailPlacement = { underStatement: "ko:mt-[1.125rem] ko:text-pretty", alone: "ko:mt-0 ko:text-center ko:text-balance" } as const;
+
+/*
+ * 600px is comfortable headroom, not a tight fit: the label row only needs
+ * ~350px at any viewport wide enough to reach this in the first place (the
+ * fluid card padding is viewport-driven, not container-driven, so it doesn't
+ * shrink here). Keep this well below the card's likely width in normal use —
+ * the app's own gutters and max-width already eat a good chunk of the
+ * viewport before the card ever sees it.
+ */
+const answerLabelClasses = "ko:hidden ko:@[37.5rem]/card:inline ko:font-sans ko:text-fluid-action-label ko:font-semibold ko:tracking-[-0.02em] ko:whitespace-nowrap";
+
+/**
+ * A single question card.
+ *
+ * Used for the active card, the two stacked behind it, and the copy that flies
+ * away when an answer is committed — hence the `inert` and `elevation` props
+ * rather than four near-identical components.
+ */
+export function QuestionCard({
+  content,
+  selection,
+  labels,
+  onAgree,
+  onDisagree,
+  onToggleImportant,
+  onPointerDown,
+  close,
+  guides,
+  statementAs: Statement = "p",
+  inert = false,
+  elevation = "active",
+  ref,
+  className,
+}: QuestionCard) {
+  const interactive = !inert && Boolean(onPointerDown);
+
+  return (
+    <div
+      ref={ref}
+      className={twMerge(QuestionCardVariants({ elevation, interactive }), className)}
+      onPointerDown={onPointerDown}
+      // Cards behind the active one are decoration; screen readers and the tab
+      // order should only ever see the question actually being answered.
+      inert={inert}
+      aria-hidden={inert || undefined}
+    >
+      {close ? (
+        <button type="button" className={closeClasses} aria-label={close.label} title={close.label} onPointerDown={stopPropagation} onClick={close.onClose} tabIndex={inert ? -1 : undefined}>
+          <Icon icon={icons.close} size="xsmall" decorative />
+        </button>
+      ) : null}
+
+      {guides}
+
+      {content.topic || content.title ? (
+        /* Reserves room for the corner close button so a long topic/title pair
+           wraps around it instead of running underneath it. Only applied when
+           `close` is actually passed — the deck's cards never carry this
+           control. */
+        <div className={twMerge("ko:flex ko:flex-none ko:flex-wrap ko:gap-2", close && "ko:pr-10")}>
+          {content.topic ? <Chip variant="filled">{content.topic}</Chip> : null}
+          {content.title ? <Chip variant="outline">{content.title}</Chip> : null}
+        </div>
+      ) : null}
+
+      <div className={twMerge(bodyClasses, guides ? bodyPadding.guided : bodyPadding.plain)}>
+        {content.statement ? <Statement className={statementClasses}>{content.statement}</Statement> : null}
+        {content.detail ? <p className={twMerge(detailClasses, content.statement ? detailPlacement.underStatement : detailPlacement.alone)}>{content.detail}</p> : null}
+      </div>
+
+      <div className="ko:flex ko:flex-none ko:items-center ko:gap-3">
+        <button
+          type="button"
+          className={twMerge(QuestionCardActionVariants({ action: "important" }))}
+          aria-pressed={selection.important}
+          aria-label={labels.important}
+          onPointerDown={stopPropagation}
+          onClick={onToggleImportant}
+          tabIndex={inert ? -1 : undefined}
+        >
+          {/* The prototype's marks are sized by height, the width following each
+              one's own aspect ratio — so Icon's square sizes are switched off. */}
+          <Icon icon={icons.star} size={null} filled={selection.important} decorative className="ko:h-[23px] ko:w-auto" />
+          <span className="ko-question-card-tooltip" aria-hidden="true">
+            {labels.important}
+          </span>
+        </button>
+
+        <button
+          type="button"
+          className={twMerge(QuestionCardActionVariants({ action: "agree" }))}
+          aria-pressed={selection.agree}
+          aria-label={labels.agree}
+          onPointerDown={stopPropagation}
+          onClick={onAgree}
+          tabIndex={inert ? -1 : undefined}
+        >
+          <Icon icon={icons.check} size={null} decorative className="ko:h-[21px] ko:w-auto" />
+          <span className={answerLabelClasses}>{labels.agree}</span>
+        </button>
+
+        <button
+          type="button"
+          className={twMerge(QuestionCardActionVariants({ action: "disagree" }))}
+          aria-pressed={selection.disagree}
+          aria-label={labels.disagree}
+          onPointerDown={stopPropagation}
+          onClick={onDisagree}
+          tabIndex={inert ? -1 : undefined}
+        >
+          <Icon icon={icons.cross} size={null} decorative className="ko:h-[21px] ko:w-auto" />
+          <span className={answerLabelClasses}>{labels.disagree}</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Pressing a button must not also start dragging the card. */
+function stopPropagation(event: ReactPointerEvent<HTMLButtonElement>) {
+  event.stopPropagation();
+}

--- a/packages/design-system/src/components/server/card.test.tsx
+++ b/packages/design-system/src/components/server/card.test.tsx
@@ -15,6 +15,15 @@ describe("Card", () => {
     });
   });
 
+  describe("when given the card corner", () => {
+    it("should take the whole radius from the card token", () => {
+      const { container } = render(<Card corner="card">Children</Card>);
+      expect(container.firstChild).toHaveClass("ko:rounded-card");
+      expect(container.firstChild).not.toHaveClass("ko:rounded-3xl");
+      expect(container.firstChild).not.toHaveClass("ko:rounded-tl-none");
+    });
+  });
+
   describe("when given interactive prop", () => {
     it("should not add any classes when interactive is true", () => {
       const { container } = render(<Card interactive={true}>Children</Card>);

--- a/packages/design-system/src/components/server/card.tsx
+++ b/packages/design-system/src/components/server/card.tsx
@@ -13,7 +13,14 @@ const CardVariants = cva("ko:rounded-3xl", {
       white: "ko:bg-white",
       transparent: "ko:bg-transparent",
     },
-    corner: { topRight: "ko:rounded-tr-none", topLeft: "ko:rounded-tl-none", bottomRight: "ko:rounded-br-none", bottomLeft: "ko:rounded-bl-none" },
+    corner: {
+      topRight: "ko:rounded-tr-none",
+      topLeft: "ko:rounded-tl-none",
+      bottomRight: "ko:rounded-br-none",
+      bottomLeft: "ko:rounded-bl-none",
+      /* The new design's card shape — the whole radius comes from the `--ko-radius-card` token, square top-left corner included. */
+      card: "ko:rounded-card",
+    },
     border: {
       true: "ko:border ko:border-neutral",
       false: "",

--- a/packages/design-system/src/styles.css
+++ b/packages/design-system/src/styles.css
@@ -922,6 +922,74 @@
     }
   }
 
+  /* --- QuestionCard ----------------------------------------------------------
+   * Ported from kalkulacka-2026/packages/ui/src/question-card/question-card.module.css
+   * (`.tooltip`). Everything else on the card is `ko:` utilities in
+   * questionCard.tsx; the tooltip lives here because it fades and lifts on
+   * literal timings (see the reduced-motion note below) and is shown by its
+   * *parent's* hover and focus, which a utility on the tooltip itself cannot
+   * express without a group hook.
+   *
+   * The star's label. Styled after the deck's drag-hint toast (same pill, same
+   * colors) rather than a native `title`, so it matches the app's own
+   * vocabulary for a transient label and appears the instant the button is
+   * hovered or focused instead of after the browser's built-in tooltip delay.
+   *
+   * Anchored to the button's left edge rather than centered: the star sits
+   * right next to the card's left padding, and the card clips overflow for its
+   * rounded corners, so a centered pill would get cut off on that side once the
+   * label is wider than the button itself.
+   */
+  .ko-question-card-tooltip {
+    position: absolute;
+    bottom: calc(100% + 0.5rem);
+    left: 0;
+    z-index: 1;
+
+    padding: 0.5rem 0.875rem;
+    border-radius: var(--ko-radius-pill);
+    background: var(--ko-color-neutral-ink);
+    color: var(--ko-color-on-neutral-ink);
+
+    font-family: var(--ko-font-sans);
+    font-size: 0.8125rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    white-space: nowrap;
+
+    pointer-events: none;
+    opacity: 0;
+    transform-origin: left bottom;
+    transform: translateY(4px) scale(0.92);
+    transition:
+      opacity 0.12s ease,
+      transform 0.12s var(--ko-ease-spring);
+  }
+
+  .ko-question-card-important:hover .ko-question-card-tooltip,
+  .ko-question-card-important:focus-visible .ko-question-card-tooltip {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  /*
+   * The star's tooltip fades and lifts on its own literal timings rather than
+   * `--ko-duration-*`, so the blanket reduction in @layer base does not reach
+   * it. The tooltip still appears on hover and on focus — it is what names the
+   * control — it simply stops sliding up into place.
+   */
+  @media (prefers-reduced-motion: reduce) {
+    .ko-question-card-tooltip {
+      transition: none;
+      transform: none;
+    }
+
+    .ko-question-card-important:hover .ko-question-card-tooltip,
+    .ko-question-card-important:focus-visible .ko-question-card-tooltip {
+      transform: none;
+    }
+  }
+
   /* --- Backdrop --------------------------------------------------------------
    * Ported from kalkulacka-2026/packages/ui/src/backdrop/backdrop.tsx
    * (`FallbackGradient`) and backdrop.module.css (`.host`, `.fallback`).


### PR DESCRIPTION
Part 6 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #518.

The card the whole flow is built around, ported from `kalkulacka-2026/packages/ui/src/question-card`:

- **`QuestionCard`** (client): topic and title chips, statement (`h1`/`h2`/`p` as the screen needs), detail, and the three actions built to the prototype's geometry: the important star (`aria-pressed`, filled when on), Ano and Ne with selected / hover / pressed states. Answer labels appear from a 37.5 rem card container. A `close` button and a `guides` slot serve the question dialog and the practice deck; `elevation` maps to the stacked-deck shadows; `inert` for the cards behind the active one. Pressing a button stops pointer-down propagation so it never starts a drag.
- `Card` gains a `corner="card"` variant (the square top-left corner) without changing existing variants.

Stories with the real 2026 copy (default, selected states, elevations stacked, wide with labels, closable, inert, practice card); 26 tests.

**Checks:** typecheck, lint, tests (design-system 199), design-system and Storybook builds.

**Stack:** based on #518 → next: `port/07-question-deck` (checkpoint C2 in Storybook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
