### PR TITLE
Add FlowNav and KeyboardHints

### DIFF
--- a/apps/design-system.kalkulacka.one/stories/FlowNav.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/FlowNav.stories.tsx
@@ -1,0 +1,119 @@
+// Ported from kalkulacka-2026/packages/ui/src/flow-nav/flow-nav.stories.tsx
+import { FlowNav } from "@kalkulacka-one/design-system/client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useState } from "react";
+
+/**
+ * The row sits under the deck's stage in the app, so the stories give it the
+ * same width — the three columns only read as "edges and a centre" when there
+ * is a card's width to span.
+ */
+const meta: Meta<typeof FlowNav> = {
+  title: "Components/FlowNav",
+  component: FlowNav,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  args: {
+    position: 3,
+    total: 42,
+    canGoBack: true,
+    previousLabel: "Předchozí",
+    forwardLabel: "Přeskočit",
+    counterLabel: "Otázka 3 ze 42",
+    isSkipped: false,
+    attention: false,
+    onPrevious: () => {},
+    onForward: () => {},
+  },
+  argTypes: {
+    position: { control: { type: "number", min: 1 } },
+    total: { control: { type: "number", min: 1 } },
+    canGoBack: { control: "boolean" },
+    isSkipped: { control: "boolean" },
+    attention: { control: "boolean" },
+    previousLabel: { control: "text" },
+    forwardLabel: { control: "text" },
+    counterLabel: { control: "text" },
+    onPrevious: { control: false },
+    onForward: { control: false },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "min(90vw, 34rem)" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+type FlowNavStory = StoryObj<typeof meta>;
+
+/** Nothing answered yet, so the forward control offers to skip. */
+export const Default: FlowNavStory = {};
+
+/**
+ * On the first question "back" leads to the tutorial rather than a previous
+ * card, and the app labels it so — the row keeps its shape whatever the label.
+ */
+export const FirstQuestion: FlowNavStory = {
+  args: { position: 1, previousLabel: "Návod", counterLabel: "Otázka 1 ze 42" },
+};
+
+/** Once an answer exists the forward control reads "Další" instead. */
+export const Answered: FlowNavStory = {
+  args: { forwardLabel: "Další" },
+};
+
+/** A question that was explicitly skipped keeps the control filled, as a reminder. */
+export const Skipped: FlowNavStory = {
+  args: { isSkipped: true },
+};
+
+/**
+ * Right after re-tapping an answer clears it: the same fill, arriving with a
+ * one-shot pulse so it is noticed — a nudge toward "Přeskočit" for a question
+ * that is unexpectedly unanswered again. Transient in the app (it resets when
+ * the card changes); the button below re-mounts the row to play it again.
+ */
+export const Attention: FlowNavStory = {
+  args: { attention: true },
+  render: function AttentionStory(args) {
+    const [take, setTake] = useState(0);
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "1rem", alignItems: "center" }}>
+        <div style={{ width: "100%" }}>
+          <FlowNav key={take} {...args} />
+        </div>
+        <button
+          type="button"
+          onClick={() => setTake((n) => n + 1)}
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "var(--ko-radius-pill)",
+            border: "1.5px solid var(--ko-color-border)",
+            background: "var(--ko-color-surface)",
+            color: "var(--ko-color-text)",
+            cursor: "pointer",
+            fontFamily: "var(--ko-font-sans)",
+            fontSize: "0.875rem",
+          }}
+        >
+          Přehrát znovu
+        </button>
+      </div>
+    );
+  },
+};
+
+/** The last question: the counter reaches the total, and forward leads out of the flow. */
+export const LastQuestion: FlowNavStory = {
+  args: { position: 42, forwardLabel: "Další", counterLabel: "Otázka 42 ze 42" },
+};
+
+/** Nowhere back to go — the control is disabled rather than removed, so the counter stays put. */
+export const CannotGoBack: FlowNavStory = {
+  args: { position: 1, canGoBack: false, counterLabel: "Otázka 1 ze 42" },
+};
+
+export default meta;

