### PR TITLE
Add the question page with deck, navigation and keyboard shortcuts

### DIFF
--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/question.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/question.tsx
@@ -1,11 +1,14 @@
-import { useAnswer, useAnswersStore, useCalculator, useQuestions } from "@kalkulacka-one/app/client";
+import { QuestionPage } from "@kalkulacka-one/app";
+import { useAnswersStore, useCalculator, useQuestions } from "@kalkulacka-one/app/client";
+import { IconButton } from "@kalkulacka-one/design-system/client";
+import { icons } from "@kalkulacka-one/design-system/icons";
 
 import { notFound, usePathname, useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
-import { useEffect, useReducer } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 
-import { QuestionPage as AppQuestionPage } from "@/calculator";
-import { useEmbed } from "@/components/client";
+import { HideOnEmbed, useEmbed } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
 import { useAutoSave } from "@/hooks/auto-save";
 import { saveSessionData } from "@/lib/api";
 import { reportError } from "@/lib/monitoring";
@@ -15,10 +18,18 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
   const router = useRouter();
   const pathname = usePathname();
   const calculator = useCalculator();
-  const { questions, total } = useQuestions();
+  const { questions } = useQuestions();
   const [, forceRender] = useReducer((x) => x + 1, 0);
   const locale = useLocale();
+  const embed = useEmbed();
+  const answersStore = useAnswersStore((state) => state.answers);
 
+  useAutoSave();
+
+  // The position the URL says — `current` from the route on the first render,
+  // the path itself afterwards: the page keeps it in step through
+  // `replaceState`, and `usePathname` follows that. Only the guard below and
+  // the page's initial position read it; the page owns the position from then on.
   const currentQuestion = (() => {
     try {
       return parsedParams.questionNumber(pathname);
@@ -26,18 +37,6 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
       return current;
     }
   })();
-  const question = questions[currentQuestion - 1];
-  const embed = useEmbed();
-  const answersStore = useAnswersStore((state) => state.answers);
-  const setAnswer = useAnswersStore((state) => state.setAnswer);
-
-  useAutoSave();
-
-  useEffect(() => {
-    if (question) {
-      setAnswer({ questionId: question.id });
-    }
-  }, [question, setAnswer]);
 
   useEffect(() => {
     const handlePopState = () => {
@@ -48,28 +47,47 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
     return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
-  if (!question) {
+  if (!questions[currentQuestion - 1]) {
     notFound();
   }
 
-  const handleNextClick = () => {
-    if (currentQuestion < total) {
-      const nextUrl = routes.question(segments, currentQuestion + 1, locale);
-      window.history.pushState(null, "", nextUrl);
-      forceRender();
-    } else {
-      router.push(routes.review(segments, locale));
-    }
+  // A group calculator (`snemovni-2025/kalkulacka`) is named by its group and
+  // variant keys; a standalone one by its own key. Neither carries a display
+  // name in the data, hence the config.
+  const { electionName, calculatorName } = calculatorNames({
+    group: "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined,
+    key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    fallback: calculator.title || undefined,
+  });
+
+  // In an embed the wordmark doubles as the attribution — the one way out of a
+  // partner's iframe to the full site — unless the partner opted out of it.
+  const attributionHref = embed.isEmbed && embed.config?.attribution !== false ? (process.env.NEXT_PUBLIC_CANONICAL_URL ?? "/") : undefined;
+  const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
+
+  /*
+   * The URL tracks the question so a refresh or a shared link lands in the
+   * right place — but via `replaceState` rather than a router push (or the
+   * `pushState` the previous page used). Routing on every answer would put a
+   * navigation between the swipe and the next card, which is exactly the
+   * latency this interaction cannot afford; and a history entry per question
+   * made the back button walk through every answered card before it left the
+   * flow. Next's router follows `replaceState`, so `usePathname` above stays
+   * in step.
+   */
+  const handlePositionChange = useCallback(
+    (position: number) => {
+      window.history.replaceState(null, "", routes.question(segments, position, locale));
+    },
+    [segments, locale],
+  );
+
+  const handleFinish = () => {
+    router.push(routes.review(segments, locale));
   };
 
-  const handlePreviousClick = () => {
-    if (currentQuestion === 1) {
-      router.push(routes.guide(segments, locale));
-    } else {
-      const prevUrl = routes.question(segments, currentQuestion - 1, locale);
-      window.history.pushState(null, "", prevUrl);
-      forceRender();
-    }
+  const handleBackToGuide = () => {
+    router.push(routes.guide(segments, locale));
   };
 
   const handleCloseClick = async () => {
@@ -83,21 +101,22 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
     router.push("/");
   };
 
-  const answer = useAnswer(question.id);
-
   return (
-    <div>
-      <AppQuestionPage
-        embedContext={embed}
-        calculator={calculator}
-        question={question}
-        number={currentQuestion}
-        total={total}
-        onPreviousClick={handlePreviousClick}
-        onNextClick={handleNextClick}
-        onCloseClick={handleCloseClick}
-        answer={answer}
-      />
-    </div>
+    <QuestionPage
+      appTitle="Volební kalkulačka"
+      electionName={electionName}
+      calculatorName={calculatorName}
+      initialPosition={currentQuestion}
+      headerActions={
+        <HideOnEmbed>
+          <IconButton icon={icons.close} label="Zavřít" variant="surface" onClick={handleCloseClick} />
+        </HideOnEmbed>
+      }
+      attributionHref={attributionHref}
+      logoMonochrome={logoMonochrome}
+      onPositionChange={handlePositionChange}
+      onFinish={handleFinish}
+      onBackToGuide={handleBackToGuide}
+    />
   );
 }

--- a/apps/www.volebnikalkulacka.cz/tests/e2e/calculator-flow.spec.ts
+++ b/apps/www.volebnikalkulacka.cz/tests/e2e/calculator-flow.spec.ts
@@ -163,18 +163,21 @@ async function answerQuestions(page: Page, maxQuestions = 3) {
     try {
       await expect(page.locator("main")).toBeVisible();
 
-      const answerOptions = page.locator('button[role="radio"], input[type="radio"], button:has-text("Souhlasím"), button:has-text("Nesouhlasím"), button:has-text("Ano"), button:has-text("Ne")');
+      // By role, so the answer buttons on the cards stacked behind the active one
+      // (inert and `aria-hidden`, but earlier in the DOM) are never the first match.
+      const answerOptions = page.locator('button[role="radio"], input[type="radio"]').or(page.getByRole("button", { name: /^(Souhlasím|Nesouhlasím|Ano|Ne)$/ }));
 
       if ((await answerOptions.count()) === 0) break;
 
       if (!(await clickWithRetry(answerOptions.first()))) break;
       await page.waitForTimeout(TIMEOUTS.ACTION_DELAY);
 
+      // Answering moves to the next question on its own; a "Další" is only there to press when the question was already answered.
       const nextButton = page.locator('button:has-text("Další"), button:has-text("Pokračovat"), a:has-text("Další")').first();
-      if (!(await nextButton.isVisible())) break;
-
-      await page.waitForTimeout(TIMEOUTS.ACTION_DELAY);
-      if (!(await clickWithRetry(nextButton))) break;
+      if (await nextButton.isVisible()) {
+        await page.waitForTimeout(TIMEOUTS.ACTION_DELAY);
+        if (!(await clickWithRetry(nextButton))) break;
+      }
 
       await page.waitForTimeout(TIMEOUTS.QUESTION_DELAY);
     } catch {

--- a/packages/app/src/answers/answers.test.ts
+++ b/packages/app/src/answers/answers.test.ts
@@ -3,7 +3,7 @@ import type { Answer } from "@kalkulacka-one/schema";
 
 import { describe, expect, it } from "vitest";
 
-import { countAnswered, countSkipped, firstUnansweredIndex, hasAnswer, isVisited } from "./answers";
+import { countAnswered, countSkipped, firstUnansweredIndex, hasAnswer, isVisited, toSegments } from "./answers";
 
 const questions = [{ id: "q1" }, { id: "q2" }, { id: "q3" }];
 
@@ -98,5 +98,41 @@ describe("firstUnansweredIndex", () => {
 
   it("ignores stored answers to questions this calculator no longer asks", () => {
     expect(firstUnansweredIndex(questions, [yes("retired-question")])).toBe(0);
+  });
+});
+
+describe("toSegments", () => {
+  it("maps each question to its answer's state, in question order", () => {
+    expect(toSegments(questions, [no("q1"), yes("q3")])).toEqual([
+      { state: "disagree", important: false },
+      { state: "unanswered", important: false },
+      { state: "agree", important: false },
+    ]);
+  });
+
+  it("reads a visited question without a position as skipped", () => {
+    expect(toSegments(questions, [skipped("q1")])[0]).toEqual({ state: "skipped", important: false });
+  });
+
+  it("reads an explicit neutral as skipped in the bar, even though it scores", () => {
+    expect(toSegments(questions, [neutral("q2")])[1]).toEqual({ state: "skipped", important: false });
+  });
+
+  it("carries the important flag whatever the state, including before an answer exists", () => {
+    expect(
+      toSegments(questions, [
+        { questionId: "q1", answer: true, isImportant: true },
+        { questionId: "q2", isImportant: true },
+      ]),
+    ).toEqual([
+      { state: "agree", important: true },
+      { state: "skipped", important: true },
+      { state: "unanswered", important: false },
+    ]);
+  });
+
+  it("ignores stored answers to questions this calculator no longer asks", () => {
+    expect(toSegments(questions, [yes("retired-question")])).toHaveLength(3);
+    expect(toSegments(questions, [yes("retired-question")]).every((segment) => segment.state === "unanswered")).toBe(true);
   });
 });

--- a/packages/app/src/answers/answers.ts
+++ b/packages/app/src/answers/answers.ts
@@ -1,5 +1,5 @@
 // Ported from kalkulacka-2026/packages/core/src/answers/answers.ts — only countAnswered, countSkipped,
-// firstUnansweredIndex and the "visited" semantics; the transitions live in the answers store here.
+// firstUnansweredIndex, toSegments and the "visited" semantics; the transitions live in the answers store here.
 import type { Answer } from "@kalkulacka-one/schema";
 
 /**
@@ -15,6 +15,11 @@ import type { Answer } from "@kalkulacka-one/schema";
  */
 
 type QuestionLike = { id: string };
+
+/** How a question reads in the progress bar. Mirrors the design system's `SegmentState`. */
+export type AnswerSegmentState = "unanswered" | "agree" | "disagree" | "skipped";
+
+export type AnswerSegment = { state: AnswerSegmentState; important: boolean };
 
 /** A real position: yes, no, or an explicit neutral. */
 export function hasAnswer(answer?: Answer): boolean {
@@ -56,4 +61,28 @@ export function countSkipped(questions: readonly QuestionLike[], answers: readon
 export function firstUnansweredIndex(questions: readonly QuestionLike[], answers: readonly Answer[]): number {
   const lookup = byQuestion(answers);
   return questions.findIndex((question) => !isVisited(lookup.get(question.id)));
+}
+
+/**
+ * One segment per question, for the progress bar.
+ *
+ * `skipped` covers both a question visited and left without a position and an
+ * explicit neutral — the bar is a readout of how much is decided, and neither
+ * decides anything. The neutral still scores; only the bar declines to draw
+ * the distinction.
+ */
+export function toSegments(questions: readonly QuestionLike[], answers: readonly Answer[]): AnswerSegment[] {
+  const lookup = byQuestion(answers);
+
+  return questions.map((question) => {
+    const answer = lookup.get(question.id);
+    const important = answer?.isImportant === true;
+
+    if (!answer) return { state: "unanswered", important };
+    if (answer.answer === true) return { state: "agree", important };
+    if (answer.answer === false) return { state: "disagree", important };
+
+    // Visited without a position, or an explicit neutral: either reads as skipped in the bar.
+    return { state: "skipped", important };
+  });
 }

--- a/packages/app/src/components/index.ts
+++ b/packages/app/src/components/index.ts
@@ -10,6 +10,7 @@ export * from "./providers";
 export * from "./public-result-navigation-card";
 export * from "./question-card";
 export * from "./question-navigation-card";
+export * from "./question-page";
 export * from "./result-navigation-card";
 export * from "./review-navigation-card";
 export * from "./review-question-card";

--- a/packages/app/src/components/question-page.test.tsx
+++ b/packages/app/src/components/question-page.test.tsx
@@ -1,0 +1,409 @@
+import type { Answer } from "@kalkulacka-one/schema";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AnswersStoreContext, CalculatorStoreContext, createAnswersStore, createCalculatorStore } from "@/client/stores";
+import type { CalculatorData } from "@/data-fetching";
+import { csMessages } from "@/locales";
+
+import { LocaleProvider } from "./providers";
+import { QuestionPage } from "./question-page";
+
+const questionIds = ["11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222", "33333333-3333-4333-8333-333333333333"] as const;
+const [q1, q2] = questionIds;
+
+const calculatorData: CalculatorData = {
+  data: {
+    calculator: {
+      id: "00000000-0000-4000-8000-000000000000",
+      createdAt: new Date(0).toISOString(),
+      key: "kalkulacka",
+      shortTitle: "Sněmovní 2025",
+    },
+    questions: questionIds.map((id, index) => ({ id, title: `Otázka ${index + 1}`, statement: `Tvrzení ${index + 1}`, tags: [`Téma ${index + 1}`] })),
+    candidates: [{ id: "44444444-4444-4444-8444-444444444444", references: [{ id: "55555555-5555-4555-8555-555555555555", type: "organization" }] }],
+    candidatesAnswers: {},
+  },
+  baseUrl: "https://data.kalkulacka.one/kalkulacka",
+};
+
+type RenderOptions = {
+  answers?: Answer[];
+  props?: Partial<QuestionPage>;
+};
+
+function renderPage({ answers = [], props = {} }: RenderOptions = {}) {
+  const onPositionChange = vi.fn();
+  const onFinish = vi.fn();
+  const onBackToGuide = vi.fn();
+  const answersStore = createAnswersStore();
+  answersStore.getState().setAnswers(answers);
+
+  const result = render(
+    <LocaleProvider locale="cs" messages={csMessages}>
+      <CalculatorStoreContext.Provider value={createCalculatorStore(calculatorData)}>
+        <AnswersStoreContext.Provider value={answersStore}>
+          <QuestionPage
+            appTitle="Volební kalkulačka"
+            electionName="Sněmovní volby 2025"
+            calculatorName="Volební kalkulačka"
+            initialPosition={1}
+            onPositionChange={onPositionChange}
+            onFinish={onFinish}
+            onBackToGuide={onBackToGuide}
+            {...props}
+          />
+        </AnswersStoreContext.Provider>
+      </CalculatorStoreContext.Provider>
+    </LocaleProvider>,
+  );
+
+  const stored = (questionId: string) => answersStore.getState().answers.find((answer) => answer.questionId === questionId);
+
+  return { ...result, answersStore, stored, onPositionChange, onFinish, onBackToGuide };
+}
+
+const yes = (questionId: string): Answer => ({ questionId, answer: true });
+
+/* The card being answered — the only one with a heading; the stacked cards are inert. */
+const heading = () => screen.getByRole("heading", { level: 1 });
+const button = (name: string) => screen.getByRole("button", { name });
+const forward = () => screen.getByRole("navigation").querySelector("button:last-of-type");
+
+/* The page's own live region — the deck has one of its own for the committed answer. */
+const landedRegion = () => screen.getAllByRole("status").find((region) => !region.closest(".ko-deck"));
+
+/* The app bar, found from its wordmark. */
+const appHeader = () => screen.getByText("Volební kalkulačka", { selector: "p" }).closest("header");
+
+const filled = "ko:bg-neutral-ink";
+
+describe("QuestionPage", () => {
+  describe("the screen", () => {
+    it("shows the statement as the heading, with the topic and title chips", () => {
+      renderPage();
+      expect(heading()).toHaveTextContent("Tvrzení 1");
+      const card = heading().closest(".ko-deck-active");
+      expect(card).toHaveTextContent("Téma 1");
+      expect(card).toHaveTextContent("Otázka 1");
+    });
+
+    it("stacks the next questions behind the card, inert", () => {
+      const { container } = renderPage();
+      const next = container.querySelector(".ko-deck-next");
+      expect(next).toHaveTextContent("Tvrzení 2");
+      expect(next?.firstElementChild).toHaveAttribute("inert");
+      expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    });
+
+    it("names the election and the calculator in the header", () => {
+      renderPage();
+      expect(appHeader()).toHaveTextContent("Sněmovní volby Volební kalkulačka 2025");
+    });
+
+    it("renders the header actions and the attribution link when given", () => {
+      renderPage({ props: { headerActions: <button type="button">Zavřít</button>, attributionHref: "https://www.volebnikalkulacka.cz" } });
+      expect(appHeader()).toContainElement(button("Zavřít"));
+      expect(screen.getByRole("link")).toHaveAttribute("href", "https://www.volebnikalkulacka.cz");
+    });
+
+    it("starts at the position it was given", () => {
+      renderPage({ props: { initialPosition: 2 } });
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "2");
+      expect(screen.getByText("Otázka 2 z 3")).toBeInTheDocument();
+    });
+
+    it("clamps a position past the end to the last question", () => {
+      renderPage({ props: { initialPosition: 9 } });
+      expect(heading()).toHaveTextContent("Tvrzení 3");
+    });
+
+    it("draws the progress from the answers", () => {
+      renderPage({ answers: [yes(q1), { questionId: q2, answer: false, isImportant: true }], props: { initialPosition: 3 } });
+      const bar = screen.getByRole("progressbar");
+      expect(bar).toHaveAttribute("aria-label", "Průběh vyplňování");
+      expect(bar).toHaveAttribute("aria-valuemax", "3");
+      const segments = Array.from(bar.children).map((segment) => segment.firstElementChild);
+      expect(segments[0]).toHaveClass("ko:bg-agree");
+      expect(segments[1]).toHaveClass("ko:bg-disagree");
+      expect(bar.children[1]?.querySelector("span")).toHaveClass("ko:bg-disagree");
+    });
+
+    it("lists the keyboard shortcuts", () => {
+      renderPage();
+      expect(screen.getByText("Procházet bez odpovědi")).toBeInTheDocument();
+      expect(screen.getByTitle("Šipka vlevo")).toBeInTheDocument();
+      expect(screen.getByTitle("Tečka")).toBeInTheDocument();
+    });
+  });
+
+  describe("arriving", () => {
+    it("records the question as visited without a position", () => {
+      const { stored } = renderPage();
+      expect(stored(q1)).toEqual({ questionId: q1 });
+    });
+
+    it("leaves an existing answer alone", () => {
+      const { stored } = renderPage({ answers: [{ questionId: q1, answer: false, isImportant: true }] });
+      expect(stored(q1)).toEqual({ questionId: q1, answer: false, isImportant: true });
+    });
+
+    it("offers to skip, unfilled, and to go back to the guide", () => {
+      renderPage();
+      expect(button("Přeskočit")).not.toHaveClass(filled);
+      expect(button("Návod")).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: "Další" })).toBeNull();
+    });
+
+    it("is silent about the card it opened on", () => {
+      renderPage();
+      expect(landedRegion()).toHaveTextContent("");
+      expect(landedRegion()).toHaveAttribute("aria-live", "polite");
+    });
+
+    it("does not report a position it was given", () => {
+      const { onPositionChange } = renderPage({ props: { initialPosition: 2 } });
+      expect(onPositionChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("answering", () => {
+    it("writes the answer and moves to the next question", async () => {
+      const user = userEvent.setup();
+      const { stored, onPositionChange } = renderPage();
+
+      await user.click(button("Ano"));
+      expect(stored(q1)).toEqual({ questionId: q1, answer: true, isImportant: false });
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+      expect(onPositionChange).toHaveBeenCalledWith(2);
+      expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "2");
+    });
+
+    it("announces the card it landed on", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(button("Ne"));
+      expect(landedRegion()).toHaveTextContent("Otázka 2 z 3: Tvrzení 2");
+    });
+
+    it("answers with the arrow keys", () => {
+      const { stored } = renderPage();
+      fireEvent.keyDown(window, { key: "ArrowRight" });
+      expect(stored(q1)).toEqual({ questionId: q1, answer: false, isImportant: false });
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+    });
+
+    it("carries a star pressed before the answer into it", async () => {
+      const user = userEvent.setup();
+      const { stored } = renderPage();
+
+      await user.click(button("Pro mě důležité"));
+      expect(stored(q1)).toEqual({ questionId: q1, isImportant: true });
+      expect(button("Pro mě důležité")).toHaveAttribute("aria-pressed", "true");
+
+      await user.click(button("Ne"));
+      expect(stored(q1)).toEqual({ questionId: q1, answer: false, isImportant: true });
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+    });
+
+    it("clears an answer chosen a second time and stays, nudging toward Přeskočit", async () => {
+      const user = userEvent.setup();
+      const { stored, onPositionChange } = renderPage({ answers: [yes(q1)] });
+      expect(button("Ano")).toHaveAttribute("aria-pressed", "true");
+
+      await user.click(button("Ano"));
+      expect(stored(q1)).toEqual({ questionId: q1, answer: undefined });
+      expect(heading()).toHaveTextContent("Tvrzení 1");
+      expect(onPositionChange).not.toHaveBeenCalled();
+      expect(button("Ano")).toHaveAttribute("aria-pressed", "false");
+      expect(button("Přeskočit")).toHaveClass(filled);
+    });
+
+    it("drops the nudge on the next move", async () => {
+      const user = userEvent.setup();
+      renderPage({ answers: [yes(q1)] });
+
+      await user.click(button("Ano"));
+      await user.click(button("Přeskočit"));
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+      expect(button("Přeskočit")).not.toHaveClass(filled);
+    });
+
+    it("reads Další once answered and moves on without rewriting the answer", async () => {
+      const user = userEvent.setup();
+      const { stored } = renderPage({ answers: [yes(q1)] });
+      expect(screen.queryByRole("button", { name: "Přeskočit" })).toBeNull();
+
+      await user.click(button("Další"));
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+      expect(stored(q1)).toEqual({ questionId: q1, answer: true });
+    });
+
+    it("hands over to the recap after the last question, once", async () => {
+      const user = userEvent.setup();
+      const { onFinish, onPositionChange } = renderPage({ props: { initialPosition: 3 } });
+
+      await user.click(button("Ano"));
+      expect(onFinish).toHaveBeenCalledTimes(1);
+      expect(onPositionChange).not.toHaveBeenCalled();
+
+      // The deck is finished: no live card to answer again while the navigation is on its way.
+      expect(screen.queryByRole("heading", { level: 1 })).toBeNull();
+      fireEvent.keyDown(window, { key: "ArrowLeft" });
+      fireEvent.keyDown(window, { key: "." });
+      expect(onFinish).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("skipping", () => {
+    it("moves on with the nav, leaving the question visited without a position", async () => {
+      const user = userEvent.setup();
+      const { stored, onPositionChange } = renderPage();
+
+      await user.click(button("Přeskočit"));
+      expect(stored(q1)).toEqual({ questionId: q1, answer: undefined, isImportant: false });
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+      expect(onPositionChange).toHaveBeenCalledWith(2);
+    });
+
+    it("drops a star armed before the skip", () => {
+      const { stored } = renderPage();
+      fireEvent.keyDown(window, { key: "ArrowUp" });
+      fireEvent.keyDown(window, { key: "ArrowDown" });
+      expect(stored(q1)).toEqual({ questionId: q1, answer: undefined, isImportant: false });
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+    });
+
+    it("fills Přeskočit when coming back to a question explicitly skipped", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(button("Přeskočit"));
+      await user.click(button("Předchozí"));
+      expect(heading()).toHaveTextContent("Tvrzení 1");
+      expect(button("Přeskočit")).toHaveClass(filled);
+    });
+
+    it("fills Přeskočit for a question an earlier session left without a position", () => {
+      renderPage({ answers: [{ questionId: q1 }] });
+      expect(button("Přeskočit")).toHaveClass(filled);
+    });
+
+    it("does not fill Přeskočit for a question only browsed past", () => {
+      renderPage();
+      fireEvent.keyDown(window, { key: "." });
+      fireEvent.keyDown(window, { key: "," });
+      expect(heading()).toHaveTextContent("Tvrzení 1");
+      expect(button("Přeskočit")).not.toHaveClass(filled);
+
+      fireEvent.keyDown(window, { key: "." });
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+      expect(button("Přeskočit")).not.toHaveClass(filled);
+    });
+
+    it("forgets the skip once the question gets an answer", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      await user.click(button("Přeskočit"));
+      await user.click(button("Předchozí"));
+      await user.click(button("Ne"));
+      await user.click(button("Předchozí"));
+      expect(heading()).toHaveTextContent("Tvrzení 1");
+      expect(button("Další")).toBeInTheDocument();
+
+      // Clearing the answer fills the control again, but only as the nudge:
+      // it does not survive a move, and the old skip is not remembered either.
+      await user.click(button("Ne"));
+      expect(button("Přeskočit")).toHaveClass(filled);
+      fireEvent.keyDown(window, { key: "." });
+      fireEvent.keyDown(window, { key: "," });
+      expect(heading()).toHaveTextContent("Tvrzení 1");
+      expect(button("Přeskočit")).not.toHaveClass(filled);
+    });
+
+    it("hands over to the recap when the last question is skipped", async () => {
+      const user = userEvent.setup();
+      const { onFinish } = renderPage({ props: { initialPosition: 3 } });
+
+      await user.click(button("Přeskočit"));
+      expect(onFinish).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("going back", () => {
+    it("returns to the previous question", async () => {
+      const user = userEvent.setup();
+      const { onPositionChange, onBackToGuide } = renderPage({ props: { initialPosition: 2 } });
+
+      await user.click(button("Předchozí"));
+      expect(heading()).toHaveTextContent("Tvrzení 1");
+      expect(onPositionChange).toHaveBeenCalledWith(1);
+      expect(onBackToGuide).not.toHaveBeenCalled();
+    });
+
+    it("goes back to the guide from the first question", async () => {
+      const user = userEvent.setup();
+      const { onBackToGuide, onPositionChange } = renderPage();
+
+      await user.click(button("Návod"));
+      expect(onBackToGuide).toHaveBeenCalledTimes(1);
+      expect(onPositionChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("browsing with , and .", () => {
+    it("moves without recording an answer", () => {
+      const { answersStore, onPositionChange } = renderPage({ props: { initialPosition: 2 } });
+
+      fireEvent.keyDown(window, { key: "." });
+      expect(heading()).toHaveTextContent("Tvrzení 3");
+      fireEvent.keyDown(window, { key: "," });
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+
+      expect(onPositionChange.mock.calls).toEqual([[3], [2]]);
+      expect(answersStore.getState().answers.every((answer) => answer.answer === undefined && !answer.isImportant)).toBe(true);
+    });
+
+    it("announces each card landed on", () => {
+      renderPage({ props: { initialPosition: 2 } });
+      fireEvent.keyDown(window, { key: "." });
+      expect(landedRegion()).toHaveTextContent("Otázka 3 z 3: Tvrzení 3");
+    });
+
+    it("leaves the flow at either end", () => {
+      const { onBackToGuide, onFinish } = renderPage({ props: { initialPosition: 3 } });
+      fireEvent.keyDown(window, { key: "." });
+      expect(onFinish).toHaveBeenCalledTimes(1);
+
+      const second = renderPage();
+      fireEvent.keyDown(window, { key: "," });
+      expect(second.onBackToGuide).toHaveBeenCalledTimes(1);
+      expect(onBackToGuide).not.toHaveBeenCalled();
+    });
+
+    it("ignores the keys with a modifier or inside a form field", () => {
+      const { onPositionChange } = renderPage({ props: { initialPosition: 2 } });
+      fireEvent.keyDown(window, { key: ".", metaKey: true });
+      fireEvent.keyDown(window, { key: ",", ctrlKey: true });
+      fireEvent.keyDown(window, { key: ".", altKey: true });
+
+      const input = document.createElement("input");
+      document.body.appendChild(input);
+      fireEvent.keyDown(input, { key: "." });
+      input.remove();
+
+      expect(heading()).toHaveTextContent("Tvrzení 2");
+      expect(onPositionChange).not.toHaveBeenCalled();
+    });
+  });
+
+  it("keeps the forward control at the nav's far end", () => {
+    renderPage();
+    expect(forward()).toHaveTextContent("Přeskočit");
+  });
+});

--- a/packages/app/src/components/question-page.tsx
+++ b/packages/app/src/components/question-page.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+// Ported from kalkulacka-2026/apps/web/components/question-flow.tsx (+ .module.css) and apps/web/lib/question-content.ts
+import { FlowNav, type QuestionCardContent, QuestionDeck, type QuestionDeckHandle } from "@kalkulacka-one/design-system/client";
+import { icons } from "@kalkulacka-one/design-system/icons";
+import { AppHeader, KeyboardHints, ProgressSegments, Shell, VisuallyHidden } from "@kalkulacka-one/design-system/server";
+import type { Question } from "@kalkulacka-one/schema";
+
+import { useTranslations } from "next-intl";
+import { type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+
+import { hasAnswer, isVisited, toSegments } from "@/answers";
+import { useAnswersStore } from "@/client/stores";
+import { useQuestions } from "@/client/view-models";
+
+export type QuestionPage = {
+  /** The header wordmark text, e.g. "Volební kalkulačka" — the product name, owned by the app. */
+  appTitle: string;
+  /** The election's display name, e.g. "Sněmovní volby 2025". */
+  electionName?: string;
+  /** The calculator's display name — the header's subtitle. */
+  calculatorName: string;
+  /** 1-based, from the URL. Only seeds the position; the page owns it from then on. */
+  initialPosition: number;
+  /** Right side of the header: today the app's close button, later the menu. */
+  headerActions?: ReactNode;
+  /** Embeds: makes the wordmark an outbound link to the full site. */
+  attributionHref?: string;
+  logoMonochrome?: boolean;
+  /**
+   * Called with the new 1-based position on every move, so the app can keep
+   * the URL in step.
+   *
+   * The URL tracks the question so a refresh or a shared link lands in the
+   * right place — but the app should do it via `history.replaceState` rather
+   * than a router push. Routing on every answer would put a navigation between
+   * the swipe and the next card, which is exactly the latency this interaction
+   * cannot afford; and one history entry per question would make the back
+   * button walk through forty answered cards before leaving the flow.
+   */
+  onPositionChange: (position: number) => void;
+  /** The last card has been committed — the app takes the reader to the recap. */
+  onFinish: () => void;
+  /** "Návod" on the first question — the app takes the reader back to the guide. */
+  onBackToGuide: () => void;
+};
+
+/**
+ * Domain question -> the shape a `QuestionCard` draws.
+ *
+ * The seam between the data and the design system, which know nothing of each
+ * other by design. It lives in the app package because that is the only layer
+ * allowed to see both — and in one place because the deck and, later, the
+ * recap's dialog must show the same card, down to which tag counts as the
+ * topic.
+ */
+export function toCardContent(question: Question): QuestionCardContent {
+  return {
+    id: question.id,
+    statement: question.statement,
+    title: question.title,
+    detail: question.detail,
+    topic: question.tags?.[0],
+  };
+}
+
+/*
+ * The deck and its nav, below the shell's header. `min-height: 0` is what
+ * keeps the deck inside the viewport: without it this flex child would refuse
+ * to shrink below its content's height and push the nav off the bottom edge
+ * instead of the card getting shorter.
+ */
+const flowClasses =
+  "koa:flex-1 koa:min-h-0 koa:flex koa:flex-col koa:pl-[calc(var(--ko-spacing-fluid-gutter)+env(safe-area-inset-left,0px))] koa:pr-[calc(var(--ko-spacing-fluid-gutter)+env(safe-area-inset-right,0px))]";
+
+const progressClasses = "koa:flex-none koa:pt-(--ko-spacing-fluid-progress-top) koa:mb-6";
+
+/*
+ * The card and the nav below it are centred as one group in the remaining
+ * vertical space — not the card alone — so the pair sits together rather than
+ * the card floating near the top with the nav stranded far below it.
+ *
+ * The shell's content column already stops at `dvh`, so on a phone in a
+ * browser the bottom padding is only breathing room — the inset itself has a
+ * value where there is no address bar to have taken care of it (an installed
+ * PWA). Tighter gaps from the `desk` breakpoint (53.75rem, the design system's
+ * "a keyboard is assumed" line — spelled out here because the app package has
+ * no named breakpoints of its own).
+ */
+const centerClasses =
+  "koa:flex-1 koa:min-h-0 koa:w-full koa:max-w-[51.25rem] koa:mx-auto koa:flex koa:flex-col koa:justify-center koa:gap-6 koa:min-[53.75rem]:gap-2 koa:pb-[max(1rem,env(safe-area-inset-bottom,0px))]";
+
+/*
+ * The deck is absolutely positioned inside this box, so the stage owns the
+ * card's size. Capping its height on wide screens (rather than letting it fill
+ * all remaining space) keeps the statement from floating in an oversized card.
+ */
+const stageClasses = "koa:relative koa:flex-1 koa:min-h-0 koa:w-full koa:min-[53.75rem]:flex-[0_1_33.75rem]";
+
+/**
+ * The question flow: the progress bar, the deck, the nav row and the keyboard
+ * hints, on the pinned shell that never scrolls.
+ *
+ * Position is the page's own state, seeded from the URL once. Every move
+ * reports the new position through `onPositionChange`; nothing here ever
+ * routes, so the swipe and the next card are never separated by a navigation.
+ *
+ * Landing on a question with no entry writes one without a position — that is
+ * how this platform records "visited": the intro's "Pokračovat v odpovídání"
+ * resumes at the first question with nothing recorded, and a question passed
+ * over counts as seen. 2026 only ever wrote on an explicit skip; here the
+ * write is on arrival, as the previous question page did it.
+ */
+export function QuestionPage({ appTitle, electionName, calculatorName, initialPosition, headerActions, attributionHref, logoMonochrome, onPositionChange, onFinish, onBackToGuide }: QuestionPage) {
+  const t = useTranslations("koa.components.questionPage");
+  const { questions, total } = useQuestions();
+  const answers = useAnswersStore((state) => state.answers);
+  const getAnswer = useAnswersStore((state) => state.getAnswer);
+  const setAnswer = useAnswersStore((state) => state.setAnswer);
+
+  const [index, setIndex] = useState(() => Math.min(Math.max(initialPosition - 1, 0), total - 1));
+
+  /**
+   * True right after re-tapping the current answer clears it — a nudge toward
+   * "Přeskočit" for the moment the question is unexpectedly unanswered again.
+   * Reset on every move, so it never survives to the next card.
+   */
+  const [justCleared, setJustCleared] = useState(false);
+
+  /**
+   * True from the moment the last question's commit hands over to the recap
+   * until this screen unmounts. The navigation is asynchronous — an RSC
+   * round-trip, or in dev a compile — and without this flag the deck sits
+   * fully live in the meantime: its ghost design snaps the same card back after
+   * the exit animation, so a slow navigation read as "question 42 can be
+   * answered forever", each answer firing another navigation.
+   */
+  const [leaving, setLeaving] = useState(false);
+
+  /**
+   * The card that just landed, spoken.
+   *
+   * Answering leaves focus on the control that was pressed while the card's
+   * content is replaced underneath it, so a reader working by keyboard hears
+   * the deck confirm their own answer ("Ano") and is then told nothing
+   * whatsoever about the question they have arrived at — the one thing on the
+   * screen that changed. Polite, so it queues behind that confirmation and the
+   * two read in the order they happened.
+   *
+   * Empty until the first move: on arrival the question is simply part of the
+   * page, and a live region that speaks its own initial contents would read
+   * the card out a second time.
+   */
+  const [landed, setLanded] = useState("");
+
+  /**
+   * The "visited" entries this page wrote itself, and the questions explicitly
+   * skipped here.
+   *
+   * Every unanswered question on screen has an entry (see the landing effect
+   * below), so "visited without a position" alone cannot tell a question the
+   * reader merely looked at from one they passed over — and the nav's filled
+   * "Přeskočit" is meant for the latter only: an explicit skip, or an entry an
+   * earlier session left behind. 2026 kept a `skipped` flag on the entry
+   * itself; this platform's `Answer` has none, so the page remembers instead.
+   */
+  const [writtenIds, setWrittenIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [skippedIds, setSkippedIds] = useState<ReadonlySet<string>>(() => new Set());
+
+  const deckRef = useRef<QuestionDeckHandle>(null);
+  const question = questions[index];
+
+  // Landing: record the question as visited the moment it is shown. Idempotent —
+  // it may run more than once for the same card (StrictMode, for one).
+  useEffect(() => {
+    const landedQuestion = questions[index];
+    if (!landedQuestion || getAnswer(landedQuestion.id)) return;
+
+    setAnswer({ questionId: landedQuestion.id });
+    setWrittenIds((ids) => new Set(ids).add(landedQuestion.id));
+  }, [index, questions, getAnswer, setAnswer]);
+
+  /** Everything a move implies: the new card, the nudge reset, the announcement, the URL. */
+  const moveTo = useCallback(
+    (nextIndex: number) => {
+      const target = questions[nextIndex];
+      if (!target) return;
+
+      setIndex(nextIndex);
+      setJustCleared(false);
+      setLanded(t("announce", { position: nextIndex + 1, total, statement: target.statement }));
+      onPositionChange(nextIndex + 1);
+    },
+    [questions, total, t, onPositionChange],
+  );
+
+  /**
+   * Move on — and off the end of the deck into the recap.
+   *
+   * The last card advancing to itself would leave someone stuck on question 42
+   * with a "Další" that does nothing, so the deck's end is the recap's entrance.
+   */
+  const advance = useCallback(() => {
+    if (leaving) return;
+    if (index + 1 >= total) {
+      setLeaving(true);
+      onFinish();
+      return;
+    }
+    moveTo(index + 1);
+  }, [index, leaving, moveTo, onFinish, total]);
+
+  /**
+   * Back one card — and, from the first one, back to the tutorial.
+   *
+   * Question 1 used to carry a dead "Předchozí": the one place in the flow
+   * where the control is visible but does nothing, shown to exactly the people
+   * least sure of what they are doing. The screen behind question 1 is the
+   * návod, so that is where the back control goes, named for the place it
+   * returns to like every other back link in the app.
+   */
+  const goToPrevious = useCallback(() => {
+    if (leaving) return;
+    if (index === 0) {
+      onBackToGuide();
+      return;
+    }
+    moveTo(index - 1);
+  }, [index, leaving, moveTo, onBackToGuide]);
+
+  /**
+   * Lifts the card away without writing to the answer store — used both by
+   * "Další" on an already-answered question and by the browse-only shortcut,
+   * which must never record anything even on an unanswered one.
+   */
+  const advanceAnimated = useCallback(() => {
+    deckRef.current?.advance();
+    advance();
+  }, [advance]);
+
+  const handleAnswer = useCallback(
+    (agree: boolean, important: boolean) => {
+      if (leaving || !question) return;
+
+      const existing = getAnswer(question.id);
+      const isClearing = existing?.answer === agree;
+
+      // Re-choosing the same answer clears it; that is an edit, not progress.
+      if (isClearing) {
+        setAnswer({ questionId: question.id, answer: undefined });
+      } else {
+        setAnswer({ questionId: question.id, answer: agree, isImportant: important || existing?.isImportant === true });
+        // A position supersedes an earlier skip.
+        setSkippedIds((ids) => {
+          if (!ids.has(question.id)) return ids;
+          const next = new Set(ids);
+          next.delete(question.id);
+          return next;
+        });
+      }
+
+      setJustCleared(isClearing);
+      if (!isClearing) advance();
+    },
+    [advance, getAnswer, leaving, question, setAnswer],
+  );
+
+  /**
+   * Explicitly skip. "Important" only makes sense attached to a real position,
+   * so skipping drops any flag armed before the skip rather than carrying it
+   * forward unanswered.
+   */
+  const handleSkip = useCallback(() => {
+    if (leaving || !question) return;
+    setAnswer({ questionId: question.id, answer: undefined, isImportant: false });
+    setSkippedIds((ids) => new Set(ids).add(question.id));
+    advance();
+  }, [advance, leaving, question, setAnswer]);
+
+  /**
+   * Toggle "pro mě důležité". Can be armed before answering: the star pressed
+   * first is carried into whichever answer is then given.
+   */
+  const handleToggleImportant = useCallback(() => {
+    if (!question) return;
+    setAnswer({ questionId: question.id, isImportant: !getAnswer(question.id)?.isImportant });
+  }, [getAnswer, question, setAnswer]);
+
+  /*
+   * `,` / `.` browse without touching the answer store — deliberately not
+   * modifier keys on the existing arrows. Shift+Arrow already means "extend
+   * a text selection" to the browser and some screen readers, which is
+   * exactly the wrong association for a shortcut whose entire point is "this
+   * one is safe, it changes nothing." Mirrors the nav buttons: `,` is
+   * identical to Předchozí, `.` is the store-write-free half of Další.
+   */
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      // `event.target` is not always an Element (it's `window`/`document` for
+      // some synthetically dispatched or unfocused-body keydowns) — guard
+      // before calling an Element-only method on it.
+      const target = event.target;
+      if (target instanceof HTMLElement && target.closest("input, textarea, select, [contenteditable]")) return;
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+
+      if (event.key === ",") {
+        event.preventDefault();
+        goToPrevious();
+      } else if (event.key === ".") {
+        event.preventDefault();
+        advanceAnimated();
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [goToPrevious, advanceAnimated]);
+
+  if (!question) return null;
+
+  const answer = answers.find((entry) => entry.questionId === question.id);
+  const isAnswered = hasAnswer(answer);
+  const isSkipped = !isAnswered && (skippedIds.has(question.id) || (isVisited(answer) && !writtenIds.has(question.id)));
+  const next = questions[index + 1];
+  const after = questions[index + 2];
+
+  return (
+    <Shell
+      scroll="pinned"
+      header={<AppHeader title={appTitle} electionName={electionName} calculatorName={calculatorName} href={attributionHref} logoMonochrome={logoMonochrome} actions={headerActions} />}
+    >
+      {/* The flow's own landmark. It was the one screen in the app whose
+          content sat in a bare `<div>`, so "jump to the main content" — the
+          first thing a screen-reader user does on any page — had nowhere to
+          land on the forty-two screens they spend the longest on. */}
+      <main className={flowClasses}>
+        <div className={progressClasses}>
+          <ProgressSegments segments={toSegments(questions, answers)} currentIndex={index} label={t("progressLabel")} />
+        </div>
+
+        <div className={centerClasses}>
+          <div className={stageClasses}>
+            <QuestionDeck
+              ref={deckRef}
+              current={toCardContent(question)}
+              next={next ? toCardContent(next) : undefined}
+              after={after ? toCardContent(after) : undefined}
+              selection={{
+                agree: answer?.answer === true,
+                disagree: answer?.answer === false,
+                important: answer?.isImportant === true,
+              }}
+              labels={{
+                agree: t("agree"),
+                disagree: t("disagree"),
+                important: t("important"),
+                importantSuffix: t("importantSuffix"),
+                skip: t("skip"),
+              }}
+              onAnswer={handleAnswer}
+              onSkip={handleSkip}
+              onToggleImportant={handleToggleImportant}
+              finished={leaving}
+            />
+          </div>
+
+          <FlowNav
+            position={index + 1}
+            total={total}
+            canGoBack
+            onPrevious={goToPrevious}
+            onForward={isAnswered ? advanceAnimated : handleSkip}
+            previousLabel={index === 0 ? t("guide") : t("previous")}
+            forwardLabel={isAnswered ? t("next") : t("skip")}
+            isSkipped={isSkipped}
+            attention={justCleared}
+            counterLabel={t("counter", { position: index + 1, total })}
+          />
+
+          {/*
+            Left and right get a hint each rather than one shared "odpovědět":
+            which arrow means "souhlasím" is the one thing about this shortcut
+            a first-time user cannot guess, and the paired row also matches
+            the left/right order of the answer buttons on the card.
+          */}
+          <KeyboardHints
+            hints={[
+              { keys: [{ icon: icons.arrowLeft, label: t("hints.arrowLeft") }], label: t("agree") },
+              { keys: [{ icon: icons.arrowRight, label: t("hints.arrowRight") }], label: t("disagree") },
+              { keys: [{ icon: icons.arrowUp, label: t("hints.arrowUp") }], label: t("hints.important") },
+              { keys: [{ icon: icons.arrowDown, label: t("hints.arrowDown") }], label: t("skip") },
+              {
+                keys: [
+                  { icon: icons.comma, label: t("hints.comma") },
+                  { icon: icons.period, label: t("hints.period") },
+                ],
+                label: t("hints.browse"),
+              },
+            ]}
+          />
+
+          <VisuallyHidden as="output" aria-live="polite">
+            {landed}
+          </VisuallyHidden>
+        </div>
+      </main>
+    </Shell>
+  );
+}

--- a/packages/app/src/locales/cs.json
+++ b/packages/app/src/locales/cs.json
@@ -41,6 +41,29 @@
         "factRecapTitle": "Rekapitulace",
         "factRecapDescription": "Na konci uvidíte všechny otázky pohromadě a odpovědi můžete ještě změnit."
       },
+      "questionPage": {
+        "counter": "Otázka {position} z {total}",
+        "progressLabel": "Průběh vyplňování",
+        "agree": "Ano",
+        "disagree": "Ne",
+        "important": "Pro mě důležité",
+        "importantSuffix": " · Pro mě důležité",
+        "skip": "Přeskočit",
+        "next": "Další",
+        "previous": "Předchozí",
+        "guide": "Návod",
+        "hints": {
+          "arrowLeft": "Šipka vlevo",
+          "arrowRight": "Šipka vpravo",
+          "arrowUp": "Šipka nahoru",
+          "arrowDown": "Šipka dolů",
+          "comma": "Čárka",
+          "period": "Tečka",
+          "important": "Důležité",
+          "browse": "Procházet bez odpovědi"
+        },
+        "announce": "Otázka {position} z {total}: {statement}"
+      },
       "publicResultNavigationCard": {
         "fillOwnCalculatorButton": "Vyplnit vlastní kalkulačku"
       },

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -41,6 +41,29 @@
         "factRecapTitle": "Recap",
         "factRecapDescription": "At the end you'll see all the questions together and can still change your answers."
       },
+      "questionPage": {
+        "counter": "Question {position} of {total}",
+        "progressLabel": "Progress",
+        "agree": "Yes",
+        "disagree": "No",
+        "important": "Important to me",
+        "importantSuffix": " · Important to me",
+        "skip": "Skip",
+        "next": "Next",
+        "previous": "Previous",
+        "guide": "Guide",
+        "hints": {
+          "arrowLeft": "Left arrow",
+          "arrowRight": "Right arrow",
+          "arrowUp": "Up arrow",
+          "arrowDown": "Down arrow",
+          "comma": "Comma",
+          "period": "Period",
+          "important": "Important",
+          "browse": "Browse without answering"
+        },
+        "announce": "Question {position} of {total}: {statement}"
+      },
       "publicResultNavigationCard": {
         "fillOwnCalculatorButton": "Fill your own calculator"
       },

--- a/packages/app/src/locales/mk.json
+++ b/packages/app/src/locales/mk.json
@@ -41,6 +41,29 @@
         "factRecapTitle": "Рекапитулација",
         "factRecapDescription": "На крајот ќе ги видите сите прашања заедно и одговорите сè уште можете да ги промените."
       },
+      "questionPage": {
+        "counter": "Прашање {position} од {total}",
+        "progressLabel": "Напредок на пополнувањето",
+        "agree": "Да",
+        "disagree": "Не",
+        "important": "Важно за мене",
+        "importantSuffix": " · Важно за мене",
+        "skip": "Прескокни",
+        "next": "Следно",
+        "previous": "Претходно",
+        "guide": "Водич",
+        "hints": {
+          "arrowLeft": "Стрелка налево",
+          "arrowRight": "Стрелка надесно",
+          "arrowUp": "Стрелка нагоре",
+          "arrowDown": "Стрелка надолу",
+          "comma": "Запирка",
+          "period": "Точка",
+          "important": "Важно",
+          "browse": "Прелистување без одговор"
+        },
+        "announce": "Прашање {position} од {total}: {statement}"
+      },
       "publicResultNavigationCard": {
         "fillOwnCalculatorButton": "Пополнете го вашиот калкулатор"
       },

--- a/packages/app/src/locales/sk.json
+++ b/packages/app/src/locales/sk.json
@@ -41,6 +41,29 @@
         "factRecapTitle": "Rekapitulácia",
         "factRecapDescription": "Na konci uvidíte všetky otázky pohromade a odpovede môžete ešte zmeniť."
       },
+      "questionPage": {
+        "counter": "Otázka {position} z {total}",
+        "progressLabel": "Priebeh vypĺňania",
+        "agree": "Áno",
+        "disagree": "Nie",
+        "important": "Pre mňa dôležité",
+        "importantSuffix": " · Pre mňa dôležité",
+        "skip": "Preskočiť",
+        "next": "Ďalšia",
+        "previous": "Predchádzajúca",
+        "guide": "Návod",
+        "hints": {
+          "arrowLeft": "Šípka vľavo",
+          "arrowRight": "Šípka vpravo",
+          "arrowUp": "Šípka nahor",
+          "arrowDown": "Šípka nadol",
+          "comma": "Čiarka",
+          "period": "Bodka",
+          "important": "Dôležité",
+          "browse": "Prechádzať bez odpovede"
+        },
+        "announce": "Otázka {position} z {total}: {statement}"
+      },
       "publicResultNavigationCard": {
         "fillOwnCalculatorButton": "Vyplniť vlastnú kalkulačku"
       },


### PR DESCRIPTION
Part 9 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #521. **Checkpoint C3 — the core interaction in the real app, and the agreed decision point before the results screens.**

Ported from `kalkulacka-2026/apps/web/components/question-flow.tsx`:

- **`QuestionPage`** in `@kalkulacka-one/app`: progress segments, the deck (#520), the previous / counter / forward strip (#521), desktop keyboard hints, and a polite live region announcing the landed question. Arrow keys answer (← Ano, → Ne, ↑ important, ↓ skip), `,` and `.` browse without writing, the active statement is the page's `h1`, stacked cards are inert. The URL follows by `history.replaceState`, so answering never grows the history (the old page pushed an entry per question). Re-choosing an answer clears it in place and nudges the forward control toward "Přeskočit"; the last question leads to the recap; previous on question 1 leads to the guide. Strings under `koa.components.questionPage` in cs, sk, mk, en.
- **`toSegments`** joins the answer helpers (progress bar states; an explicit neutral reads as skipped in the bar).
- **Czech app**: the question wrapper renders the new page (autosave, embed handling and the close button unchanged); the e2e flow selects answer buttons by role because the inert cards behind the active one come first in the DOM.

Two deliberate adaptations to this platform's answer model, documented in the code: landing on a question writes a visited entry (as the old page did), so the page remembers which entries it wrote itself and only shows the filled "Přeskočit" for explicit skips or entries left by an earlier session; and clearing an answer keeps the star (2026 dropped the whole entry). Not ported: the 2026 route prefetch warm-up.

Verified side by side with the 2026 app at 1024 and 375 px: identical layout rectangles for header, progress, deck, nav and hints; same heading metrics. One visible difference outside this PR: the Czech app loads Geist as a variable font (true bold), the 2026 app synthesises bold from static weights, so long statements can wrap one line earlier here.

**Checks:** typecheck, lint, tests (app 150, design-system 276), Czech app build, Czech Playwright flow (30 passed).

**Stack:** based on #521 → next: `port/10-guide-page` (checkpoint C4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
