### PR TITLE
Add the swipeable question deck with drag guides and progress segments

### DIFF
--- a/apps/design-system.kalkulacka.one/stories/DragGuides.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/DragGuides.stories.tsx
@@ -1,0 +1,71 @@
+import { DRAG_DIRECTIONS, DragGuides } from "@kalkulacka-one/design-system/client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+const labels = {
+  agree: "Ano",
+  disagree: "Ne",
+  important: "Pro mě důležité",
+  skip: "Přeskočit",
+};
+
+/**
+ * The compass positions itself over a card's padding box, so the stories give
+ * it a card-shaped surface to sit on. The band it fills stops above where the
+ * card's action row would be, which is why the pills sit clear of the bottom
+ * edge.
+ */
+const meta: Meta<typeof DragGuides> = {
+  title: "Components/DragGuides",
+  component: DragGuides,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  args: { labels, split: false, active: null },
+  argTypes: {
+    split: { control: "boolean" },
+    active: {
+      control: "select",
+      options: [null, ...DRAG_DIRECTIONS],
+    },
+    practised: { control: false },
+    labels: { control: "object" },
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          position: "relative",
+          width: "min(90vw, 26rem)",
+          height: "18rem",
+          background: "var(--ko-color-surface)",
+          borderRadius: "var(--ko-radius-card)",
+          boxShadow: "var(--ko-shadow-card)",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+type DragGuidesStory = StoryObj<typeof meta>;
+
+/** Touch: icon-only pills, one diagonal arrow plus a star per "important" corner. */
+export const Touch: DragGuidesStory = {};
+
+/** Mouse: labelled pills, diagonals decomposed into an up arrow plus the answer's own arrow. */
+export const Pointer: DragGuidesStory = {
+  args: { split: true },
+};
+
+/** Directions already tried fade back, leaving the untried ones lit. */
+export const Practised: DragGuidesStory = {
+  args: { split: true, practised: new Set(["w", "s"] as const) },
+};
+
+/** The pill a drag is currently pointing at fills solid and lifts. */
+export const ActiveDrag: DragGuidesStory = {
+  args: { split: true, active: "ne" },
+};
+
+export default meta;

--- a/apps/design-system.kalkulacka.one/stories/ProgressSegments.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/ProgressSegments.stories.tsx
@@ -1,0 +1,60 @@
+import { ProgressSegments, type Segment } from "@kalkulacka-one/design-system/server";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+const partial: Segment[] = [
+  { state: "agree" },
+  { state: "agree", important: true },
+  { state: "disagree" },
+  { state: "skipped" },
+  { state: "disagree", important: true },
+  { state: "unanswered" },
+  { state: "unanswered" },
+  { state: "unanswered" },
+];
+
+/** 42 questions is the real Pardubice count — the segments get thin. */
+const fullLength: Segment[] = Array.from({ length: 42 }, (_, i): Segment => {
+  if (i > 25) return { state: "unanswered" };
+  if (i % 7 === 0) return { state: "skipped" };
+  if (i % 3 === 0) return { state: "disagree", important: i % 6 === 0 };
+  return { state: "agree", important: i % 5 === 0 };
+});
+
+const meta: Meta<typeof ProgressSegments> = {
+  title: "Components/ProgressSegments",
+  component: ProgressSegments,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  argTypes: {
+    currentIndex: { control: { type: "number", min: 0 } },
+    label: { control: "text" },
+    segments: { control: "object" },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "min(90vw, 40rem)" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+type ProgressSegmentsStory = StoryObj<typeof meta>;
+
+/** Answered segments take the answer's colour; a skip stays idle; a dot marks "pro mě důležité". */
+export const PartiallyAnswered: ProgressSegmentsStory = {
+  args: { segments: partial, currentIndex: 5, label: "Otázka 6 z 8" },
+};
+
+/** The full run of 42, mixed states, with the current segment taller in the middle. */
+export const FullLength: ProgressSegmentsStory = {
+  args: { segments: fullLength, currentIndex: 26, label: "Otázka 27 z 42" },
+};
+
+/** Nothing answered yet: every segment idle, the first one enlarged. */
+export const Start: ProgressSegmentsStory = {
+  args: { segments: Array.from({ length: 42 }, (): Segment => ({ state: "unanswered" })), currentIndex: 0, label: "Otázka 1 z 42" },
+};
+
+export default meta;

--- a/apps/design-system.kalkulacka.one/stories/QuestionDeck.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/QuestionDeck.stories.tsx
@@ -1,0 +1,208 @@
+import { type CardSelection, type QuestionCardContent, QuestionDeck, type QuestionDeckHandle, type QuestionDeckProps } from "@kalkulacka-one/design-system/client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useRef, useState } from "react";
+
+/* Three real questions from the 2026 Pardubice set. */
+const QUESTIONS: [QuestionCardContent, QuestionCardContent, QuestionCardContent] = [
+  {
+    id: "q1",
+    topic: "Energetika",
+    title: "Omezení vánoční výzdoby",
+    statement: "Město by mělo kvůli rostoucím cenám energie omezit veřejné slavnostní osvětlení v době Vánoc.",
+    detail: "K podobnému kroku přistoupila například rakouská Vídeň. Na hlavním bulváru Ring kolem centra nebude vánoční osvětlení vůbec.",
+  },
+  {
+    id: "q2",
+    topic: "Veřejný pořádek",
+    title: "Regulace zábavní pyrotechniky",
+    statement: "Používání zábavní pyrotechniky jindy než na Silvestra má být ve městě zakázané.",
+    detail: "V případě neregulace bývají problematické hlavně letní měsíce, kdy jsou ohňostroje součástí řady domácích oslav.",
+  },
+  {
+    id: "q3",
+    topic: "Bydlení",
+    title: "Bytový fond",
+    statement: "Město má budovat a udržovat vlastní bytový fond.",
+    detail: "Odpůrci tvrdí, že soukromí majitelé se o nemovitosti postarají lépe.",
+  },
+];
+
+const labels = {
+  agree: "Ano",
+  disagree: "Ne",
+  important: "Pro mě důležité",
+  importantSuffix: " · Pro mě důležité",
+  skip: "Přeskočit",
+};
+
+const none: CardSelection = { agree: false, disagree: false, important: false };
+
+/** The deck cycles, so every position resolves to one of the three. */
+function questionAt(index: number): QuestionCardContent {
+  return QUESTIONS[((index % QUESTIONS.length) + QUESTIONS.length) % QUESTIONS.length] ?? QUESTIONS[0];
+}
+
+/**
+ * The deck fills whatever positioned box it is given — the flow's stage in
+ * the app. The stage is the deck's own size, the buttons below it are the
+ * story's.
+ */
+function Stage({ children }: { children: React.ReactNode }) {
+  return <div style={{ position: "relative", width: "min(90vw, 34rem)", height: "33.75rem" }}>{children}</div>;
+}
+
+type HarnessProps = Pick<QuestionDeckProps, "labels" | "dragGuides" | "finished">;
+
+/**
+ * Fully interactive: drag the card left to agree, right to disagree, down to
+ * skip, and up-and-across to also mark it important. Arrow keys do the same;
+ * so do the buttons on the card. Answers are kept per question, so cycling
+ * back round to a card shows what was recorded — and choosing the answer it
+ * already has clears it, as the app's store does.
+ */
+function DeckHarness({ labels, dragGuides, finished }: HarnessProps) {
+  const deck = useRef<QuestionDeckHandle>(null);
+  const [index, setIndex] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, CardSelection>>({});
+
+  const current = questionAt(index);
+  const selection = answers[current.id] ?? none;
+
+  const advance = () => setIndex((i) => (i + 1) % QUESTIONS.length);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: "1.5rem" }}>
+      <Stage>
+        <QuestionDeck
+          ref={deck}
+          current={current}
+          next={questionAt(index + 1)}
+          after={questionAt(index + 2)}
+          selection={selection}
+          labels={labels}
+          dragGuides={dragGuides}
+          finished={finished}
+          onAnswer={(agree, important) => {
+            const same = agree ? selection.agree : selection.disagree;
+            if (same) {
+              // Choosing the answer already given clears it; the deck did
+              // not fly the card, so the story stays on it too.
+              setAnswers((prev) => ({ ...prev, [current.id]: { ...selection, agree: false, disagree: false, important } }));
+              return;
+            }
+            setAnswers((prev) => ({ ...prev, [current.id]: { agree, disagree: !agree, important } }));
+            advance();
+          }}
+          onSkip={advance}
+          onToggleImportant={() => setAnswers((prev) => ({ ...prev, [current.id]: { ...selection, important: !selection.important } }))}
+        />
+      </Stage>
+
+      <div style={{ display: "flex", gap: "1rem", alignItems: "center", fontFamily: "var(--ko-font-sans)", fontSize: "0.875rem", color: "var(--ko-color-text-muted)" }}>
+        <button
+          type="button"
+          onClick={() => {
+            // What "Další" does in the app: the card lifts away and the next
+            // one comes up, with nothing recorded.
+            deck.current?.advance();
+            advance();
+          }}
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "var(--ko-radius-pill)",
+            border: "1.5px solid var(--ko-color-border)",
+            background: "var(--ko-color-surface)",
+            color: "var(--ko-color-text)",
+            cursor: "pointer",
+            fontSize: "0.875rem",
+          }}
+        >
+          Další (ref.advance)
+        </button>
+        <span>
+          {index + 1}/{QUESTIONS.length} · {selection.agree ? "Ano" : selection.disagree ? "Ne" : "—"}
+          {selection.important ? " ★" : ""}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+const meta: Meta<typeof QuestionDeck> = {
+  title: "Components/QuestionDeck",
+  component: QuestionDeck,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  args: {
+    current: QUESTIONS[0],
+    next: QUESTIONS[1],
+    after: QUESTIONS[2],
+    selection: none,
+    labels,
+    finished: false,
+    dragGuides: undefined,
+    onAnswer: () => {},
+    onSkip: () => {},
+    onToggleImportant: () => {},
+  },
+  argTypes: {
+    finished: { control: "boolean" },
+    dragGuides: {
+      control: "select",
+      options: ["off", "touch", "pointer"],
+      mapping: {
+        off: undefined,
+        touch: { practised: new Set(["w"] as const) },
+        pointer: { split: true, practised: new Set(["w"] as const) },
+      },
+      description: "The tutorial's compass over the card: icon-only on touch, split and labelled for a mouse. `w` starts practised, as it does after the first swipe.",
+    },
+    current: { control: false },
+    next: { control: false },
+    after: { control: false },
+    selection: { control: false },
+    labels: { control: "object" },
+    onAnswer: { control: false },
+    onSkip: { control: false },
+    onToggleImportant: { control: false },
+    ref: { control: false },
+  },
+  render: (args) => <DeckHarness labels={args.labels} dragGuides={args.dragGuides} finished={args.finished} />,
+};
+
+type QuestionDeckStory = StoryObj<typeof meta>;
+
+/**
+ * Drag left for "Ano", right for "Ne", down to skip, and lift while dragging
+ * sideways to also mark the question important. The card that leaves is a
+ * ghost; the next question is already under the pointer while it flies. Arrow
+ * keys mirror every gesture. Pressing an answer the card already shows clears
+ * it without leaving; switching to the other answer holds for a beat first.
+ */
+export const Interactive: QuestionDeckStory = {};
+
+/**
+ * The tutorial's practice deck: pills around the statement for every direction
+ * the card can leave in, lighting up as a drag reaches them. "Ano" starts
+ * faded here, as it does once it has been tried.
+ */
+export const WithDragGuides: QuestionDeckStory = {
+  args: { dragGuides: { practised: new Set(["w"] as const) } },
+};
+
+/** The same compass under a mouse: diagonals split into two arrows, every pill labelled. */
+export const WithSplitDragGuides: QuestionDeckStory = {
+  args: { dragGuides: { split: true, practised: new Set(["w"] as const) } },
+};
+
+/**
+ * The last answer has been committed and the screen is leaving: the stack
+ * stays for the ghost to fly over, but no live card comes up and the keys and
+ * the pointer are ignored.
+ */
+export const Finished: QuestionDeckStory = {
+  args: { finished: true },
+};
+
+export default meta;

--- a/packages/design-system/src/components/client/dragGuides.test.tsx
+++ b/packages/design-system/src/components/client/dragGuides.test.tsx
@@ -1,0 +1,117 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { icons } from "../icons";
+import { DRAG_DIRECTIONS, DragGuides } from "./dragGuides";
+
+const labels = {
+  agree: "Ano",
+  disagree: "Ne",
+  important: "Pro mě důležité",
+  skip: "Přeskočit",
+};
+
+function pills(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>("[data-direction]"));
+}
+
+function pill(container: HTMLElement, direction: string) {
+  const element = container.querySelector<HTMLElement>(`[data-direction="${direction}"]`);
+  if (!element) throw new Error(`No pill for ${direction}`);
+  return element;
+}
+
+function paths(element: HTMLElement) {
+  return Array.from(element.querySelectorAll("path")).map((path) => path.getAttribute("d"));
+}
+
+describe("DragGuides", () => {
+  it("draws one pill per direction, in compass order, hidden from assistive tech", () => {
+    const { container } = render(<DragGuides labels={labels} />);
+    const root = container.firstElementChild;
+    expect(root).toHaveAttribute("aria-hidden", "true");
+    expect(root).toHaveClass("ko:absolute", "ko:pointer-events-none", "ko:z-1");
+    expect(pills(container).map((element) => element.dataset.direction)).toEqual([...DRAG_DIRECTIONS]);
+    expect(DRAG_DIRECTIONS).toEqual(["nw", "w", "ne", "e", "s"]);
+  });
+
+  it("places the diagonals along the top edge and the answers along the bottom", () => {
+    const { container } = render(<DragGuides labels={labels} />);
+    expect(pill(container, "nw")).toHaveClass("ko:top-0", "ko:left-0");
+    expect(pill(container, "ne")).toHaveClass("ko:top-0", "ko:right-0");
+    expect(pill(container, "w")).toHaveClass("ko:bottom-0", "ko:left-0");
+    expect(pill(container, "e")).toHaveClass("ko:bottom-0", "ko:right-0");
+    expect(pill(container, "s")).toHaveClass("ko:bottom-0", "ko:left-1/2", "ko:-translate-x-1/2");
+  });
+
+  describe("touch (the default)", () => {
+    it("is icon-only", () => {
+      const { container } = render(<DragGuides labels={labels} />);
+      expect(container).not.toHaveTextContent("Ano");
+      expect(container).not.toHaveTextContent("Přeskočit");
+      expect(container).not.toHaveTextContent("Pro mě důležité");
+    });
+
+    it("draws each diagonal as one rotated arrow plus a star", () => {
+      const { container } = render(<DragGuides labels={labels} />);
+      const nw = pill(container, "nw");
+      expect(paths(nw)).toEqual([...icons.arrowLeft.paths, ...icons.starThin.paths]);
+      expect(nw.querySelector("svg")).toHaveClass("ko:rotate-45");
+
+      const ne = pill(container, "ne");
+      expect(paths(ne)).toEqual([...icons.arrowLeft.paths, ...icons.starThin.paths]);
+      expect(ne.querySelector("svg")).toHaveClass("ko:rotate-[135deg]");
+    });
+
+    it("draws the straight directions as a single arrow", () => {
+      const { container } = render(<DragGuides labels={labels} />);
+      expect(paths(pill(container, "w"))).toEqual([...icons.arrowLeft.paths]);
+      expect(paths(pill(container, "e"))).toEqual([...icons.arrowRight.paths]);
+      expect(paths(pill(container, "s"))).toEqual([...icons.arrowDown.paths]);
+    });
+  });
+
+  describe("split (a mouse)", () => {
+    it("spells every direction out", () => {
+      const { container } = render(<DragGuides labels={labels} split />);
+      expect(pill(container, "w")).toHaveTextContent("Ano");
+      expect(pill(container, "e")).toHaveTextContent("Ne");
+      expect(pill(container, "s")).toHaveTextContent("Přeskočit");
+      expect(pill(container, "nw")).toHaveTextContent("Pro mě důležité");
+      expect(pill(container, "ne")).toHaveTextContent("Pro mě důležité");
+    });
+
+    it("decomposes the diagonals into an up arrow and the answer's own arrow", () => {
+      const { container } = render(<DragGuides labels={labels} split />);
+      expect(paths(pill(container, "nw"))).toEqual([...icons.arrowUp.paths, ...icons.arrowLeft.paths]);
+      expect(paths(pill(container, "ne"))).toEqual([...icons.arrowUp.paths, ...icons.arrowRight.paths]);
+      expect(pill(container, "nw").querySelector("svg")).not.toHaveClass("ko:rotate-45");
+    });
+  });
+
+  it("fades the directions already practised", () => {
+    const { container } = render(<DragGuides labels={labels} practised={new Set(["w", "s"] as const)} />);
+    expect(pill(container, "w")).toHaveClass("ko:opacity-45");
+    expect(pill(container, "s")).toHaveClass("ko:opacity-45");
+    expect(pill(container, "e")).not.toHaveClass("ko:opacity-45");
+    expect(pill(container, "nw")).not.toHaveClass("ko:opacity-45");
+  });
+
+  it("lights the direction the drag is pointing at as a filled neutral pill", () => {
+    const { container } = render(<DragGuides labels={labels} active="ne" />);
+    const ne = pill(container, "ne");
+    expect(ne).toHaveClass("ko:bg-neutral-ink", "ko:text-on-neutral-ink", "ko:scale-[1.08]", "ko:motion-reduce:scale-100");
+    expect(ne).not.toHaveClass("ko:bg-surface", "ko:text-text-muted");
+
+    const w = pill(container, "w");
+    expect(w).toHaveClass("ko:bg-surface", "ko:text-text-muted");
+    expect(w).not.toHaveClass("ko:bg-neutral-ink");
+  });
+
+  it("lets an active pill outrank its practised fade", () => {
+    const { container } = render(<DragGuides labels={labels} practised={new Set(["w"] as const)} active="w" />);
+    const w = pill(container, "w");
+    expect(w).toHaveClass("ko:opacity-100", "ko:bg-neutral-ink");
+    expect(w).not.toHaveClass("ko:opacity-45");
+  });
+});