--- a/apps/design-system.kalkulacka.one/stories/KeyboardHints.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/KeyboardHints.stories.tsx
@@ -1,0 +1,58 @@
+// Ported from kalkulacka-2026/packages/ui/src/keyboard-hints/keyboard-hints.stories.tsx
+import { icons } from "@kalkulacka-one/design-system/icons";
+import { type KeyboardHint, KeyboardHints } from "@kalkulacka-one/design-system/server";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+/*
+ * The five hints the question flow shows. Left and right get a hint each
+ * rather than one shared "odpovědět": which arrow means "souhlasím" is the
+ * one thing about this shortcut a first-time user cannot guess, and the
+ * paired row also matches the left/right order of the answer buttons on the
+ * card.
+ */
+const flowHints: KeyboardHint[] = [
+  { keys: [{ icon: icons.arrowLeft, label: "Šipka vlevo" }], label: "Ano" },
+  { keys: [{ icon: icons.arrowRight, label: "Šipka vpravo" }], label: "Ne" },
+  { keys: [{ icon: icons.arrowUp, label: "Šipka nahoru" }], label: "Důležité" },
+  { keys: [{ icon: icons.arrowDown, label: "Šipka dolů" }], label: "Přeskočit" },
+  {
+    keys: [
+      { icon: icons.comma, label: "Čárka" },
+      { icon: icons.period, label: "Tečka" },
+    ],
+    label: "Procházet bez odpovědi",
+  },
+];
+
+/**
+ * Hidden below the `desk` breakpoint (53.75rem / 860px) by design — there is
+ * no keyboard to hint at on a phone. Widen the canvas to see it.
+ */
+const meta: Meta<typeof KeyboardHints> = {
+  title: "Components/KeyboardHints",
+  component: KeyboardHints,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  args: { hints: flowHints },
+  argTypes: {
+    hints: { control: "object" },
+  },
+};
+
+type KeyboardHintsStory = StoryObj<typeof meta>;
+
+/** The question flow's row: four arrows, then the comma and period pair for browsing without answering. */
+export const Default: KeyboardHintsStory = {};
+
+/** Caps can also be literal text — the same browsing pair spelled as characters. */
+export const TextKeys: KeyboardHintsStory = {
+  args: {
+    hints: [
+      { keys: [",", "."], label: "Procházet bez odpovědi" },
+      { keys: ["Esc"], label: "Zavřít" },
+    ],
+  },
+};
+
+export default meta;