--- a/packages/design-system/src/components/client/dragGuides.tsx
+++ b/packages/design-system/src/components/client/dragGuides.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+// Ported from kalkulacka-2026/packages/ui/src/drag-guides/drag-guides.tsx and drag-guides.module.css
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { cva } from "class-variance-authority";
+
+import { type IconDefinition, icons } from "../icons";
+import { Icon } from "./icon";
+
+/**
+ * Where a card can be dragged, named as compass points.
+ *
+ * The diagonals are an answer *plus* "pro mě důležité" — the same swipe, lifted.
+ * There is no north on its own: an upward drag that goes nowhere sideways
+ * commits nothing.
+ */
+export type DragDirection = "nw" | "w" | "ne" | "e" | "s";
+
+export const DRAG_DIRECTIONS: readonly DragDirection[] = ["nw", "w", "ne", "e", "s"] as const;
+
+export type DragGuidesLabels = {
+  agree: string;
+  disagree: string;
+  important: string;
+  skip: string;
+};
+
+export type DragGuidesProps = {
+  labels: DragGuidesLabels;
+  /**
+   * The desktop reading: diagonals split into two straight icons (an upward
+   * arrow, then the answer's own arrow) instead of one arrow on the
+   * diagonal, and every pill spells its direction out in words.
+   *
+   * Both are a room budget, not a taste: this card lives in a fixed-width
+   * reading column, so "wide enough" never arrives from a bigger window the
+   * way it does for the card's own answer-button labels — it has to come
+   * from somewhere else, and the same signal that already tells the tutorial
+   * apart by pointer is the one this reuses. On a touch-sized card the
+   * pills stay icon-only; five of them carrying a word each is more text
+   * than the statement above has room to share the card with.
+   */
+  split?: boolean;
+  /** Directions already tried, which fade back to leave the untried ones lit. */
+  practised?: ReadonlySet<DragDirection>;
+  /** Where the drag under the pointer right now would commit. */
+  active?: DragDirection | null;
+};
+
+/*
+ * The band the pills live in: the card's own padding, minus the action row at
+ * the bottom. Inset from the card's text rather than laid over it — the pills
+ * hug the edges, so a statement wrapping to two lines still has the middle of
+ * the card to itself.
+ *
+ * `top` used to clear a chips row this card no longer has (the only card
+ * `DragGuides` is ever drawn over); it now sits flush with the same inset the
+ * other three edges use.
+ *
+ * Above the statement in front of it, not behind it (`z-1`): a labelled pill
+ * on a short statement can reach past where the centred text starts, and a
+ * pill that loses that overlap to the text it is meant to be legible over
+ * would defeat the fix its own background exists for.
+ */
+const guidesClasses = [
+  "ko:absolute ko:top-2 ko:right-2 ko:left-2 ko:z-1",
+  "ko:bottom-[calc(var(--ko-spacing-fluid-card-pad-bottom)_+_var(--ko-spacing-fluid-action)_+_0.5rem)]",
+  "ko:pointer-events-none",
+].join(" ");
+
+/**
+ * Same bordered-pill language as "Přeskočit" below the card (`Button`'s
+ * `plate` variant): a real container, not a bare icon — that pill is legible
+ * at a glance, and the arrows were not. Solid rather than translucent: this
+ * sits on the card's own opaque surface, not over the animated backdrop, so
+ * there is nothing behind it worth blurring.
+ */
+export const DragGuideVariants = cva(
+  [
+    "ko:absolute ko:flex ko:items-center ko:gap-[0.3125rem]",
+    "ko:px-2.5 ko:py-1.5 ko:rounded-pill ko:bg-surface ko:text-text-muted",
+    "ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
+    "ko:transition-[color,background-color,box-shadow,opacity,scale]",
+    "ko:duration-[var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-base),var(--ko-duration-fast)]",
+    "ko:ease-[ease,ease,ease,ease,var(--ko-ease-spring)]",
+  ],
+  {
+    variants: {
+      /*
+       * Where each one sits. The bottom row is bottom-anchored, not vertically
+       * centred: the card's body centres its text in this same band, so a
+       * mid-height pill sits exactly on top of the one line every short
+       * statement collapses to. The bottom of the band is the one point in it
+       * a centred block of text never reaches — and it happens to float the
+       * pill just above the very button the same drag answers.
+       */
+      direction: {
+        nw: "ko:top-0 ko:left-0",
+        ne: "ko:top-0 ko:right-0",
+        w: "ko:bottom-0 ko:left-0",
+        e: "ko:bottom-0 ko:right-0",
+        s: "ko:bottom-0 ko:left-1/2 ko:-translate-x-1/2",
+      },
+      /*
+       * Already tried, so it steps back — the point of the compass after the
+       * first swipe is the directions that are still news.
+       */
+      practised: {
+        true: "ko:opacity-45",
+        false: "",
+      },
+      /*
+       * Lit by the drag that is currently pointing at it — filled solid, the
+       * same treatment `FlowNav` gives an explicitly skipped question, not a
+       * colour tied to the answer. The lift is the one part that moves on its
+       * own, so it is the one part reduced motion takes away.
+       */
+      active: {
+        true: "ko:opacity-100 ko:scale-[1.08] ko:motion-reduce:scale-100 ko:bg-neutral-ink ko:text-on-neutral-ink ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-neutral-ink)]",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      practised: false,
+      active: false,
+    },
+  },
+);
+
+const iconsClasses = "ko:flex ko:flex-none ko:items-center ko:gap-0.5";
+
+/* Only rendered at all when `split` is on — see the prop's own comment. */
+const labelClasses = "ko:font-sans ko:text-xs ko:font-semibold ko:tracking-[-0.01em] ko:whitespace-nowrap";
+
+type GuideIcon = { icon: IconDefinition; rotation?: 45 | 135 };
+
+const rotationClasses = { 45: "ko:rotate-45", 135: "ko:rotate-[135deg]" } as const;
+
+/** What to draw and what to say, for one direction. */
+function guideFor(direction: DragDirection, split: boolean, labels: DragGuidesLabels): { icons: GuideIcon[]; label: string } {
+  switch (direction) {
+    case "w":
+      return { icons: [{ icon: icons.arrowLeft }], label: labels.agree };
+    case "e":
+      return { icons: [{ icon: icons.arrowRight }], label: labels.disagree };
+    case "s":
+      return { icons: [{ icon: icons.arrowDown }], label: labels.skip };
+    case "nw":
+      return {
+        icons: split ? [{ icon: icons.arrowUp }, { icon: icons.arrowLeft }] : [{ icon: icons.arrowLeft, rotation: 45 }, { icon: icons.starThin }],
+        label: labels.important,
+      };
+    case "ne":
+      return {
+        icons: split ? [{ icon: icons.arrowUp }, { icon: icons.arrowRight }] : [{ icon: icons.arrowLeft, rotation: 135 }, { icon: icons.starThin }],
+        label: labels.important,
+      };
+  }
+}
+
+/**
+ * The compass drawn inside the practice card.
+ *
+ * A first-time reader's difficulty is not that dragging is hard, it is that
+ * nothing about a card says it can be dragged at all. So the directions are
+ * drawn where they are: labelled pills hugging the card's edges — the same
+ * bordered-pill language as "Přeskočit" below the card, not a bare icon that
+ * reads as decoration — lighting up as the drag reaches them.
+ *
+ * Colour is neutral rather than tied to the answer (no green/red): five
+ * tinted marks in a 300px card competed with each other and with the card's
+ * own agree/disagree buttons for the reader's eye. What *is* dragged toward
+ * lights up with a filled neutral pill instead, the same treatment `FlowNav`
+ * gives an explicitly skipped question.
+ *
+ * Decorative: `aria-hidden`, no pointer events. Every direction is also a
+ * button on the card and a sentence in the help overlay, so nothing is lost by
+ * not putting these in the tab order.
+ */
+export function DragGuides({ labels, split = false, practised, active = null }: DragGuidesProps) {
+  return (
+    <div className={guidesClasses} aria-hidden="true">
+      {DRAG_DIRECTIONS.map((direction) => {
+        const { icons: glyphs, label } = guideFor(direction, split, labels);
+
+        return (
+          <span key={direction} data-direction={direction} className={twMerge(DragGuideVariants({ direction, practised: practised?.has(direction) ?? false, active: active === direction }))}>
+            <span className={iconsClasses}>
+              {glyphs.map(({ icon, rotation }, index) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: a fixed, order-stable pair per direction — nothing here is ever reordered or filtered.
+                <Icon key={index} icon={icon} size="xsmall" decorative className={rotation ? rotationClasses[rotation] : undefined} />
+              ))}
+            </span>
+            {split ? <span className={labelClasses}>{label}</span> : null}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/design-system/src/components/client/index.ts
+++ b/packages/design-system/src/components/client/index.ts
@@ -3,6 +3,7 @@
 export * from "./button";
 export * from "./clientTest";
 export * from "./description";
+export * from "./dragGuides";
 export * from "./expandableCard";
 export * from "./field";
 export * from "./icon";
@@ -11,5 +12,7 @@ export * from "./input";
 export * from "./label";
 export * from "./logo";
 export * from "./questionCard";
+export * from "./questionDeck/questionDeck";
+export { PHYSICS, type SwipeZone } from "./questionDeck/swipePhysics";
 export * from "./scrollMode";
 export * from "./toggleButton";

--- a/packages/design-system/src/components/client/questionDeck/questionDeck.test.tsx
+++ b/packages/design-system/src/components/client/questionDeck/questionDeck.test.tsx
@@ -1,0 +1,363 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { QuestionDeck, type QuestionDeckHandle, type QuestionDeckProps } from "./questionDeck";
+import { ANSWER_SWITCH_HOLD, EXIT, PHYSICS, SPEEDS } from "./swipePhysics";
+
+const q1 = { id: "q1", topic: "Energetika", title: "Omezení vánoční výzdoby", statement: "Město by mělo omezit veřejné slavnostní osvětlení v době Vánoc." };
+const q2 = { id: "q2", topic: "Veřejný pořádek", title: "Regulace zábavní pyrotechniky", statement: "Používání zábavní pyrotechniky jindy než na Silvestra má být zakázané." };
+const q3 = { id: "q3", topic: "Bydlení", title: "Bytový fond", statement: "Město má budovat a udržovat vlastní bytový fond." };
+
+const labels = {
+  agree: "Ano",
+  disagree: "Ne",
+  important: "Pro mě důležité",
+  importantSuffix: " · Pro mě důležité",
+  skip: "Přeskočit",
+};
+
+const none = { agree: false, disagree: false, important: false };
+
+function renderDeck(props: Partial<QuestionDeckProps> = {}) {
+  const onAnswer = vi.fn();
+  const onSkip = vi.fn();
+  const onToggleImportant = vi.fn();
+  const utils = render(<QuestionDeck current={q1} next={q2} after={q3} selection={none} labels={labels} onAnswer={onAnswer} onSkip={onSkip} onToggleImportant={onToggleImportant} {...props} />);
+  return { ...utils, onAnswer, onSkip, onToggleImportant };
+}
+
+/** The card being answered: the one holding the screen's heading. */
+function activeCard() {
+  const heading = screen.getByRole("heading", { level: 1 });
+  const card = heading.closest(".ko-deck-active");
+  if (!(card instanceof HTMLDivElement)) throw new Error("No active card");
+  return card;
+}
+
+function ghost(container: HTMLElement) {
+  return container.querySelector<HTMLDivElement>(".ko-deck-ghost");
+}
+
+/** A pointer drag from the card's centre, released `dx`/`dy` away. */
+function drag(card: HTMLElement, dx: number, dy: number) {
+  fireEvent.pointerDown(card, { clientX: 200, clientY: 200, pointerId: 1 });
+  fireEvent.pointerMove(window, { clientX: 200 + dx / 2, clientY: 200 + dy / 2, pointerId: 1 });
+  fireEvent.pointerMove(window, { clientX: 200 + dx, clientY: 200 + dy, pointerId: 1 });
+  fireEvent.pointerUp(window, { clientX: 200 + dx, clientY: 200 + dy, pointerId: 1 });
+}
+
+describe("QuestionDeck", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("the stack", () => {
+    it("shows the current question as the screen's heading and stacks the rest behind it, inert", () => {
+      const { container } = renderDeck();
+      expect(screen.getByRole("heading", { level: 1, name: q1.statement })).toBeInTheDocument();
+
+      const next = container.querySelector(".ko-deck-next");
+      expect(next).toContainElement(screen.getByText(q2.statement));
+      expect(next?.firstElementChild).toHaveAttribute("inert");
+      expect(next?.firstElementChild).toHaveClass("ko:shadow-card-next");
+
+      const back = container.querySelector(".ko-deck-back");
+      expect(back?.firstElementChild).toHaveClass("ko:bg-surface", "ko:rounded-card", "ko:shadow-card-back");
+      expect(back).not.toHaveTextContent(q3.statement);
+    });
+
+    it("lays the stack out from the physics constants on mount", () => {
+      const { container } = renderDeck();
+      expect(activeCard().style.transform).toBe("translate(0px, 0px) rotate(0deg)");
+      expect(container.querySelector<HTMLElement>(".ko-deck-next")?.style.transform).toBe("translate(12px, -22px) scale(0.95) rotate(0.5deg)");
+      expect(container.querySelector<HTMLElement>(".ko-deck-back")?.style.transform).toBe("translate(24px, -40px) scale(0.9) rotate(1deg)");
+    });
+
+    it("omits the layers it has nothing for", () => {
+      const { container } = renderDeck({ next: undefined, after: undefined });
+      expect(container.querySelector(".ko-deck-next")).toBeNull();
+      expect(container.querySelector(".ko-deck-back")).toBeNull();
+      expect(activeCard()).toBeInTheDocument();
+    });
+  });
+
+  describe("dragging", () => {
+    it("follows the pointer and tilts, without committing below the threshold", () => {
+      const { onAnswer, onSkip } = renderDeck();
+      const card = activeCard();
+      fireEvent.pointerDown(card, { clientX: 200, clientY: 200, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 164, clientY: 190, pointerId: 1 });
+      expect(card.style.transform).toBe(`translate(-36px, -10px) rotate(${-36 / PHYSICS.rotationDivisor}deg)`);
+      fireEvent.pointerUp(window, { clientX: 164, clientY: 190, pointerId: 1 });
+
+      expect(onAnswer).not.toHaveBeenCalled();
+      expect(onSkip).not.toHaveBeenCalled();
+      // Springs back to centre rather than staying where it was let go.
+      expect(card.style.transform).toBe("translate(0px, 0px) rotate(0deg)");
+      expect(card.style.transition).toContain("var(--ko-ease-spring)");
+    });
+
+    it("previews the answer on the buttons while the drag is in a zone", () => {
+      renderDeck();
+      const card = activeCard();
+      fireEvent.pointerDown(card, { clientX: 200, clientY: 200, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 160, clientY: 200, pointerId: 1 });
+      expect(screen.getByRole("button", { name: "Ano" })).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: "Ne" })).toHaveAttribute("aria-pressed", "false");
+
+      fireEvent.pointerMove(window, { clientX: 240, clientY: 140, pointerId: 1 });
+      expect(screen.getByRole("button", { name: "Ano" })).toHaveAttribute("aria-pressed", "false");
+      expect(screen.getByRole("button", { name: "Ne" })).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: "Pro mě důležité" })).toHaveAttribute("aria-pressed", "true");
+
+      // Back under the activation distance the preview clears again.
+      fireEvent.pointerMove(window, { clientX: 210, clientY: 200, pointerId: 1 });
+      expect(screen.getByRole("button", { name: "Ne" })).toHaveAttribute("aria-pressed", "false");
+      expect(screen.getByRole("button", { name: "Pro mě důležité" })).toHaveAttribute("aria-pressed", "false");
+      fireEvent.pointerUp(window, { clientX: 210, clientY: 200, pointerId: 1 });
+    });
+
+    it("commits agree on a left drag past the threshold", () => {
+      const { container, onAnswer } = renderDeck();
+      drag(activeCard(), -(PHYSICS.threshold + 30), 0);
+      expect(onAnswer).toHaveBeenCalledWith(true, false);
+
+      // The card that flies is a ghost; the real card is back at rest already.
+      const flying = ghost(container);
+      expect(flying).not.toBeNull();
+      expect(flying).toHaveAttribute("inert");
+      expect(flying).toHaveClass("ko:shadow-card-lifted");
+      expect(flying?.style.transform).toBe(`translate(${-EXIT.horizontalX}px, ${EXIT.liftNormal}px) rotate(${-EXIT.rotation}deg)`);
+      expect(flying?.style.transition).toContain(`transform ${SPEEDS.normal.fly}s var(--ko-ease-exit)`);
+      expect(activeCard().style.transform).toBe("translate(0px, 0px) rotate(0deg)");
+    });
+
+    it("commits disagree on a right drag, important when it also lifts", () => {
+      const { container, onAnswer } = renderDeck();
+      drag(activeCard(), PHYSICS.threshold + 30, PHYSICS.importantLiftY - 10);
+      expect(onAnswer).toHaveBeenCalledWith(false, true);
+      expect(ghost(container)?.style.transform).toBe(`translate(${EXIT.horizontalX}px, ${EXIT.liftImportant}px) rotate(${EXIT.rotation}deg)`);
+    });
+
+    it("commits a skip on a downward drag that clearly dominates", () => {
+      const { container, onAnswer, onSkip } = renderDeck();
+      drag(activeCard(), 10, PHYSICS.threshold + 40);
+      expect(onSkip).toHaveBeenCalledTimes(1);
+      expect(onAnswer).not.toHaveBeenCalled();
+      expect(ghost(container)?.style.transform).toBe(`translate(0px, ${EXIT.skipY}px) rotate(${EXIT.skipRotation}deg)`);
+    });
+
+    it("reads a sloppy diagonal as the horizontal answer, never a skip", () => {
+      const { onAnswer, onSkip } = renderDeck();
+      drag(activeCard(), 90, 90);
+      expect(onAnswer).toHaveBeenCalledWith(false, false);
+      expect(onSkip).not.toHaveBeenCalled();
+    });
+
+    it("forgets the ghost once it has flown", () => {
+      const { container } = renderDeck();
+      drag(activeCard(), -100, 0);
+      expect(ghost(container)).not.toBeNull();
+      act(() => {
+        vi.advanceTimersByTime(SPEEDS.normal.fly * 1000 + 60);
+      });
+      expect(ghost(container)).toBeNull();
+    });
+
+    it("lights the compass pill the drag is pointing at", () => {
+      const { container } = renderDeck({ dragGuides: { split: true } });
+      const card = activeCard();
+      expect(container.querySelector('[data-direction="w"]')).toHaveTextContent("Ano");
+      fireEvent.pointerDown(card, { clientX: 200, clientY: 200, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 160, clientY: 150, pointerId: 1 });
+      expect(container.querySelector('[data-direction="nw"]')).toHaveClass("ko:bg-neutral-ink");
+      expect(container.querySelector('[data-direction="w"]')).not.toHaveClass("ko:bg-neutral-ink");
+      fireEvent.pointerUp(window, { clientX: 160, clientY: 150, pointerId: 1 });
+      expect(container.querySelector('[data-direction="nw"]')).not.toHaveClass("ko:bg-neutral-ink");
+    });
+
+    it("shows the hint toast naming what a release would record", () => {
+      const { container } = renderDeck();
+      const toast = container.querySelector(".ko-deck-toast");
+      expect(toast).not.toHaveClass("ko-deck-toast-visible");
+      fireEvent.pointerDown(activeCard(), { clientX: 200, clientY: 200, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 260, clientY: 150, pointerId: 1 });
+      expect(toast).toHaveClass("ko-deck-toast-visible");
+      expect(toast).toHaveTextContent("Ne · Pro mě důležité");
+      fireEvent.pointerMove(window, { clientX: 200, clientY: 300, pointerId: 1 });
+      expect(toast).toHaveTextContent("Přeskočit");
+      fireEvent.pointerUp(window, { clientX: 200, clientY: 300, pointerId: 1 });
+      expect(toast).not.toHaveClass("ko-deck-toast-visible");
+    });
+  });
+
+  describe("the keyboard", () => {
+    it("answers with the arrow keys, carrying the star's state", () => {
+      const { onAnswer, rerender, onSkip, onToggleImportant } = renderDeck();
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      expect(onAnswer).toHaveBeenLastCalledWith(true, false);
+
+      rerender(<QuestionDeck current={q2} selection={{ ...none, important: true }} labels={labels} onAnswer={onAnswer} onSkip={onSkip} onToggleImportant={onToggleImportant} />);
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      expect(onAnswer).toHaveBeenLastCalledWith(false, true);
+
+      fireEvent.keyDown(window, { key: "ArrowDown" });
+      expect(onSkip).toHaveBeenCalledTimes(1);
+
+      fireEvent.keyDown(window, { key: "ArrowUp" });
+      expect(onToggleImportant).toHaveBeenCalledTimes(1);
+    });
+
+    it("flies the card out on a keyboard answer, slower than a flick", () => {
+      const { container } = renderDeck();
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      const flying = ghost(container);
+      expect(flying).toContainElement(screen.getByText(q1.statement, { selector: ".ko-deck-ghost *" }));
+      expect(flying?.style.transition).toContain(`transform ${SPEEDS.slow.fly}s var(--ko-ease-exit)`);
+      expect(flying?.querySelector('[aria-label="Ano"]')).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("ignores keys pressed with a modifier or inside a form field", () => {
+      const { onAnswer, onSkip } = renderDeck();
+      fireEvent.keyDown(window, { key: "ArrowLeft", metaKey: true });
+      fireEvent.keyDown(window, { key: "ArrowLeft", ctrlKey: true });
+      fireEvent.keyDown(window, { key: "ArrowDown", altKey: true });
+      expect(onAnswer).not.toHaveBeenCalled();
+      expect(onSkip).not.toHaveBeenCalled();
+
+      const input = document.createElement("input");
+      document.body.appendChild(input);
+      fireEvent.keyDown(input, { key: "ArrowLeft" });
+      expect(onAnswer).not.toHaveBeenCalled();
+      input.remove();
+    });
+
+    it("clears an answer chosen a second time, without leaving the card", () => {
+      const { container, onAnswer } = renderDeck({ selection: { agree: true, disagree: false, important: false } });
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      expect(onAnswer).toHaveBeenCalledWith(true, false);
+      expect(ghost(container)).toBeNull();
+      expect(activeCard()).toBeInTheDocument();
+    });
+
+    it("holds a switched answer on screen for a beat before the card leaves on it", () => {
+      const { container, onAnswer } = renderDeck({ selection: { agree: true, disagree: false, important: false } });
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+
+      // The button moves at once; the flight waits.
+      expect(screen.getByRole("button", { name: "Ne" })).toHaveAttribute("aria-pressed", "true");
+      expect(screen.getByRole("button", { name: "Ano" })).toHaveAttribute("aria-pressed", "false");
+      expect(onAnswer).not.toHaveBeenCalled();
+      expect(ghost(container)).toBeNull();
+
+      // A second press during the hold is the same press arriving twice.
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      expect(onAnswer).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(ANSWER_SWITCH_HOLD * 1000);
+      });
+      expect(onAnswer).toHaveBeenCalledWith(false, false);
+      expect(ghost(container)).not.toBeNull();
+    });
+  });
+
+  describe("the live region", () => {
+    it("announces the committed answer", () => {
+      renderDeck();
+      const output = screen.getByRole("status");
+      expect(output.tagName).toBe("OUTPUT");
+      expect(output).toHaveAttribute("aria-live", "polite");
+      expect(output).toHaveTextContent("");
+
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      expect(output).toHaveTextContent(/^Ano$/);
+    });
+
+    it("spells out the important suffix and the skip", () => {
+      const { rerender, onAnswer, onSkip, onToggleImportant } = renderDeck({ selection: { ...none, important: true } });
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      expect(screen.getByRole("status")).toHaveTextContent("Ne · Pro mě důležité");
+
+      rerender(<QuestionDeck current={q2} selection={none} labels={labels} onAnswer={onAnswer} onSkip={onSkip} onToggleImportant={onToggleImportant} />);
+      fireEvent.keyDown(window, { key: "ArrowDown" });
+      expect(screen.getByRole("status")).toHaveTextContent("Přeskočit");
+    });
+  });
+
+  describe("finished", () => {
+    it("renders no live card and ignores every input", () => {
+      const { container, onAnswer, onSkip } = renderDeck({ finished: true });
+      expect(screen.queryByRole("heading", { level: 1 })).toBeNull();
+      expect(container.querySelector(".ko-deck-active")).toBeNull();
+
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      fireEvent.keyDown(window, { key: "ArrowDown" });
+      expect(onAnswer).not.toHaveBeenCalled();
+      expect(onSkip).not.toHaveBeenCalled();
+      expect(ghost(container)).toBeNull();
+    });
+
+    it("keeps the stack behind for the ghost to leave over", () => {
+      const { container } = renderDeck({ finished: true });
+      expect(container.querySelector(".ko-deck-next")).not.toBeNull();
+    });
+  });
+
+  describe("advance()", () => {
+    it("lifts the current card away as a ghost without recording anything", () => {
+      const ref = createRef<QuestionDeckHandle>();
+      const { container, onAnswer, onSkip } = renderDeck({ ref, selection: { agree: true, disagree: false, important: true } });
+
+      act(() => {
+        ref.current?.advance();
+      });
+
+      const flying = ghost(container);
+      expect(flying).not.toBeNull();
+      expect(flying?.style.transform).toBe(`translate(0px, ${EXIT.advanceY}px) scale(${EXIT.advanceScale})`);
+      expect(flying?.style.transition).toContain(`transform ${SPEEDS.instant.fly}s var(--ko-ease-exit)`);
+      expect(flying?.querySelector('[aria-label="Ano"]')).toHaveAttribute("aria-pressed", "true");
+      expect(flying?.querySelector('[aria-label="Pro mě důležité"]')).toHaveAttribute("aria-pressed", "true");
+      expect(onAnswer).not.toHaveBeenCalled();
+      expect(onSkip).not.toHaveBeenCalled();
+    });
+
+    it("does nothing once finished", () => {
+      const ref = createRef<QuestionDeckHandle>();
+      const { container } = renderDeck({ ref, finished: true });
+      act(() => {
+        ref.current?.advance();
+      });
+      expect(ghost(container)).toBeNull();
+    });
+  });
+
+  describe("under prefers-reduced-motion", () => {
+    it("collapses the flight but never the drag itself", () => {
+      vi.stubGlobal("matchMedia", (query: string) => ({
+        matches: query.includes("prefers-reduced-motion"),
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }));
+
+      const { container } = renderDeck();
+      const card = activeCard();
+      fireEvent.pointerDown(card, { clientX: 200, clientY: 200, pointerId: 1 });
+      fireEvent.pointerMove(window, { clientX: 100, clientY: 200, pointerId: 1 });
+      // The card still follows the hand.
+      expect(card.style.transform).toBe(`translate(-100px, 0px) rotate(${-100 / PHYSICS.rotationDivisor}deg)`);
+      fireEvent.pointerUp(window, { clientX: 100, clientY: 200, pointerId: 1 });
+
+      expect(ghost(container)?.style.transition).toContain("transform 0.001s var(--ko-ease-exit)");
+
+      vi.unstubAllGlobals();
+    });
+  });
+});

--- a/packages/design-system/src/components/client/questionDeck/questionDeck.tsx
+++ b/packages/design-system/src/components/client/questionDeck/questionDeck.tsx
@@ -1,0 +1,400 @@
+"use client";
+
+// Ported from kalkulacka-2026/packages/ui/src/question-deck/question-deck.tsx and question-deck.module.css
+import { type Ref, useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState } from "react";
+
+import { VisuallyHidden } from "../../server/visuallyHidden";
+import { type DragDirection, DragGuides } from "../dragGuides";
+import { type CardSelection, QuestionCard, type QuestionCardContent } from "../questionCard";
+import { advanceTransform, answerSwitchHold, type CommitSpeed, exitTransform, type SwipeZone, speedFor } from "./swipePhysics";
+import { type SwipeIntent, useSwipeDeck } from "./useSwipeDeck";
+
+export type QuestionDeckLabels = {
+  agree: string;
+  disagree: string;
+  important: string;
+  skip: string;
+  /** Appended to the hint when the swipe also marks the question important. */
+  importantSuffix: string;
+};
+
+export type QuestionDeckProps = {
+  /** The question being answered. */
+  current: QuestionCardContent;
+  /** Peeking out behind it, if there is one. */
+  next?: QuestionCardContent;
+  /** Third in the stack. Only its silhouette is visible. */
+  after?: QuestionCardContent;
+  selection: CardSelection;
+  labels: QuestionDeckLabels;
+  /** `important` reflects the star at the moment of answering. */
+  onAnswer: (agree: boolean, important: boolean) => void;
+  onSkip: () => void;
+  onToggleImportant: () => void;
+  /**
+   * Draw the direction compass over the card. The tutorial's practice deck
+   * passes it; the flow does not, where the arrows would be permanent furniture
+   * over every one of forty questions.
+   */
+  dragGuides?: { practised?: ReadonlySet<DragDirection>; split?: boolean };
+  /**
+   * The last card has been committed and the screen is leaving. The ghost
+   * still flies, but no live card snaps back behind it and further input is
+   * ignored — without this, the deck's decoupled-ghost design re-offers the
+   * same question for as long as the navigation away takes, and a slow
+   * network reads as "I can answer the last question forever."
+   */
+  finished?: boolean;
+  ref?: Ref<QuestionDeckHandle>;
+};
+
+export type QuestionDeckHandle = {
+  /**
+   * Play the "moving on" animation for a question that is already answered.
+   *
+   * Driven from outside because the control that triggers it — "Další" — lives
+   * in the navigation bar below the deck, not on the card.
+   */
+  advance: () => void;
+};
+
+type Ghost = {
+  content: QuestionCardContent;
+  selection: CardSelection;
+  from: string;
+  to: string;
+  speed: CommitSpeed;
+};
+
+const AT_REST = "translate(0px, 0px) rotate(0deg)";
+
+/**
+ * The swipeable card stack.
+ *
+ * The card that leaves is not the card the user was touching: on commit we
+ * clone it into a "ghost" layer that flies out on its own, and immediately snap
+ * the real card back to centre showing the next question. That decoupling is
+ * what keeps the next question interactive during the exit animation.
+ *
+ * The moment-to-moment transforms are inline styles written by `useSwipeDeck`;
+ * only the static arrangement of the layers lives in `styles.css` (`.ko-deck*`).
+ */
+export function QuestionDeck({ current, next, after, selection, labels, onAnswer, onSkip, onToggleImportant, dragGuides, finished = false, ref }: QuestionDeckProps) {
+  const [ghost, setGhost] = useState<Ghost | null>(null);
+  const [hint, setHint] = useState<SwipeIntent | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const ghostRef = useRef<HTMLDivElement>(null);
+  const ghostTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  /**
+   * The answer a card is switching to, held on screen for `ANSWER_SWITCH_HOLD`
+   * before the card leaves on it — see that constant for why.
+   *
+   * Non-null only during that beat, and it is what the card renders while it
+   * lasts: the store still holds the *old* answer until `commit` runs, so
+   * without this the card would sit through the pause still showing the answer
+   * being replaced.
+   */
+  const [switching, setSwitching] = useState<SwipeIntent | null>(null);
+  const switchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const commit = useCallback(
+    (intent: SwipeIntent, speed: CommitSpeed, from: string) => {
+      if (finished) return;
+      const { zone, important } = intent;
+
+      setGhost({
+        content: current,
+        selection: {
+          agree: zone === "agree",
+          disagree: zone === "disagree",
+          important: zone === "skip" ? selection.important : important,
+        },
+        from,
+        to: exitTransform(zone, important),
+        speed,
+      });
+
+      // Screen readers get told what was recorded; the swipe itself is silent.
+      setAnnouncement(zone === "skip" ? labels.skip : `${zone === "agree" ? labels.agree : labels.disagree}${important ? labels.importantSuffix : ""}`);
+
+      if (zone === "skip") onSkip();
+      else onAnswer(zone === "agree", important);
+    },
+    [current, finished, selection.important, labels, onAnswer, onSkip],
+  );
+
+  const { cardRef, nextRef, backRef, onPointerDown, isDragging, animateStackRise } = useSwipeDeck({
+    onCommit: (swipeIntent, from) => commit(swipeIntent, "normal", from),
+    onIntentChange: setHint,
+    // Not draggable through the hold: the card is showing an answer it is
+    // about to leave on, and a drag would be answering it a second time.
+    disabled: switching !== null,
+  });
+
+  /** Tapping a button commits from rest, so it flies out a little slower. */
+  const commitFromButton = useCallback(
+    (zone: SwipeZone, important: boolean) => {
+      setSwitching(null);
+      commit({ zone, important }, "slow", AT_REST);
+      animateStackRise("slow");
+    },
+    [commit, animateStackRise],
+  );
+
+  /**
+   * Answer from a button or the keyboard.
+   *
+   * `replacing` an answer that is already there splits this into two visible
+   * steps — the selection moves to the pressed button, then the card leaves on
+   * it. A first answer stays a single step.
+   */
+  const answerFromButton = useCallback(
+    (zone: SwipeZone, important: boolean, replacing: boolean) => {
+      if (!replacing) {
+        commitFromButton(zone, important);
+        return;
+      }
+
+      setSwitching({ zone, important });
+      switchTimer.current = setTimeout(() => commitFromButton(zone, important), answerSwitchHold() * 1000);
+    },
+    [commitFromButton],
+  );
+
+  const handleAgree = useCallback(() => {
+    // Presses during the hold are the same press arriving twice — the card is
+    // already committed to leaving on this answer.
+    if (switching) return;
+    if (selection.agree) {
+      // Choosing the same answer again clears it, without leaving the card.
+      onAnswer(true, selection.important);
+      return;
+    }
+    answerFromButton("agree", selection.important, selection.disagree);
+  }, [answerFromButton, onAnswer, selection.agree, selection.disagree, selection.important, switching]);
+
+  const handleDisagree = useCallback(() => {
+    if (switching) return;
+    if (selection.disagree) {
+      onAnswer(false, selection.important);
+      return;
+    }
+    answerFromButton("disagree", selection.important, selection.agree);
+  }, [answerFromButton, onAnswer, selection.agree, selection.disagree, selection.important, switching]);
+
+  const handleSkip = useCallback(() => {
+    if (switching) return;
+    commit({ zone: "skip", important: false }, "normal", AT_REST);
+    animateStackRise("normal");
+  }, [commit, animateStackRise, switching]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      advance: () => {
+        if (finished) return;
+        // No fling: the answer is not changing, so the card just lifts away.
+        setGhost({
+          content: current,
+          selection,
+          from: AT_REST,
+          to: advanceTransform(),
+          speed: "instant",
+        });
+        animateStackRise("instant");
+      },
+    }),
+    [current, finished, selection, animateStackRise],
+  );
+
+  // Drive the ghost's flight once React has painted it at its starting point.
+  useLayoutEffect(() => {
+    if (!ghost) return;
+    const el = ghostRef.current;
+    if (!el) return;
+
+    // Reduced motion collapses both to near-zero: the answered card is simply
+    // gone rather than thrown off the side of the screen, which is the single
+    // largest movement in the app and the one this preference exists for.
+    const { fly, fade } = speedFor(ghost.speed);
+
+    el.style.transition = "none";
+    el.style.transform = ghost.from;
+    el.style.opacity = "1";
+
+    // Force a reflow so the browser treats the next assignment as a change to
+    // animate rather than folding both into one paint.
+    void el.offsetWidth;
+
+    el.style.transition = `transform ${fly}s var(--ko-ease-exit), opacity ${fade}s ease-in`;
+    el.style.transform = ghost.to;
+    el.style.opacity = "0";
+
+    if (ghostTimer.current) clearTimeout(ghostTimer.current);
+    ghostTimer.current = setTimeout(() => setGhost(null), fly * 1000 + 60);
+  }, [ghost]);
+
+  useEffect(
+    () => () => {
+      if (ghostTimer.current) clearTimeout(ghostTimer.current);
+      if (switchTimer.current) clearTimeout(switchTimer.current);
+    },
+    [],
+  );
+
+  // Keyboard mirrors the gestures: left/right answer, down skips, up marks
+  // important — the same directions the swipes use.
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      // `event.target` is not always an Element (it's `window`/`document` for
+      // some synthetically dispatched or unfocused-body keydowns) — guard
+      // before calling an Element-only method on it.
+      const target = event.target;
+      if (target instanceof HTMLElement && target.closest("input, textarea, select, [contenteditable]")) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      switch (event.key) {
+        case "ArrowLeft":
+          event.preventDefault();
+          handleAgree();
+          break;
+        case "ArrowRight":
+          event.preventDefault();
+          handleDisagree();
+          break;
+        case "ArrowDown":
+          event.preventDefault();
+          handleSkip();
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          onToggleImportant();
+          break;
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [handleAgree, handleDisagree, handleSkip, onToggleImportant]);
+
+  const cardLabels = {
+    agree: labels.agree,
+    disagree: labels.disagree,
+    important: labels.important,
+  };
+
+  const showHint = isDragging && hint !== null;
+
+  /*
+   * While dragging, the active card previews the answer it would record —
+   * matching the prototype, where the buttons themselves light up under the
+   * drag rather than only the hint pill saying so. Below the zone-activation
+   * threshold `hint` is null and the preview briefly clears, exactly as it
+   * does in the prototype, until the drag re-crosses into a zone. "Important"
+   * is the one thing that does not clear: it is an OR with the stored value so
+   * a question armed by an earlier star tap stays visibly armed through a
+   * drag that does not itself reach the up-swipe threshold.
+   */
+  const activeSelection: CardSelection = switching
+    ? {
+        // The beat before the card leaves: it shows the answer it is leaving
+        // on, which the store does not hold yet.
+        agree: switching.zone === "agree",
+        disagree: switching.zone === "disagree",
+        important: switching.important || selection.important,
+      }
+    : isDragging
+      ? {
+          agree: hint?.zone === "agree",
+          disagree: hint?.zone === "disagree",
+          important: (hint !== null && hint.zone !== "skip" && hint.important) || selection.important,
+        }
+      : selection;
+
+  return (
+    <div className="ko-deck">
+      {after ? (
+        <div ref={backRef} className="ko-deck-layer ko-deck-back">
+          {/* An empty card, so the stack still reads as a deck on the last question. */}
+          <div className="ko:absolute ko:inset-0 ko:bg-surface ko:rounded-card ko:border ko:border-border ko:shadow-card-back" />
+        </div>
+      ) : null}
+
+      {next ? (
+        <div ref={nextRef} className="ko-deck-layer ko-deck-next">
+          <QuestionCard content={next} selection={{ agree: false, disagree: false, important: false }} labels={cardLabels} elevation="next" inert />
+        </div>
+      ) : null}
+
+      {finished ? null : (
+        <QuestionCard
+          ref={cardRef}
+          className="ko-deck-active"
+          content={current}
+          selection={activeSelection}
+          labels={cardLabels}
+          /* The one card on the deck that is being read, so its statement is the
+             screen's heading. The layers behind it and the ghost in front are
+             `inert` and out of the accessibility tree entirely, so this never
+             puts a second `<h1>` in front of anyone. */
+          statementAs="h1"
+          onPointerDown={onPointerDown}
+          onAgree={handleAgree}
+          onDisagree={handleDisagree}
+          onToggleImportant={onToggleImportant}
+          guides={dragGuides ? <DragGuides labels={labels} split={dragGuides.split} practised={dragGuides.practised} active={showHint ? directionForIntent(hint) : null} /> : undefined}
+        />
+      )}
+
+      {ghost ? <QuestionCard ref={ghostRef} className="ko-deck-ghost" content={ghost.content} selection={ghost.selection} labels={cardLabels} elevation="lifted" inert /> : null}
+
+      <div className={showHint ? "ko-deck-toast ko-deck-toast-visible" : "ko-deck-toast"} aria-hidden="true">
+        {hint ? <HintLabel intent={hint} labels={labels} /> : null}
+      </div>
+
+      {/* Announces the committed answer without moving focus. */}
+      <VisuallyHidden as="output" aria-live="polite">
+        {announcement}
+      </VisuallyHidden>
+    </div>
+  );
+}
+
+/**
+ * Which arrow the drag is currently pointing at.
+ *
+ * Read from the same intent the hint toast uses, so the compass and the toast
+ * can never disagree about what releasing right now would do.
+ */
+function directionForIntent(intent: SwipeIntent | null): DragDirection | null {
+  if (!intent) return null;
+  if (intent.zone === "skip") return "s";
+  if (intent.zone === "agree") return intent.important ? "nw" : "w";
+  return intent.important ? "ne" : "e";
+}
+
+/**
+ * What releasing right now would record.
+ *
+ * Whatever the card's own buttons say, and nothing else. An answer has exactly
+ * one name in this app — the `agree`/`disagree` labels — and the toast is the
+ * one place that name used to be rewritten, first shrinking to a compact form
+ * on a narrow deck and later spelling out a longer synonym. A control that
+ * renames the answer at the moment of committing is teaching the reader a
+ * second word for the thing they just chose.
+ */
+function HintLabel({ intent, labels }: { intent: SwipeIntent; labels: QuestionDeckLabels }) {
+  if (intent.zone === "skip") return <span>{labels.skip}</span>;
+
+  const answer = intent.zone === "agree" ? labels.agree : labels.disagree;
+
+  return (
+    <span>
+      {answer}
+      {intent.important ? labels.importantSuffix : ""}
+    </span>
+  );
+}