--- a/packages/design-system/src/components/client/flowNav.test.tsx
+++ b/packages/design-system/src/components/client/flowNav.test.tsx
@@ -1,0 +1,185 @@
+// Ported from kalkulacka-2026/packages/ui/src/flow-nav/flow-nav.tsx (the 2026 package carried no tests for it)
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { icons } from "../icons";
+import { ButtonVariants } from "./button";
+import { FlowNav, FlowNavButtonVariants, type FlowNavProps } from "./flowNav";
+
+const base: FlowNavProps = {
+  position: 3,
+  total: 42,
+  canGoBack: true,
+  previousLabel: "Předchozí",
+  forwardLabel: "Přeskočit",
+  counterLabel: "Otázka 3 ze 42",
+  onPrevious: () => {},
+  onForward: () => {},
+};
+
+const filled = ["ko:bg-neutral-ink", "ko:text-on-neutral-ink", "ko:data-hover:bg-neutral-ink/90", "ko:data-active:bg-neutral-ink/80"];
+
+const classesOf = (...args: Parameters<typeof FlowNavButtonVariants>) => twMerge(FlowNavButtonVariants(...args)).split(" ");
+
+function previous() {
+  return screen.getByRole("button", { name: "Předchozí" });
+}
+
+function forward(name = "Přeskočit") {
+  return screen.getByRole("button", { name });
+}
+
+function paths(element: HTMLElement) {
+  return Array.from(element.querySelectorAll("path")).map((path) => path.getAttribute("d"));
+}
+
+describe("FlowNav", () => {
+  it("is a nav row at the fluid nav height with the counter in a centred middle column", () => {
+    render(<FlowNav {...base} />);
+    const nav = screen.getByRole("navigation");
+    expect(nav).toHaveClass("ko:grid", "ko:grid-cols-[1fr_auto_1fr]", "ko:items-center", "ko:h-fluid-nav", "ko:flex-none");
+    expect(nav.children).toHaveLength(3);
+    expect(nav.children[1]).toHaveClass("ko:justify-self-center");
+  });
+
+  it("labels both controls and wires their callbacks", () => {
+    const onPrevious = vi.fn();
+    const onForward = vi.fn();
+    render(<FlowNav {...base} onPrevious={onPrevious} onForward={onForward} />);
+
+    fireEvent.click(previous());
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+    expect(onForward).not.toHaveBeenCalled();
+
+    fireEvent.click(forward());
+    expect(onForward).toHaveBeenCalledTimes(1);
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads the forward control as whatever the caller says it does", () => {
+    render(<FlowNav {...base} forwardLabel="Další" />);
+    expect(forward("Další")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Přeskočit" })).toBeNull();
+  });
+
+  describe("the previous control", () => {
+    it("is disabled, not hidden, when there is nowhere back to go", () => {
+      const onPrevious = vi.fn();
+      render(<FlowNav {...base} canGoBack={false} onPrevious={onPrevious} />);
+      const button = previous();
+      expect(button).toBeDisabled();
+      expect(button).toBeVisible();
+      fireEvent.click(button);
+      expect(onPrevious).not.toHaveBeenCalled();
+    });
+
+    it("is enabled when it can go back", () => {
+      render(<FlowNav {...base} />);
+      expect(previous()).toBeEnabled();
+    });
+
+    it("carries the thin left chevron before its label, decoratively", () => {
+      render(<FlowNav {...base} />);
+      const button = previous();
+      expect(paths(button)).toEqual([...icons.chevronLeftThin.paths]);
+      const icon = button.querySelector("svg");
+      expect(icon).toHaveAttribute("aria-hidden", "true");
+      expect(icon?.nextElementSibling).toHaveTextContent("Předchozí");
+    });
+  });
+
+  describe("the forward control", () => {
+    it("carries the thin right chevron after its label, decoratively", () => {
+      render(<FlowNav {...base} />);
+      const button = forward();
+      expect(paths(button)).toEqual([...icons.chevronRightThin.paths]);
+      const icon = button.querySelector("svg");
+      expect(icon).toHaveAttribute("aria-hidden", "true");
+      expect(icon?.previousElementSibling).toHaveTextContent("Přeskočit");
+    });
+
+    it("rests as a ghost pill", () => {
+      render(<FlowNav {...base} />);
+      const button = forward();
+      expect(button).toHaveClass("ko:bg-transparent", "ko:data-hover:bg-neutral-wash", "ko:rounded-pill", "ko:justify-self-end", "ko:-mr-3.5");
+      expect(button).not.toHaveClass(...filled);
+    });
+
+    it("stays filled while the question is explicitly skipped", () => {
+      render(<FlowNav {...base} isSkipped />);
+      const button = forward();
+      expect(button).toHaveClass(...filled);
+      expect(button).not.toHaveClass("ko:bg-transparent", "ko:text-neutral-ink", "ko:data-hover:bg-neutral-wash");
+      expect(previous()).not.toHaveClass(...filled);
+    });
+
+    it("fills like skipped when the answer was just cleared (2026 styles the two identically)", () => {
+      render(<FlowNav {...base} attention />);
+      const button = forward();
+      expect(button).toHaveClass(...filled);
+      expect(button).not.toHaveClass("ko:bg-transparent");
+    });
+
+    it("can be both skipped and nudged at once", () => {
+      render(<FlowNav {...base} isSkipped attention />);
+      expect(forward()).toHaveClass(...filled);
+    });
+  });
+
+  describe("the counter", () => {
+    it("speaks the caller's sentence and hides the digits", () => {
+      render(<FlowNav {...base} />);
+      const spoken = screen.getByText("Otázka 3 ze 42");
+      expect(spoken).toHaveClass("ko:sr-only");
+      expect(spoken).not.toHaveAttribute("aria-hidden");
+
+      const digits = screen.getByText("3").parentElement;
+      expect(digits).toHaveAttribute("aria-hidden", "true");
+      expect(digits).toHaveTextContent("3/42");
+    });
+
+    it("emphasises the position in tabular figures", () => {
+      render(<FlowNav {...base} position={12} total={42} />);
+      const position = screen.getByText("12");
+      expect(position.tagName).toBe("STRONG");
+      expect(position).toHaveClass("ko:font-bold", "ko:text-text-strong");
+      const counter = position.closest("p");
+      expect(counter).toHaveClass("ko:tabular-nums", "ko:text-text-subtle", "ko:text-[1.0625rem]");
+    });
+  });
+
+  describe("FlowNavButtonVariants", () => {
+    it("starts from Button's small ghost pill", () => {
+      const ghost = twMerge(ButtonVariants({ variant: "ghost", size: "small" })).split(" ");
+      /* Everything the pill brings, minus what the nav overrides: its spacing, type, and the 45% disabled fade. */
+      const kept = ghost.filter((cls) => !/^ko:(px|py|text|font)-/.test(cls) && cls !== "ko:data-disabled:opacity-45");
+      expect(kept).toEqual(expect.arrayContaining(["ko:rounded-pill", "ko:bg-transparent", "ko:data-hover:bg-neutral-wash", "ko:data-active:scale-[0.97]", "ko:data-focus:outline-3"]));
+      expect(classesOf({ placement: "forward" })).toEqual(expect.arrayContaining(kept));
+    });
+
+    it("takes the source's spacing and type over the pill's own", () => {
+      const classes = classesOf({ placement: "previous" });
+      expect(classes).toEqual(expect.arrayContaining(["ko:px-3.5", "ko:py-[0.4375rem]", "ko:text-[1.0625rem]", "ko:font-bold", "ko:text-neutral-ink", "ko:justify-self-start", "ko:-ml-3.5"]));
+      expect(classes).not.toContain("ko:px-4");
+      expect(classes).not.toContain("ko:py-2");
+      expect(classes).not.toContain("ko:text-sm");
+      expect(classes).not.toContain("ko:font-semibold");
+      expect(classes).not.toContain("ko:text-text");
+    });
+
+    it("reads disabled in the subtle colour at full opacity", () => {
+      const classes = classesOf({ placement: "previous" });
+      expect(classes).toEqual(expect.arrayContaining(["ko:data-disabled:text-text-subtle", "ko:data-disabled:opacity-100", "ko:data-disabled:cursor-default"]));
+      expect(classes).not.toContain("ko:data-disabled:opacity-45");
+    });
+
+    it("fills the skipped state with the solid neutral", () => {
+      const classes = classesOf({ placement: "forward", skipped: true });
+      expect(classes).toEqual(expect.arrayContaining(filled));
+      expect(classes).not.toContain("ko:bg-transparent");
+      expect(classes).not.toContain("ko:data-hover:bg-neutral-wash");
+    });
+  });
+});

--- a/packages/design-system/src/components/client/flowNav.tsx
+++ b/packages/design-system/src/components/client/flowNav.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// Ported from kalkulacka-2026/packages/ui/src/flow-nav/flow-nav.tsx and flow-nav.module.css
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { Button as ButtonHeadless } from "@headlessui/react";
+import { cva } from "class-variance-authority";
+
+import { icons } from "../icons";
+import { VisuallyHidden } from "../server/visuallyHidden";
+import { ButtonVariants } from "./button";
+import { Icon } from "./icon";
+
+export type FlowNavProps = {
+  /** 1-based position of the question on screen. */
+  position: number;
+  total: number;
+  onPrevious: () => void;
+  /** Advances — skipping the question if it has no answer yet. */
+  onForward: () => void;
+  canGoBack: boolean;
+  /**
+   * The forward control reads as "Další" once an answer exists and
+   * "Přeskočit" while it does not.
+   */
+  forwardLabel: string;
+  previousLabel: string;
+  /** Highlight the control because this question was explicitly skipped. */
+  isSkipped?: boolean;
+  /**
+   * Highlight the control because the answer was just cleared — re-tapping an
+   * already-chosen position, which leaves the question unanswered again right
+   * as someone is looking at it. A transient nudge toward "Přeskočit" rather
+   * than `isSkipped`'s persisted state.
+   */
+  attention?: boolean;
+  /** e.g. "Otázka 3 ze 42", for assistive tech. */
+  counterLabel: string;
+};
+
+/*
+ * `flex: none` in the flow's column, which must never scroll. Three columns
+ * with the middle one sized to its content, so the counter is centred on the
+ * row itself and not between two labels of unequal width ("Návod" on the
+ * first question is a good deal shorter than "Předchozí").
+ */
+const navClasses = "ko:flex-none ko:grid ko:grid-cols-[1fr_auto_1fr] ko:items-center ko:h-fluid-nav";
+
+/**
+ * The two controls, either side of the counter.
+ *
+ * Built on `Button`'s ghost pill — its hover wash, press, focus ring,
+ * transition and disabled handling — at the nav's own spacing and type: the
+ * 2026 "lead" size (1.0625rem), bold, in the neutral ink rather than the body
+ * text. The pill's horizontal padding is cancelled by a negative margin on the
+ * outer side, so the *label* lines up with the card's edge above and the
+ * pill's wash overhangs it on hover; the counter has no such wash and stays
+ * where it is.
+ */
+export const FlowNavButtonVariants = cva(
+  [
+    ButtonVariants({ variant: "ghost", size: "small" }),
+    "ko:px-3.5 ko:py-[0.4375rem]",
+    "ko:text-neutral-ink ko:text-[1.0625rem] ko:font-bold",
+    /*
+     * The source's disabled look: the subtle text colour at full opacity, not
+     * `Button`'s 45% fade — a faded bold label next to a strong counter read
+     * as broken, where a quieter colour reads as "nowhere to go".
+     */
+    "ko:data-disabled:text-text-subtle ko:data-disabled:opacity-100",
+  ],
+  {
+    variants: {
+      placement: {
+        previous: "ko:justify-self-start ko:-ml-3.5",
+        forward: "ko:justify-self-end ko:-mr-3.5",
+      },
+      /*
+       * An explicitly skipped question keeps the control filled, as a
+       * reminder — the same solid neutral `Button` uses, and the same fill
+       * `DragGuides` lights the pill a drag is pointing at with.
+       */
+      skipped: {
+        true: "ko:bg-neutral-ink ko:text-on-neutral-ink ko:data-hover:bg-neutral-ink/90 ko:data-active:bg-neutral-ink/80",
+        false: "",
+      },
+    },
+    defaultVariants: {
+      skipped: false,
+    },
+  },
+);
+
+/* The lead size again, in the subtle colour, so the numbers sit as quietly as the labels either side are loud. */
+const counterClasses = "ko:justify-self-center ko:m-0 ko:font-sans ko:text-[1.0625rem] ko:tracking-[-0.01em] ko:text-text-subtle ko:tabular-nums";
+
+const positionClasses = "ko:font-bold ko:text-text-strong";
+
+/**
+ * The row under the deck: back, the counter, forward.
+ *
+ * "Forward" rather than "next" because it does two jobs — advancing past an
+ * answered question and skipping an unanswered one — and the caller passes
+ * whichever label is true right now. The counter is drawn as digits and read
+ * as a sentence: the visible `3/42` is `aria-hidden` and `counterLabel`
+ * carries the spoken form, so a screen reader hears "Otázka 3 ze 42" rather
+ * than "three slash forty-two".
+ */
+export function FlowNav({ position, total, onPrevious, onForward, canGoBack, forwardLabel, previousLabel, isSkipped = false, attention = false, counterLabel }: FlowNavProps) {
+  return (
+    <nav className={navClasses}>
+      {/* Disabled rather than hidden at the start: the row keeps its shape, and the counter stays centred. */}
+      <ButtonHeadless type="button" className={twMerge(FlowNavButtonVariants({ placement: "previous" }))} onClick={onPrevious} disabled={!canGoBack}>
+        <Icon icon={icons.chevronLeftThin} size="xsmall" decorative />
+        <span>{previousLabel}</span>
+      </ButtonHeadless>
+
+      <p className={counterClasses}>
+        <VisuallyHidden>{counterLabel}</VisuallyHidden>
+        <span aria-hidden="true">
+          <strong className={positionClasses}>{position}</strong>/{total}
+        </span>
+      </p>
+
+      <ButtonHeadless type="button" className={twMerge(FlowNavButtonVariants({ placement: "forward", skipped: isSkipped || attention }))} onClick={onForward}>
+        <span>{forwardLabel}</span>
+        <Icon icon={icons.chevronRightThin} size="xsmall" decorative />
+      </ButtonHeadless>
+    </nav>
+  );
+}

--- a/packages/design-system/src/components/client/index.ts
+++ b/packages/design-system/src/components/client/index.ts
@@ -6,6 +6,7 @@ export * from "./description";
 export * from "./dragGuides";
 export * from "./expandableCard";
 export * from "./field";
+export * from "./flowNav";
 export * from "./icon";
 export * from "./icon-button";
 export * from "./input";

--- a/packages/design-system/src/components/server/index.ts
+++ b/packages/design-system/src/components/server/index.ts
@@ -8,6 +8,7 @@ export * from "./chip";
 export * from "./dotIndicator";
 export * from "./edgeFade";
 export * from "./iconBadge";
+export * from "./keyboardHints";
 export * from "./progressBar";
 export * from "./progressSegments";
 export * from "./screen";

--- a/packages/design-system/src/components/server/keyboardHints.test.tsx
+++ b/packages/design-system/src/components/server/keyboardHints.test.tsx
@@ -1,0 +1,88 @@
+// Ported from kalkulacka-2026/packages/ui/src/keyboard-hints/keyboard-hints.tsx (the 2026 package carried no tests for it)
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { icons } from "../icons";
+import { type KeyboardHint, KeyboardHints } from "./keyboardHints";
+
+/* The five hints the question flow shows. */
+const hints: KeyboardHint[] = [
+  { keys: [{ icon: icons.arrowLeft, label: "Šipka vlevo" }], label: "Ano" },
+  { keys: [{ icon: icons.arrowRight, label: "Šipka vpravo" }], label: "Ne" },
+  { keys: [{ icon: icons.arrowUp, label: "Šipka nahoru" }], label: "Důležité" },
+  { keys: [{ icon: icons.arrowDown, label: "Šipka dolů" }], label: "Přeskočit" },
+  { keys: [",", "."], label: "Procházet bez odpovědi" },
+];
+
+function caps(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>("kbd"));
+}
+
+function paths(element: HTMLElement) {
+  return Array.from(element.querySelectorAll("path")).map((path) => path.getAttribute("d"));
+}
+
+describe("KeyboardHints", () => {
+  it("lists every hint with its label", () => {
+    const { container } = render(<KeyboardHints hints={hints} />);
+    expect(container.firstElementChild?.children).toHaveLength(hints.length);
+    for (const hint of hints) {
+      expect(container).toHaveTextContent(hint.label);
+    }
+  });
+
+  it("draws one <kbd> cap per key, in order", () => {
+    const { container } = render(<KeyboardHints hints={hints} />);
+    expect(caps(container)).toHaveLength(6);
+    const [comma, period] = caps(container).slice(-2);
+    expect(comma).toHaveTextContent(",");
+    expect(period).toHaveTextContent(".");
+    expect(comma?.parentElement).toBe(period?.parentElement);
+  });
+
+  it("draws an icon key as the icon, named for a screen reader", () => {
+    const { container } = render(<KeyboardHints hints={hints} />);
+    const left = screen.getByRole("img", { name: "Šipka vlevo" });
+    expect(left.closest("kbd")).not.toBeNull();
+    expect(paths(left.closest("kbd") as HTMLElement)).toEqual([...icons.arrowLeft.paths]);
+    expect(screen.getByRole("img", { name: "Šipka dolů" })).toBeInTheDocument();
+    expect(screen.getAllByRole("img")).toHaveLength(4);
+  });
+
+  it("accepts a raw path as an icon key", () => {
+    const { container } = render(<KeyboardHints hints={[{ keys: [{ icon: "M4 4 L20 20", label: "Enter" }], label: "Potvrdit" }]} />);
+    expect(screen.getByRole("img", { name: "Enter" })).toBeInTheDocument();
+    expect(paths(container)).toEqual(["M4 4 L20 20"]);
+  });
+
+  it("styles a cap as a small surface tile with a hairline inset border", () => {
+    const { container } = render(<KeyboardHints hints={hints} />);
+    for (const cap of caps(container)) {
+      expect(cap).toHaveClass(
+        "ko:inline-flex",
+        "ko:min-w-6",
+        "ko:h-6",
+        "ko:rounded-chip",
+        "ko:bg-surface",
+        "ko:shadow-[inset_0_0_0_1px_var(--ko-color-border-strong)]",
+        "ko:text-[0.8125rem]",
+        "ko:font-medium",
+        "ko:text-text",
+      );
+    }
+  });
+
+  it("is hidden below the desk breakpoint but stays in the accessibility tree", () => {
+    const { container } = render(<KeyboardHints hints={hints} />);
+    const root = container.firstElementChild;
+    expect(root).toHaveClass("ko:hidden", "ko:desk:flex", "ko:text-text-muted", "ko:text-sm");
+    expect(root).not.toHaveAttribute("aria-hidden");
+    expect(container.querySelector("[aria-hidden='true']:not(svg)")).toBeNull();
+  });
+
+  it("holds nothing interactive", () => {
+    render(<KeyboardHints hints={hints} />);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+});

--- a/packages/design-system/src/components/server/keyboardHints.tsx
+++ b/packages/design-system/src/components/server/keyboardHints.tsx
@@ -1,0 +1,84 @@
+// Ported from kalkulacka-2026/packages/ui/src/keyboard-hints/keyboard-hints.tsx and keyboard-hints.module.css
+import { Icon } from "../client/icon";
+import type { IconDefinition } from "../icons";
+
+/**
+ * A key cap: either literal text (`","`) or an icon plus the name a screen
+ * reader should read in its place. The name arrives as a prop rather than
+ * from a lookup because this package holds no strings of its own.
+ */
+export type HintKey = string | { icon: IconDefinition | string; label: string };
+
+export type KeyboardHint = {
+  /** Rendered as separate `<kbd>` caps, e.g. `[",", "."]`. */
+  keys: HintKey[];
+  label: string;
+};
+
+export type KeyboardHintsProps = {
+  hints: KeyboardHint[];
+};
+
+/*
+ * Desktop only — there's no physical keyboard to hint at on the phone-sized
+ * layout this app mostly runs at, and the row has nowhere to go on a narrow
+ * screen without crowding the nav above it. `desk` is the breakpoint where a
+ * keyboard is assumed (see the theme), the same "is there room" reasoning the
+ * answer-button labels use for their own threshold.
+ *
+ * Hidden with `display: none` rather than removed from the tree so the markup
+ * is the same at every width — only the breakpoint decides, no JavaScript.
+ */
+const hintsClasses = "ko:hidden ko:desk:flex ko:justify-center ko:flex-wrap ko:gap-x-6 ko:gap-y-2 ko:pt-4 ko:pb-2 ko:font-sans ko:text-sm ko:text-text-muted";
+
+const hintClasses = "ko:inline-flex ko:items-center ko:gap-2 ko:whitespace-nowrap";
+
+const keysClasses = "ko:inline-flex ko:gap-[0.1875rem]";
+
+/*
+ * The cap is drawn at a 1px hairline rather than the app's 1.5px border: at
+ * this size the heavier line out-shouts the 1.5-on-24 icon sitting inside it,
+ * and the cap would read louder than the arrow it contains. The chip radius,
+ * so a cap sits in the same family as the topic chip on the card above it.
+ */
+const keyClasses = [
+  "ko:inline-flex ko:items-center ko:justify-center ko:min-w-6 ko:h-6 ko:px-[0.3125rem]",
+  "ko:rounded-chip ko:bg-surface ko:shadow-[inset_0_0_0_1px_var(--ko-color-border-strong)]",
+  "ko:font-sans ko:text-[0.8125rem] ko:font-medium ko:text-text",
+].join(" ");
+
+/* Text keys are their own id; an icon key is a definition object, so its spoken name stands in. */
+function keyId(key: HintKey) {
+  return typeof key === "string" ? key : key.label;
+}
+
+/**
+ * A reference row for the keyboard shortcuts, shown only where there's both a
+ * keyboard and room for it (see the `desk` breakpoint above). Purely
+ * informational — no interactive elements, so it costs nothing in the tab
+ * order — but left in the accessibility tree rather than `aria-hidden`,
+ * since a keyboard user is exactly who benefits from it existing.
+ *
+ * An icon key is named through the icon itself (`role="img"` with its
+ * `label` as the title) rather than an `aria-label` on the `<kbd>`: a `<kbd>`
+ * has no role that accepts a name, so a label on it is the one thing here a
+ * screen reader is allowed to ignore.
+ */
+export function KeyboardHints({ hints }: KeyboardHintsProps) {
+  return (
+    <div className={hintsClasses}>
+      {hints.map((hint) => (
+        <span key={hint.label} className={hintClasses}>
+          <span className={keysClasses}>
+            {hint.keys.map((key) => (
+              <kbd key={keyId(key)} className={keyClasses}>
+                {typeof key === "string" ? key : <Icon icon={key.icon} size="xsmall" title={key.label} decorative={false} />}
+              </kbd>
+            ))}
+          </span>
+          {hint.label}
+        </span>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Part 8 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #520.

Ported from `kalkulacka-2026/packages/ui/src/{flow-nav,keyboard-hints}`:

- **`FlowNav`**: previous / counter / forward on the fluid nav height. The counter's digits are decorative and the caller's sentence ("Otázka 3 ze 42") is what screen readers get; forward reads "Další" once answered and "Přeskočit" otherwise, and takes the skipped fill both for an explicitly skipped question and for the moment an answer was just cleared (`attention`), exactly as the source styles the two.
- **`KeyboardHints`**: the `<kbd>` cap row, hidden below the `desk` breakpoint but left in the accessibility tree on purpose (the source's reasoning is kept as a comment).

Stories with the five real flow hints; 25 tests.

**Checks:** typecheck, lint, tests (design-system 276), design-system and Storybook builds.

**Stack:** based on #520 → next: `port/09-question-page` (checkpoint C3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