--- a/packages/design-system/src/components/client/questionDeck/swipePhysics.test.ts
+++ b/packages/design-system/src/components/client/questionDeck/swipePhysics.test.ts
@@ -1,0 +1,91 @@
+// Ported verbatim from kalkulacka-2026/packages/ui/src/question-deck/swipe-physics.test.ts
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PHYSICS, REDUCED_DURATION, SPEEDS, SPRING_BACK_DURATION, shouldCommit, speedFor, springBackDuration, zoneForOffset } from "./swipePhysics";
+
+describe("zoneForOffset", () => {
+  it("reads a left drag as agree and a right drag as disagree", () => {
+    expect(zoneForOffset(-50, 0)).toEqual({ zone: "agree", important: false });
+    expect(zoneForOffset(50, 0)).toEqual({ zone: "disagree", important: false });
+  });
+
+  it("ignores travel too small to be intentional", () => {
+    expect(zoneForOffset(PHYSICS.zoneActivateX, 0)).toBeNull();
+    expect(zoneForOffset(-PHYSICS.zoneActivateX, 0)).toBeNull();
+    expect(zoneForOffset(0, 0)).toBeNull();
+  });
+
+  it('arms "important" when the drag also lifts', () => {
+    expect(zoneForOffset(-60, -60)).toEqual({ zone: "agree", important: true });
+    expect(zoneForOffset(60, -60)).toEqual({ zone: "disagree", important: true });
+  });
+
+  it("reads a downward drag as skip", () => {
+    expect(zoneForOffset(0, 80)).toEqual({ zone: "skip", important: false });
+  });
+
+  it("prefers the horizontal answer on a sloppy diagonal", () => {
+    // Travelling down and right in roughly equal measure: the user was aiming
+    // sideways, so this must not silently skip the question.
+    expect(zoneForOffset(80, 80)).toEqual({ zone: "disagree", important: false });
+  });
+
+  it("only skips when the downward drag clearly dominates", () => {
+    const dy = 100;
+    const dominant = dy / PHYSICS.skipDominance;
+
+    expect(zoneForOffset(dominant - 10, dy)?.zone).toBe("skip");
+    expect(zoneForOffset(dominant + 10, dy)?.zone).toBe("disagree");
+  });
+});
+
+describe("shouldCommit", () => {
+  it("needs the threshold to be exceeded horizontally", () => {
+    expect(shouldCommit("agree", -PHYSICS.threshold, 0)).toBe(false);
+    expect(shouldCommit("agree", -PHYSICS.threshold - 1, 0)).toBe(true);
+    expect(shouldCommit("disagree", PHYSICS.threshold + 1, 0)).toBe(true);
+  });
+
+  it("measures a skip against downward travel only", () => {
+    expect(shouldCommit("skip", 0, PHYSICS.threshold + 1)).toBe(true);
+    expect(shouldCommit("skip", 500, PHYSICS.threshold - 1)).toBe(false);
+  });
+});
+
+/*
+ * These two are read straight into inline `transition` strings, so there is no
+ * `--ko-duration-*` token in the path for `styles.css`'s reduced-motion rule to
+ * collapse — the query has to be read here or the largest movement in the app
+ * (a card thrown 480px off the side of the screen) plays regardless of the
+ * preference.
+ */
+describe("under prefers-reduced-motion", () => {
+  function setReduceMotion(reduce: boolean) {
+    vi.stubGlobal("matchMedia", (query: string) => ({
+      matches: reduce && query.includes("prefers-reduced-motion"),
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }));
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("collapses the fly-out and the spring back", () => {
+    setReduceMotion(true);
+
+    expect(speedFor("normal")).toEqual({ fly: REDUCED_DURATION, fade: REDUCED_DURATION });
+    expect(speedFor("slow")).toEqual({ fly: REDUCED_DURATION, fade: REDUCED_DURATION });
+    expect(springBackDuration()).toBe(REDUCED_DURATION);
+  });
+
+  it("leaves the measured timings alone when it is not asked for", () => {
+    setReduceMotion(false);
+
+    expect(speedFor("normal")).toEqual(SPEEDS.normal);
+    expect(speedFor("slow")).toEqual(SPEEDS.slow);
+    expect(springBackDuration()).toBe(SPRING_BACK_DURATION);
+  });
+});

--- a/packages/design-system/src/components/client/questionDeck/swipePhysics.ts
+++ b/packages/design-system/src/components/client/questionDeck/swipePhysics.ts
@@ -1,0 +1,199 @@
+// Ported verbatim from kalkulacka-2026/packages/ui/src/question-deck/swipe-physics.ts
+
+/**
+ * Gesture constants, measured from the prototype.
+ *
+ * These are the feel of the product, so they live together and named rather
+ * than scattered as literals. They are not theme tokens: a partner re-skinning
+ * the app should not be able to accidentally change how a swipe behaves.
+ */
+
+import { prefersReducedMotion } from "../../../utilities/prefersReducedMotion";
+
+export type SwipeZone = "agree" | "disagree" | "skip";
+
+/** Where the stacked cards sit when the top card is at rest. */
+export const STACK_NEXT = {
+  x: 12,
+  y: -22,
+  scale: 0.95,
+  rotate: 0.5,
+  brightness: 0.99,
+  opacity: 1,
+} as const;
+
+export const STACK_BACK = {
+  x: 24,
+  y: -40,
+  scale: 0.9,
+  rotate: 1,
+  brightness: 0.98,
+  opacity: 1,
+} as const;
+
+/** How far the stack cards travel toward the front as the top card is dragged. */
+export const STACK_TRAVEL = {
+  next: { x: -16, y: 18, scale: 0.05, rotate: -0.8, brightness: 0.08, opacity: 0 },
+  back: { x: -16, y: 16, scale: 0.06, rotate: -0.7, brightness: 0.1, opacity: 0 },
+} as const;
+
+export const PHYSICS = {
+  /** Drag distance that commits an answer. */
+  threshold: 50,
+  /** Horizontal drag is divided by this to produce the card's tilt in degrees. */
+  rotationDivisor: 18,
+  /** Drag distance at which the stack has fully caught up. */
+  stackProgressDistance: 130,
+  /** Horizontal travel before a left/right intent is recognised. */
+  zoneActivateX: 25,
+  /** Upward travel that arms "pro mě důležité" mid-swipe. */
+  importantLiftY: -38,
+  /** Downward travel before a skip is recognised... */
+  skipActivateY: 45,
+  /** ...and how much it must dominate horizontal travel to count as one. */
+  skipDominance: 1.2,
+} as const;
+
+/** Where a committed card flies to. */
+export const EXIT = {
+  horizontalX: 480,
+  /** An important answer flicks up and away; an ordinary one drops slightly. */
+  liftImportant: -300,
+  liftNormal: 60,
+  rotation: 24,
+  skipY: 560,
+  skipRotation: 2,
+  /** Advancing without recording an answer — a small lift, no fling. */
+  advanceY: -34,
+  advanceScale: 0.94,
+} as const;
+
+export type CommitSpeed = "normal" | "slow" | "instant";
+
+/**
+ * Committing by tap animates slower than committing by flick: the card has no
+ * momentum to inherit, so matching the drag timing reads as abrupt.
+ */
+export const SPEEDS: Record<CommitSpeed, { fly: number; fade: number }> = {
+  normal: { fly: 0.38, fade: 0.16 },
+  slow: { fly: 0.44, fade: 0.2 },
+  instant: { fly: 0.12, fade: 0.1 },
+};
+
+export const SPRING_BACK_DURATION = 0.36;
+
+/**
+ * How long a card holds on a freshly-changed answer before it leaves.
+ *
+ * Only ever applies to *changing* an answer that already exists — pressing "Ne"
+ * on a card that currently reads "Ano". Committing and flying in the same frame
+ * makes those two presses look identical from the outside: the card is gone
+ * before the button it was pressed on has visibly changed, so the one thing the
+ * reader wanted confirmed — that the new answer took — is the one thing they
+ * never see. The beat is the confirmation; the flight is the consequence.
+ *
+ * A first answer does not get it. There is nothing to correct, the button's own
+ * press state already reads, and paying a quarter of a second on every one of
+ * forty cards to say what was never in doubt is a tax, not a reassurance.
+ */
+export const ANSWER_SWITCH_HOLD = 0.26;
+
+/**
+ * What every duration here collapses to under `prefers-reduced-motion`.
+ *
+ * Near-zero rather than zero, matching what `styles.css` does to the duration
+ * tokens: a transition of `0s` is not a transition at all and fires no
+ * `transitionend`, and the deck's own timers are sized against these numbers.
+ */
+export const REDUCED_DURATION = 0.001;
+
+/*
+ * The two readers below are what the deck animates through, and they exist
+ * because these durations are written straight into inline `transition`
+ * strings — there is no `--ko-duration-*` token in the path for `styles.css`'s
+ * reduced-motion rule to collapse, so the query has to be read in JS.
+ *
+ * What is *not* reduced is the drag itself. A card following a finger is
+ * direct manipulation rather than animation: it moves because the hand moves,
+ * it stops when the hand stops, and freezing it would take the gesture away
+ * instead of calming it. Only the parts that play on their own once the hand
+ * is off — the fly-out, the stack rising to the front behind it, and the
+ * spring back from a drag that did not commit — are what this switches off.
+ */
+
+/** How long a committed card takes to leave, and to fade while it does. */
+export function speedFor(speed: CommitSpeed): { fly: number; fade: number } {
+  if (prefersReducedMotion()) return { fly: REDUCED_DURATION, fade: REDUCED_DURATION };
+  return SPEEDS[speed];
+}
+
+/**
+ * The beat between an answer changing and the card leaving on it.
+ *
+ * Collapsed under reduced motion along with everything else: with no flight to
+ * separate the change from, a pause is a delay and nothing more.
+ */
+export function answerSwitchHold(): number {
+  return prefersReducedMotion() ? REDUCED_DURATION : ANSWER_SWITCH_HOLD;
+}
+
+/** How long an abandoned drag takes to settle back to centre. */
+export function springBackDuration(): number {
+  return prefersReducedMotion() ? REDUCED_DURATION : SPRING_BACK_DURATION;
+}
+
+export function transform(x: number, y: number, rotation: number) {
+  return `translate(${x}px, ${y}px) rotate(${rotation}deg)`;
+}
+
+export function stackTransform(x: number, y: number, scale: number, rotate = 0) {
+  return `translate(${x}px, ${y}px) scale(${scale}) rotate(${rotate}deg)`;
+}
+
+/**
+ * Read a drag offset as intent.
+ *
+ * Order matters: a downward drag is tested first and must clearly dominate, so
+ * that a sloppy diagonal still registers as the left/right answer the user
+ * meant rather than silently skipping the question.
+ */
+export function zoneForOffset(dx: number, dy: number): { zone: SwipeZone; important: boolean } | null {
+  const absX = Math.abs(dx);
+  const absY = Math.abs(dy);
+
+  if (dy > PHYSICS.skipActivateY && absY > absX * PHYSICS.skipDominance) {
+    return { zone: "skip", important: false };
+  }
+
+  if (absX > PHYSICS.zoneActivateX) {
+    // Left is "Ano" — it matches the button order on the card.
+    return {
+      zone: dx < 0 ? "agree" : "disagree",
+      important: dy < PHYSICS.importantLiftY,
+    };
+  }
+
+  return null;
+}
+
+/** Whether a released drag travelled far enough to commit. */
+export function shouldCommit(zone: SwipeZone, dx: number, dy: number): boolean {
+  if (zone === "skip") return dy > PHYSICS.threshold;
+  return Math.abs(dx) > PHYSICS.threshold;
+}
+
+export function exitTransform(zone: SwipeZone, important: boolean): string {
+  if (zone === "skip") {
+    return transform(0, EXIT.skipY, EXIT.skipRotation);
+  }
+
+  const sign = zone === "agree" ? -1 : 1;
+  const lift = important ? EXIT.liftImportant : EXIT.liftNormal;
+
+  return transform(sign * EXIT.horizontalX, lift, sign * EXIT.rotation);
+}
+
+/** Advancing to an already-answered card: no fling, just a lift and fade. */
+export function advanceTransform(): string {
+  return `translate(0px, ${EXIT.advanceY}px) scale(${EXIT.advanceScale})`;
+}

--- a/packages/design-system/src/components/client/questionDeck/useSwipeDeck.ts
+++ b/packages/design-system/src/components/client/questionDeck/useSwipeDeck.ts
@@ -1,0 +1,305 @@
+// Ported from kalkulacka-2026/packages/ui/src/question-deck/use-swipe-deck.ts
+import { type PointerEvent as ReactPointerEvent, useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import { type CommitSpeed, PHYSICS, STACK_BACK, STACK_NEXT, STACK_TRAVEL, type SwipeZone, shouldCommit, speedFor, springBackDuration, stackTransform, transform, zoneForOffset } from "./swipePhysics";
+
+export type SwipeIntent = { zone: SwipeZone; important: boolean };
+
+export type UseSwipeDeckOptions = {
+  /**
+   * Called when a drag travelled far enough to count as an answer.
+   *
+   * `fromTransform` is where the card was at release — the caller hands it to
+   * the fly-out so the exit animation continues from the drag rather than
+   * jumping back to centre first.
+   */
+  onCommit: (intent: SwipeIntent, fromTransform: string) => void;
+  /** Zone under the finger right now, for the drag hint. `null` when unclear. */
+  onIntentChange?: (intent: SwipeIntent | null) => void;
+  disabled?: boolean;
+};
+
+/**
+ * Pointer-driven card dragging, ported from the prototype.
+ *
+ * Transforms are written straight to the DOM rather than held in React state:
+ * a drag produces a pointermove every frame, and re-rendering three stacked
+ * cards at that rate is exactly the kind of jank this interaction cannot
+ * afford. React still owns *what* is on each card — only the moment-to-moment
+ * position is imperative.
+ */
+export function useSwipeDeck({ onCommit, onIntentChange, disabled = false }: UseSwipeDeckOptions) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const nextRef = useRef<HTMLDivElement>(null);
+  const backRef = useRef<HTMLDivElement>(null);
+
+  const dragging = useRef(false);
+  const start = useRef({ x: 0, y: 0 });
+  const offset = useRef({ x: 0, y: 0 });
+  const intentRef = useRef<SwipeIntent | null>(null);
+
+  const [isDragging, setIsDragging] = useState(false);
+  const [intent, setIntent] = useState<SwipeIntent | null>(null);
+
+  const publishIntent = useCallback(
+    (next: SwipeIntent | null) => {
+      const prev = intentRef.current;
+      if (prev?.zone === next?.zone && prev?.important === next?.important) return;
+
+      intentRef.current = next;
+      setIntent(next);
+      onIntentChange?.(next);
+    },
+    [onIntentChange],
+  );
+
+  /** Snap the stack back to its resting arrangement, without animating. */
+  const resetStack = useCallback(() => {
+    const card = cardRef.current;
+    if (card) {
+      card.style.transition = "none";
+      card.style.transform = transform(0, 0, 0);
+      card.style.opacity = "1";
+    }
+
+    const next = nextRef.current;
+    if (next) {
+      next.style.transition = "none";
+      next.style.transform = stackTransform(STACK_NEXT.x, STACK_NEXT.y, STACK_NEXT.scale, STACK_NEXT.rotate);
+      next.style.filter = `brightness(${STACK_NEXT.brightness})`;
+      next.style.opacity = String(STACK_NEXT.opacity);
+    }
+
+    const back = backRef.current;
+    if (back) {
+      back.style.transition = "none";
+      back.style.transform = stackTransform(STACK_BACK.x, STACK_BACK.y, STACK_BACK.scale, STACK_BACK.rotate);
+      back.style.filter = `brightness(${STACK_BACK.brightness})`;
+      back.style.opacity = String(STACK_BACK.opacity);
+    }
+  }, []);
+
+  /** Animate the upcoming card rising and enlarging to the front on button/keyboard commit. */
+  const animateStackRise = useCallback((speed: CommitSpeed = "normal") => {
+    // Near-zero under reduced motion, so the next card is simply already at
+    // the front rather than sliding and growing into it.
+    const { fly } = speedFor(speed);
+    const easing = `transform ${fly}s var(--ko-ease-spring), filter ${fly}s ease, opacity ${fly}s ease`;
+
+    const card = cardRef.current;
+    if (card) {
+      card.style.transition = "none";
+      card.style.transform = stackTransform(STACK_NEXT.x, STACK_NEXT.y, STACK_NEXT.scale, STACK_NEXT.rotate);
+      card.style.filter = `brightness(${STACK_NEXT.brightness})`;
+      card.style.opacity = "1";
+
+      void card.offsetWidth;
+
+      card.style.transition = easing;
+      card.style.transform = transform(0, 0, 0);
+      card.style.filter = "brightness(1)";
+    }
+
+    const next = nextRef.current;
+    if (next) {
+      next.style.transition = "none";
+      next.style.transform = stackTransform(STACK_BACK.x, STACK_BACK.y, STACK_BACK.scale, STACK_BACK.rotate);
+      next.style.filter = `brightness(${STACK_BACK.brightness})`;
+      next.style.opacity = String(STACK_BACK.opacity);
+
+      void next.offsetWidth;
+
+      next.style.transition = easing;
+      next.style.transform = stackTransform(STACK_NEXT.x, STACK_NEXT.y, STACK_NEXT.scale, STACK_NEXT.rotate);
+      next.style.filter = `brightness(${STACK_NEXT.brightness})`;
+    }
+
+    const back = backRef.current;
+    if (back) {
+      back.style.transition = "none";
+      back.style.transform = stackTransform(STACK_BACK.x, STACK_BACK.y, STACK_BACK.scale, STACK_BACK.rotate);
+      back.style.filter = `brightness(${STACK_BACK.brightness})`;
+      back.style.opacity = String(STACK_BACK.opacity);
+    }
+  }, []);
+
+  const springBack = useCallback(() => {
+    // The drag that got here was the reader's own hand and is never reduced;
+    // this is the part that plays by itself once they let go, so it is.
+    const settle = springBackDuration();
+    const easing = `transform ${settle}s var(--ko-ease-spring), filter ${settle}s ease, opacity ${settle}s ease`;
+
+    const card = cardRef.current;
+    if (card) {
+      card.style.transition = easing;
+      card.style.transform = transform(0, 0, 0);
+    }
+
+    const next = nextRef.current;
+    if (next) {
+      next.style.transition = easing;
+      next.style.transform = stackTransform(STACK_NEXT.x, STACK_NEXT.y, STACK_NEXT.scale, STACK_NEXT.rotate);
+      next.style.filter = `brightness(${STACK_NEXT.brightness})`;
+      next.style.opacity = String(STACK_NEXT.opacity);
+    }
+
+    const back = backRef.current;
+    if (back) {
+      back.style.transition = easing;
+      back.style.transform = stackTransform(STACK_BACK.x, STACK_BACK.y, STACK_BACK.scale, STACK_BACK.rotate);
+      back.style.filter = `brightness(${STACK_BACK.brightness})`;
+      back.style.opacity = String(STACK_BACK.opacity);
+    }
+  }, []);
+
+  // Listeners live on the window rather than the card so a fast drag that
+  // outruns the pointer still tracks. They are attached synchronously from
+  // `onPointerDown` itself — not from a `useEffect` keyed off `isDragging` —
+  // because on touch devices a tap or flick can produce its pointermove/up
+  // before React commits the state update and runs the effect, silently
+  // dropping the gesture (and, since `handleUp` never runs, leaving
+  // `dragging.current` stuck `true`). Attaching inline has no such gap.
+  const attachListeners = useCallback(() => {
+    const handleMove = (event: globalThis.PointerEvent) => {
+      const dx = event.clientX - start.current.x;
+      const dy = event.clientY - start.current.y;
+      offset.current = { x: dx, y: dy };
+
+      const card = cardRef.current;
+      if (card) card.style.transform = transform(dx, dy, dx / PHYSICS.rotationDivisor);
+
+      // The stack rises toward the front as the top card leaves.
+      const progress = Math.min(1, Math.max(Math.abs(dx), Math.abs(dy)) / PHYSICS.stackProgressDistance);
+
+      const next = nextRef.current;
+      if (next) {
+        next.style.transform = stackTransform(
+          STACK_NEXT.x + STACK_TRAVEL.next.x * progress,
+          STACK_NEXT.y + STACK_TRAVEL.next.y * progress,
+          STACK_NEXT.scale + STACK_TRAVEL.next.scale * progress,
+          STACK_NEXT.rotate + STACK_TRAVEL.next.rotate * progress,
+        );
+        next.style.filter = `brightness(${STACK_NEXT.brightness + STACK_TRAVEL.next.brightness * progress})`;
+        next.style.opacity = String(STACK_NEXT.opacity + STACK_TRAVEL.next.opacity * progress);
+      }
+
+      const back = backRef.current;
+      if (back) {
+        back.style.transform = stackTransform(
+          STACK_BACK.x + STACK_TRAVEL.back.x * progress,
+          STACK_BACK.y + STACK_TRAVEL.back.y * progress,
+          STACK_BACK.scale + STACK_TRAVEL.back.scale * progress,
+          STACK_BACK.rotate + STACK_TRAVEL.back.rotate * progress,
+        );
+        back.style.filter = `brightness(${STACK_BACK.brightness + STACK_TRAVEL.back.brightness * progress})`;
+        back.style.opacity = String(STACK_BACK.opacity + STACK_TRAVEL.back.opacity * progress);
+      }
+
+      publishIntent(zoneForOffset(dx, dy));
+    };
+
+    const detach = () => {
+      window.removeEventListener("pointermove", handleMove);
+      window.removeEventListener("pointerup", handleUp);
+      window.removeEventListener("pointercancel", handleUp);
+    };
+
+    const handleUp = () => {
+      if (!dragging.current) return;
+      dragging.current = false;
+      setIsDragging(false);
+      detach();
+
+      const { x: dx, y: dy } = offset.current;
+      const settled = intentRef.current;
+
+      if (settled && shouldCommit(settled.zone, dx, dy)) {
+        const from = cardRef.current?.style.transform || transform(0, 0, 0);
+        publishIntent(null);
+
+        // An upward flick arms "important" even if the pointer drifted back
+        // below the threshold before release.
+        onCommit(
+          {
+            zone: settled.zone,
+            important: settled.important || dy < PHYSICS.importantLiftY,
+          },
+          from,
+        );
+
+        // The card the user was holding has been cloned into the fly-out layer;
+        // the real one goes straight back to centre showing the next question.
+        resetStack();
+        return;
+      }
+
+      publishIntent(null);
+      springBack();
+    };
+
+    window.addEventListener("pointermove", handleMove);
+    window.addEventListener("pointerup", handleUp);
+    window.addEventListener("pointercancel", handleUp);
+
+    return detach;
+  }, [onCommit, publishIntent, springBack, resetStack]);
+
+  // Runs the returned cleanup once the current drag ends, then forgets it —
+  // `attachListeners` itself never depends on `isDragging`, so there is no
+  // render in between "pointer went down" and "listeners are live".
+  const detachRef = useRef<(() => void) | null>(null);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (disabled) return;
+
+      if (event.currentTarget.setPointerCapture) {
+        try {
+          event.currentTarget.setPointerCapture(event.pointerId);
+        } catch {
+          // Ignore capture failures (e.g. if element is detached)
+        }
+      }
+
+      dragging.current = true;
+      start.current = { x: event.clientX, y: event.clientY };
+      offset.current = { x: 0, y: 0 };
+
+      // Kill transitions so the card tracks the pointer exactly.
+      for (const ref of [cardRef, nextRef, backRef]) {
+        if (ref.current) ref.current.style.transition = "none";
+      }
+
+      setIsDragging(true);
+
+      // Attached here, synchronously, rather than in a `useEffect` — see the
+      // comment above `attachListeners`. `pointermove`/`pointerup` can arrive
+      // (and on a quick touch tap, both can arrive) before React would
+      // otherwise have committed `isDragging` and run the effect.
+      detachRef.current?.();
+      detachRef.current = attachListeners();
+    },
+    [disabled, attachListeners],
+  );
+
+  useEffect(() => () => detachRef.current?.(), []);
+
+  // Ensure initial inline transforms match JS physics constants on mount and HMR updates.
+  useLayoutEffect(() => {
+    resetStack();
+  }, [resetStack]);
+
+  return {
+    cardRef,
+    nextRef,
+    backRef,
+    onPointerDown,
+    /** True only while the pointer is down and moving the card. */
+    isDragging,
+    /** What the current drag would do if released now. */
+    intent,
+    resetStack,
+    springBack,
+    animateStackRise,
+  };
+}

--- a/packages/design-system/src/components/server/index.ts
+++ b/packages/design-system/src/components/server/index.ts
@@ -9,6 +9,7 @@ export * from "./dotIndicator";
 export * from "./edgeFade";
 export * from "./iconBadge";
 export * from "./progressBar";
+export * from "./progressSegments";
 export * from "./screen";
 export * from "./shell";
 export * from "./steppedProgressBar";

--- a/packages/design-system/src/components/server/progressSegments.test.tsx
+++ b/packages/design-system/src/components/server/progressSegments.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ProgressSegments, type Segment } from "./progressSegments";
+
+const segments: Segment[] = [
+  { state: "agree" },
+  { state: "agree", important: true },
+  { state: "disagree" },
+  { state: "skipped" },
+  { state: "disagree", important: true },
+  { state: "unanswered", important: true },
+  { state: "unanswered" },
+  { state: "unanswered" },
+];
+
+function segment(index: number) {
+  const element = screen.getByRole("progressbar").children[index];
+  if (!(element instanceof HTMLElement)) throw new Error(`No segment ${index}`);
+  return element;
+}
+
+function bar(index: number) {
+  const element = segment(index).firstElementChild;
+  if (!(element instanceof HTMLElement)) throw new Error(`No bar ${index}`);
+  return element;
+}
+
+function dot(index: number) {
+  return segment(index).querySelector("span");
+}
+
+describe("ProgressSegments", () => {
+  it("is a labelled progressbar counting questions from one", () => {
+    render(<ProgressSegments segments={segments} currentIndex={5} label="Otázka 6 z 8" />);
+    const progressbar = screen.getByRole("progressbar", { name: "Otázka 6 z 8" });
+    expect(progressbar).toHaveAttribute("aria-valuemin", "1");
+    expect(progressbar).toHaveAttribute("aria-valuemax", "8");
+    expect(progressbar).toHaveAttribute("aria-valuenow", "6");
+  });
+
+  it("draws one segment per question, hidden from assistive tech", () => {
+    render(<ProgressSegments segments={segments} currentIndex={0} label="Otázka 1 z 8" />);
+    const progressbar = screen.getByRole("progressbar");
+    expect(progressbar.children).toHaveLength(segments.length);
+    for (const child of progressbar.children) {
+      expect(child).toHaveAttribute("aria-hidden", "true");
+    }
+  });
+
+  it("colours answered segments by the answer", () => {
+    render(<ProgressSegments segments={segments} currentIndex={7} label="Otázka 8 z 8" />);
+    expect(bar(0)).toHaveClass("ko:bg-agree");
+    expect(bar(2)).toHaveClass("ko:bg-disagree");
+    expect(bar(6)).toHaveClass("ko:bg-border");
+    expect(bar(6)).not.toHaveClass("ko:bg-agree", "ko:bg-disagree");
+  });
+
+  it("reads a skipped question exactly like an unanswered one", () => {
+    render(<ProgressSegments segments={segments} currentIndex={7} label="Otázka 8 z 8" />);
+    expect(bar(3).className).toBe(bar(6).className);
+    expect(bar(3)).toHaveClass("ko:bg-border");
+  });
+
+  it("enlarges the current segment in the subtle text colour", () => {
+    render(<ProgressSegments segments={segments} currentIndex={5} label="Otázka 6 z 8" />);
+    expect(bar(5)).toHaveClass("ko:h-[11px]", "ko:bg-text-subtle", "ko:animate-segment-pop", "ko:motion-reduce:animate-none");
+    expect(bar(5)).not.toHaveClass("ko:h-1.5", "ko:bg-border");
+    expect(bar(4)).toHaveClass("ko:h-1.5");
+    expect(bar(4)).not.toHaveClass("ko:bg-text-subtle");
+  });
+
+  it("lets the current colour win over an answer already given", () => {
+    render(<ProgressSegments segments={segments} currentIndex={0} label="Otázka 1 z 8" />);
+    expect(bar(0)).toHaveClass("ko:bg-text-subtle");
+    expect(bar(0)).not.toHaveClass("ko:bg-agree");
+  });
+
+  describe("the important dot", () => {
+    it("is drawn only under segments marked important", () => {
+      render(<ProgressSegments segments={segments} currentIndex={7} label="Otázka 8 z 8" />);
+      expect(dot(0)).toBeNull();
+      expect(dot(1)).not.toBeNull();
+      expect(dot(4)).not.toBeNull();
+      expect(dot(5)).not.toBeNull();
+      expect(screen.getByRole("progressbar").querySelectorAll("span")).toHaveLength(3);
+    });
+
+    it("takes the answer's colour, and stays idle before one exists", () => {
+      render(<ProgressSegments segments={segments} currentIndex={7} label="Otázka 8 z 8" />);
+      expect(dot(1)).toHaveClass("ko:bg-agree", "ko:size-1", "ko:rounded-full");
+      expect(dot(4)).toHaveClass("ko:bg-disagree");
+      expect(dot(5)).toHaveClass("ko:bg-border");
+      expect(dot(5)).not.toHaveClass("ko:bg-agree", "ko:bg-disagree");
+    });
+
+    it("drops below the taller current segment", () => {
+      render(<ProgressSegments segments={segments} currentIndex={1} label="Otázka 2 z 8" />);
+      expect(dot(1)).toHaveClass("ko:top-[14px]");
+      expect(dot(1)).not.toHaveClass("ko:top-[9px]");
+      expect(dot(4)).toHaveClass("ko:top-[9px]");
+    });
+  });
+});

--- a/packages/design-system/src/components/server/progressSegments.tsx
+++ b/packages/design-system/src/components/server/progressSegments.tsx
@@ -1,0 +1,111 @@
+// Ported from kalkulacka-2026/packages/ui/src/progress-segments/progress-segments.tsx and progress-segments.module.css
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { cva } from "class-variance-authority";
+
+/** How a single question reads in the progress bar. */
+export type SegmentState = "unanswered" | "agree" | "disagree" | "skipped";
+
+export type Segment = {
+  state: SegmentState;
+  /** Marked "pro mě důležité" — shown as a dot under the segment. */
+  important?: boolean;
+};
+
+export type ProgressSegmentsProps = {
+  segments: Segment[];
+  /** Index of the question currently on screen. */
+  currentIndex: number;
+  /** Accessible label, e.g. "Otázka 3 ze 42". Supplied by the caller. */
+  label: string;
+};
+
+/* Fixed height so the enlarged current segment does not shift the layout. */
+const trackClasses = "ko:flex ko:items-start ko:gap-[3px] ko:h-[17px]";
+
+const segmentClasses = "ko:relative ko:flex-1 ko:min-w-0";
+
+/**
+ * The bar itself. Idle is the border colour; the question being answered
+ * right now reads as a taller segment in the subtle text colour, and pops in
+ * on a keyframe that reduced motion switches off.
+ */
+export const ProgressSegmentBarVariants = cva(
+  ["ko:h-1.5 ko:rounded-[3px] ko:bg-border", "ko:transition-[height,background-color] ko:duration-[var(--ko-duration-slow),var(--ko-duration-base)] ko:ease-[ease]"],
+  {
+    variants: {
+      state: {
+        unanswered: "",
+        skipped: "",
+        agree: "ko:bg-agree",
+        disagree: "ko:bg-disagree",
+      },
+      current: {
+        true: "ko:h-[11px] ko:rounded-[5.5px] ko:bg-text-subtle ko:origin-center ko:animate-segment-pop ko:motion-reduce:animate-none",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      state: "unanswered",
+      current: false,
+    },
+  },
+);
+
+/*
+ * "Pro mě důležité" — a dot below the segment. Idle-coloured by default (it
+ * can be armed before an answer exists, and while skipped), then recoloured to
+ * match the bar once an actual position is taken.
+ */
+export const ProgressSegmentDotVariants = cva(
+  ["ko:absolute ko:top-[9px] ko:left-1/2 ko:-translate-x-1/2 ko:size-1 ko:rounded-full ko:bg-border", "ko:transition-[background-color] ko:duration-[var(--ko-duration-base)] ko:ease-[ease]"],
+  {
+    variants: {
+      state: {
+        unanswered: "",
+        skipped: "",
+        agree: "ko:bg-agree",
+        disagree: "ko:bg-disagree",
+      },
+      current: {
+        true: "ko:top-[14px]",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      state: "unanswered",
+      current: false,
+    },
+  },
+);
+
+/**
+ * One segment per question, coloured by the answer given.
+ *
+ * Presentational only — it takes an already-derived list rather than answers,
+ * so the mapping from domain answers to visual state stays testable in the app.
+ *
+ * `skipped` reads identically to `unanswered` here — an idle bar, not a third
+ * colour. The bar is a progress readout ("how much is decided"), and a skip is
+ * not a decision; filling it in would overstate what's actually been settled.
+ * `Přeskočit` still exists as an affordance elsewhere (the nav button fills
+ * when a question was explicitly passed over) — only this bar declines to draw
+ * the distinction.
+ */
+export function ProgressSegments({ segments, currentIndex, label }: ProgressSegmentsProps) {
+  return (
+    <div className={trackClasses} role="progressbar" aria-label={label} aria-valuemin={1} aria-valuemax={segments.length} aria-valuenow={currentIndex + 1}>
+      {segments.map((segment, index) => {
+        const current = index === currentIndex;
+
+        return (
+          // biome-ignore lint/suspicious/noArrayIndexKey: segments are a fixed positional list.
+          <div key={index} className={segmentClasses} aria-hidden="true">
+            <div className={twMerge(ProgressSegmentBarVariants({ state: segment.state, current }))} />
+            {segment.important ? <span className={twMerge(ProgressSegmentDotVariants({ state: segment.state, current }))} /> : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/design-system/src/styles.css
+++ b/packages/design-system/src/styles.css
@@ -292,6 +292,24 @@
   --ease-spring: var(--ko-motion-easing-spring, cubic-bezier(0.2, 0.9, 0.3, 1));
   --ease-exit: var(--ko-motion-easing-exit, cubic-bezier(0.3, 0.6, 0.4, 1));
 
+  /*
+   * The progress bar's current segment popping in (`ProgressSegments`). A
+   * theme animation so it is one `ko:animate-segment-pop` utility, which
+   * `ko:motion-reduce:animate-none` can switch off.
+   */
+  --animate-segment-pop: ko-segment-pop var(--ko-duration-slow) var(--ko-ease-spring);
+
+  @keyframes ko-segment-pop {
+    0% {
+      transform: scaleY(0.4);
+      opacity: 0.3;
+    }
+    100% {
+      transform: scaleY(1);
+      opacity: 1;
+    }
+  }
+
   /* Elevation, tinted with the neutral so shadows belong to the theme. */
   --shadow-card: 0 4px 12px -2px oklch(from var(--ko-shadow-color) l c h / 0.1), 0 16px 36px -8px oklch(from var(--ko-shadow-color) l c h / 0.18);
   --shadow-card-next: 0 2px 8px -2px oklch(from var(--ko-shadow-color) l c h / 0.08), 0 10px 24px -6px oklch(from var(--ko-shadow-color) l c h / 0.14);
@@ -987,6 +1005,159 @@
     .ko-question-card-important:hover .ko-question-card-tooltip,
     .ko-question-card-important:focus-visible .ko-question-card-tooltip {
       transform: none;
+    }
+  }
+
+  /* --- QuestionDeck ----------------------------------------------------------
+   * Ported from kalkulacka-2026/packages/ui/src/question-deck/question-deck.module.css.
+   *
+   * The static arrangement of the deck's layers. Everything that moves — the
+   * drag, the stack rising to the front, the ghost's flight, the spring back —
+   * is written as inline `style` by `useSwipeDeck` (that is how the source
+   * works, and a drag cannot afford a React render per pointer move), so what
+   * lives here is only where each layer rests before a script touches it and
+   * the order they paint in.
+   *
+   * The z-index stack, in the 2026 `--vk-z-*` values: back 1, next 2, the
+   * active card 3, the ghost 4, the toast 6.
+   */
+  .ko-deck {
+    position: relative;
+    width: 100%;
+    height: 100%;
+
+    /*
+     * Also what makes the deck the containing block for its fixed-position
+     * toast — see `.ko-deck-toast` before removing this.
+     */
+    container-type: inline-size;
+    container-name: deck;
+  }
+
+  .ko-deck-layer {
+    position: absolute;
+    inset: 0;
+    transform-origin: 50% 50%;
+  }
+
+  .ko-deck-back {
+    z-index: 1;
+    transform: translate(0px, -60px) scale(0.88);
+    filter: brightness(0.95);
+    opacity: 1;
+  }
+
+  .ko-deck-next {
+    z-index: 2;
+    transform: translate(0px, -32px) scale(0.94);
+    filter: brightness(0.98);
+    opacity: 1;
+    pointer-events: none;
+  }
+
+  /*
+   * The drag surface: the card under the reader's hand. `touch-action: none`
+   * so the browser never claims a swipe for scrolling once it has started on
+   * the card; the card's own `interactive` variant says the same, this is the
+   * deck's guarantee regardless.
+   */
+  .ko-deck-active {
+    z-index: 3;
+    touch-action: none;
+    transform-origin: 50% 50%;
+  }
+
+  /* The copy of the just-answered card, mid-flight. */
+  .ko-deck-ghost {
+    z-index: 4;
+    pointer-events: none;
+    transform-origin: 50% 50%;
+  }
+
+  /*
+   * The drag hint.
+   *
+   * `fixed`, but resolved against the deck, not the viewport: `.ko-deck` sets
+   * `container-type`, which makes it the containing block for its
+   * fixed-position descendants. That is deliberate — it parks the toast over
+   * the bottom of the card, right where the eye already is mid-drag, instead of
+   * at the foot of the screen under the sticky bar. Anything that removes
+   * containment from `.ko-deck` will silently move this to the viewport edge.
+   *
+   * The deck's heaviest elevation, on the smallest thing that uses it. The
+   * toast lands directly over the sticky action bar and the card's own answer
+   * buttons — solid fill alone left it reading as another button in that
+   * stack rather than as something floating above it, and the one thing that
+   * separates a layer from the layer below is the shadow it casts on it.
+   *
+   * Wraps rather than overflows. It used to be `nowrap`, which was safe only
+   * because the longest string it could hold was the compact "Ne · Pro mě
+   * důležité"; now that it always spells the answer out, "Nesouhlasím · Pro
+   * mě důležité" clears a 375px screen but not a 320px one, and a clipped
+   * toast is a worse answer than a two-line one.
+   *
+   * Capped against the viewport rather than with a `%`, which would resolve
+   * against the deck — the container that captures this element's
+   * positioning, and on a phone narrower than the room the toast really has.
+   * No `text-wrap: balance` either: balancing a pill that is one line in the
+   * common case only ever fires when it wraps, and there it traded two full
+   * lines for four short ones.
+   *
+   * `width: max-content` is what makes the cap the thing that decides. Left
+   * to shrink-to-fit, an absolutely-placed box offset by `left: 50%` gets
+   * only the half of its containing block to the right of that offset — so
+   * the toast wrapped against half a card's width and never reached the cap
+   * at all. `nowrap` used to hide that by overflowing straight through it.
+   */
+  .ko-deck-toast {
+    position: fixed;
+    left: 50%;
+    bottom: calc(env(safe-area-inset-bottom, 0px) + 1.5rem);
+    z-index: 6;
+
+    padding: 0.875rem 1.75rem;
+    border-radius: var(--ko-radius-pill);
+    background: var(--ko-color-neutral-ink);
+    color: var(--ko-color-on-neutral-ink);
+    box-shadow: var(--ko-shadow-card-lifted);
+
+    font-family: var(--ko-font-sans);
+    font-size: 1.0625rem;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    width: max-content;
+    max-width: min(100vw - 2rem, 22rem);
+    text-align: center;
+
+    pointer-events: none;
+    opacity: 0;
+    transform: translateX(-50%) translateY(8px) scale(0.92);
+    transition:
+      opacity 0.22s ease,
+      transform 0.22s var(--ko-ease-spring);
+  }
+
+  .ko-deck-toast-visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+
+  /*
+   * The toast's timings are literals rather than `--ko-duration-*` — they were
+   * measured against the drag's own feel, not the app's control tempo — so
+   * the blanket reduction in @layer base does not reach them and this has to
+   * say it. The pill still appears and still says what releasing would do; it
+   * just arrives instead of rising into place, which matters when it is being
+   * read out of the corner of an eye that is following a moving card.
+   */
+  @media (prefers-reduced-motion: reduce) {
+    .ko-deck-toast {
+      transition: none;
+      transform: translateX(-50%);
+    }
+
+    .ko-deck-toast-visible {
+      transform: translateX(-50%);
     }
   }
 

--- a/packages/design-system/src/utilities/index.ts
+++ b/packages/design-system/src/utilities/index.ts
@@ -1,1 +1,2 @@
+export * from "./prefersReducedMotion";
 export * from "./tailwind";

--- a/packages/design-system/src/utilities/prefersReducedMotion.ts
+++ b/packages/design-system/src/utilities/prefersReducedMotion.ts
@@ -1,0 +1,22 @@
+// Ported from kalkulacka-2026/packages/ui/src/prefers-reduced-motion.ts
+
+/**
+ * Whether the reader has asked their system for less movement.
+ *
+ * Most of this design system honours `prefers-reduced-motion` without asking:
+ * `styles.css` collapses the duration tokens to nothing under the query, so
+ * every transition written in terms of them is already still. This is for the
+ * handful of animations that are driven from JavaScript instead — the card deck
+ * writes its own `transition` strings as a swipe commits — where there is no
+ * token to collapse and the preference has to be read.
+ *
+ * Read at the moment an animation is about to start rather than cached: the
+ * preference can change while the page is open, and every caller is in an event
+ * handler or an effect rather than in render, so there is no hydration mismatch
+ * to worry about. `false` where there is no `window` — the server, which paints
+ * nothing that moves.
+ */
+export function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}


### PR DESCRIPTION
Part 7 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #519. **Checkpoint C2 (Storybook).**

The core interaction of the product, ported from `kalkulacka-2026/packages/ui/src/{question-deck,drag-guides,progress-segments}` with its behaviour intact:

- **`QuestionDeck`**: zone resolution (skip is tested first and must dominate, so a sloppy diagonal still registers as the answer intended; left is Ano), every constant in `swipe-physics.ts` (verbatim, with its tests), the ghost card that flies out on commit while the real card snaps back already showing the next question, the two-step hold when an answer is *changed*, the flick / tap / instant speeds, the drag preview lighting the buttons, the `finished` freeze, reduced motion collapsing the fly-out and spring-back but never the drag itself, the polite live region, arrow-key shortcuts that ignore form fields and modifiers, and `ref.advance()`.
- **`DragGuides`**: the five-pill compass around the practice card (icon-only on touch, split and labelled on a mouse; practised directions fade, the active one fills).
- **`ProgressSegments`**: one segment per question, skipped reads as unanswered, important questions get a dot. `SteppedProgressBar` is left alone; its generic API cannot carry these states without breaking its tests.

Styling rule applied: transforms the gesture hook computes stay inline; static stage/layer/ghost/toast rules live in `styles.css` under `@layer components`.

Verified in Storybook with real mouse drags in all four directions, held drags below the threshold (spring back, no ghost), arrow keys (clear in place, slow flight, the switch hold), `advance()`, `finished`, touch emulation at 375 px, and reduced motion. 53 new tests.

**Checks:** typecheck, lint, tests (design-system 252), design-system and Storybook builds.

**Stack:** based on #519 → next: `port/08-flow-nav`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
