### PR TITLE
Add the review page with filters and question dialog

### DIFF
--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/review.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/review.tsx
@@ -1,10 +1,14 @@
-import { useAnswers, useAnswersStore, useCalculator, useQuestions } from "@kalkulacka-one/app/client";
+import { ReviewPage } from "@kalkulacka-one/app";
+import { useAnswersStore, useCalculator, useQuestions } from "@kalkulacka-one/app/client";
+import { IconButton } from "@kalkulacka-one/design-system/client";
+import { icons } from "@kalkulacka-one/design-system/icons";
 
 import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
+import { useEffect } from "react";
 
-import { ReviewPage as AppReviewPage } from "@/calculator";
-import { useEmbed } from "@/components/client";
+import { HideOnEmbed, useEmbed } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
 import { useAutoSave } from "@/hooks/auto-save";
 import { saveSessionData } from "@/lib/api";
 import { reportError } from "@/lib/monitoring";
@@ -13,20 +17,48 @@ import { type RouteSegments, routes } from "@/lib/routing";
 export function ReviewPageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
-  const questions = useQuestions();
-  const answersStore = useAnswersStore((state) => state.answers);
-  const answers = useAnswers();
+  const { total } = useQuestions();
   const embed = useEmbed();
+  const answersStore = useAnswersStore((state) => state.answers);
   const locale = useLocale();
 
   useAutoSave();
 
-  const handleNextClick = () => {
-    router.push(routes.result(segments, locale));
+  // A group calculator (`snemovni-2025/kalkulacka`) is named by its group and
+  // variant keys; a standalone one by its own key. Neither carries a display
+  // name in the data, hence the config.
+  const { electionName, calculatorName } = calculatorNames({
+    group: "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined,
+    key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    fallback: calculator.title || undefined,
+  });
+
+  // In an embed the wordmark doubles as the attribution — the one way out of a
+  // partner's iframe to the full site — unless the partner opted out of it.
+  const attributionHref = embed.isEmbed && embed.config?.attribution !== false ? (process.env.NEXT_PUBLIC_CANONICAL_URL ?? "/") : undefined;
+  const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
+
+  const resultRoute = routes.result(segments, locale);
+
+  /*
+   * Warm the results route while the recap is being read. The screen after
+   * this one opens on a loading animation that should start the moment the
+   * button is pressed, not after an RSC round-trip — and the button is a
+   * `router.push`, not a `<Link>`, so nothing prefetches it on its own.
+   * Explicit is cheap. (No-op in dev.)
+   */
+  useEffect(() => {
+    router.prefetch(resultRoute);
+  }, [router, resultRoute]);
+
+  // The recap follows the deck's end, so "back" is the card it came from — the
+  // last question — as 2026 has it, not the first.
+  const handleBackClick = () => {
+    router.push(routes.question(segments, total, locale));
   };
 
-  const handlePreviousClick = () => {
-    router.push(routes.question(segments, questions.total, locale));
+  const handleShowResultsClick = () => {
+    router.push(resultRoute);
   };
 
   const handleCloseClick = async () => {
@@ -41,16 +73,19 @@ export function ReviewPageWithRouting({ segments }: { segments: RouteSegments })
   };
 
   return (
-    <div>
-      <AppReviewPage
-        embedContext={embed}
-        calculator={calculator}
-        questions={questions}
-        answers={answers}
-        onNextClick={handleNextClick}
-        onPreviousClick={handlePreviousClick}
-        onCloseClick={handleCloseClick}
-      />
-    </div>
+    <ReviewPage
+      appTitle="Volební kalkulačka"
+      electionName={electionName}
+      calculatorName={calculatorName}
+      headerActions={
+        <HideOnEmbed>
+          <IconButton icon={icons.close} label="Zavřít" variant="surface" onClick={handleCloseClick} />
+        </HideOnEmbed>
+      }
+      attributionHref={attributionHref}
+      logoMonochrome={logoMonochrome}
+      onBackClick={handleBackClick}
+      onShowResultsClick={handleShowResultsClick}
+    />
   );
 }

--- a/packages/app/src/answers/answers.test.ts
+++ b/packages/app/src/answers/answers.test.ts
@@ -3,7 +3,7 @@ import type { Answer } from "@kalkulacka-one/schema";
 
 import { describe, expect, it } from "vitest";
 
-import { answersByQuestion, answerTone, countAnswered, countSkipped, firstUnansweredIndex, hasAnswer, isComplete, isVisited, toSegments } from "./answers";
+import { answersByQuestion, answerTone, countAnswered, countSkipped, firstUnansweredIndex, hasAnswer, isComplete, isSkipped, isVisited, toSegments } from "./answers";
 
 const questions = [{ id: "q1" }, { id: "q2" }, { id: "q3" }];
 
@@ -38,6 +38,23 @@ describe("isVisited", () => {
 
   it("is false for a question never reached", () => {
     expect(isVisited(undefined)).toBe(false);
+  });
+});
+
+describe("isSkipped", () => {
+  it("is true for the record a skip leaves: visited, no position, the flag cleared", () => {
+    expect(isSkipped({ questionId: "q1", answer: undefined, isImportant: false })).toBe(true);
+  });
+
+  it("is false for a question only looked at, or starred before it was answered", () => {
+    expect(isSkipped(skipped("q1"))).toBe(false);
+    expect(isSkipped({ questionId: "q1", isImportant: true })).toBe(false);
+  });
+
+  it("is false for a real position and for a question never reached", () => {
+    expect(isSkipped(yes("q1"))).toBe(false);
+    expect(isSkipped({ questionId: "q1", answer: null, isImportant: false })).toBe(false);
+    expect(isSkipped(undefined)).toBe(false);
   });
 });
 

--- a/packages/app/src/answers/answers.ts
+++ b/packages/app/src/answers/answers.ts
@@ -31,6 +31,22 @@ export function isVisited(answer?: Answer): boolean {
   return answer !== undefined;
 }
 
+/**
+ * Explicitly passed over: visited, no position, and the flag cleared with it.
+ *
+ * 2026 kept a `skipped` flag on the entry; this platform's `Answer` has none,
+ * and the three facts a recap row cares about have to be told apart from the
+ * shape of the record instead. The flow's skip (and the recap's) is the one
+ * write that leaves `isImportant: false` beside a missing position — an
+ * arrival writes neither, and the star alone writes `true` — so that pair *is*
+ * the flag. It keeps the star armable on a question that was only looked at,
+ * or starred before it was answered, and locked on one that was actually
+ * skipped.
+ */
+export function isSkipped(answer?: Answer): boolean {
+  return isVisited(answer) && !hasAnswer(answer) && answer?.isImportant === false;
+}
+
 /** The stored answers keyed by question, for the helpers that walk a question list. */
 export function answersByQuestion(answers: readonly Answer[]): Map<string, Answer> {
   return new Map(answers.map((answer) => [answer.questionId, answer]));

--- a/packages/app/src/components/index.ts
+++ b/packages/app/src/components/index.ts
@@ -16,4 +16,5 @@ export * from "./question-navigation-card";
 export * from "./question-page";
 export * from "./result-navigation-card";
 export * from "./review-navigation-card";
+export * from "./review-page";
 export * from "./review-question-card";

--- a/packages/app/src/components/review-page.test.tsx
+++ b/packages/app/src/components/review-page.test.tsx
@@ -1,0 +1,402 @@
+import type { Answer } from "@kalkulacka-one/schema";
+
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AnswersStoreContext, CalculatorStoreContext, createAnswersStore, createCalculatorStore } from "@/client/stores";
+import type { CalculatorData } from "@/data-fetching";
+import { csMessages } from "@/locales";
+
+import { LocaleProvider } from "./providers";
+import { ReviewPage } from "./review-page";
+
+/*
+ * jsdom doesn't implement `<dialog>`'s `showModal()`/`close()` — the same
+ * minimum stub the design system's dialog tests use, so the question dialog's
+ * own open/close logic runs against something that behaves like a browser.
+ */
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = function (this: HTMLDialogElement) {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function (this: HTMLDialogElement) {
+    this.open = false;
+    this.dispatchEvent(new Event("close"));
+  };
+});
+
+const questionIds = ["11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222", "33333333-3333-4333-8333-333333333333", "44444444-4444-4444-8444-444444444444"] as const;
+const [q1, q2, q3, q4] = questionIds;
+const topics = ["Doprava", "Doprava", "Školství", "Školství"];
+
+const calculatorData: CalculatorData = {
+  data: {
+    calculator: {
+      id: "00000000-0000-4000-8000-000000000000",
+      createdAt: new Date(0).toISOString(),
+      key: "kalkulacka",
+      shortTitle: "Sněmovní 2025",
+    },
+    questions: questionIds.map((id, index) => ({ id, title: `Otázka ${index + 1}`, statement: `Tvrzení ${index + 1}`, tags: [topics[index] ?? ""] })),
+    candidates: [{ id: "55555555-5555-4555-8555-555555555555", references: [{ id: "66666666-6666-4666-8666-666666666666", type: "organization" }] }],
+    candidatesAnswers: {},
+  },
+  baseUrl: "https://data.kalkulacka.one/kalkulacka",
+};
+
+type RenderOptions = {
+  answers?: Answer[];
+  props?: Partial<ReviewPage>;
+};
+
+function renderPage({ answers = [], props = {} }: RenderOptions = {}) {
+  const onBackClick = vi.fn();
+  const onShowResultsClick = vi.fn();
+  const answersStore = createAnswersStore();
+  answersStore.getState().setAnswers(answers);
+
+  const result = render(
+    <LocaleProvider locale="cs" messages={csMessages}>
+      <CalculatorStoreContext.Provider value={createCalculatorStore(calculatorData)}>
+        <AnswersStoreContext.Provider value={answersStore}>
+          <ReviewPage
+            appTitle="Volební kalkulačka"
+            electionName="Sněmovní volby 2025"
+            calculatorName="Volební kalkulačka"
+            onBackClick={onBackClick}
+            onShowResultsClick={onShowResultsClick}
+            {...props}
+          />
+        </AnswersStoreContext.Provider>
+      </CalculatorStoreContext.Provider>
+    </LocaleProvider>,
+  );
+
+  const stored = (questionId: string) => answersStore.getState().answers.find((answer) => answer.questionId === questionId);
+
+  return { ...result, answersStore, stored, onBackClick, onShowResultsClick };
+}
+
+const yes = (questionId: string): Answer => ({ questionId, answer: true });
+const no = (questionId: string): Answer => ({ questionId, answer: false });
+
+/* The app bar, found from its wordmark. */
+const appHeader = () => screen.getByText("Volební kalkulačka", { selector: "p" }).closest("header");
+const recapHeader = () => document.querySelector(".ko-recap-header");
+
+const list = () => screen.getByRole("list");
+const rows = () => within(list()).getAllByRole("listitem");
+/* The row's open area is named by the title and the mark's own label, run together — "Otázka 1Ano". */
+const opener = (title: string) => screen.getByRole("button", { name: new RegExp(`^${title}(Ano|Ne|Nevím|Bez odpovědi)$`) });
+const row = (title: string) => opener(title).closest("li");
+const star = (title: string) => within(row(title) as HTMLElement).getByRole("button", { name: "Pro mě důležité" });
+const mark = (title: string) => within(row(title) as HTMLElement).getByRole("img");
+/* The scroller around the list, and the top fade just before it. */
+const scroller = () => list().parentElement as HTMLElement;
+const topFade = () => scroller().previousElementSibling;
+
+const chip = (label: string) => screen.getByRole("button", { name: new RegExp(`^${label}\\d*$`) });
+const chips = () => within(screen.getByRole("group", { name: "Filtrovat otázky" })).getAllByRole("button");
+
+const dialog = () => document.querySelector("dialog") as HTMLDialogElement;
+const statement = () => screen.queryByRole("heading", { level: 2 });
+
+const results = () => screen.getByRole("button", { name: "Zobrazit výsledky" });
+
+describe("ReviewPage", () => {
+  describe("the screen", () => {
+    it("titles the screen, describes it and tallies the answers", () => {
+      renderPage({ answers: [yes(q1), { questionId: q2 }] });
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Rekapitulace");
+      expect(screen.getByText("Zkontrolujte odpovědi, než se podíváte na výsledek. Klepnutím na otázku ji můžete změnit.")).toBeInTheDocument();
+      expect(screen.getByText("Zodpovězeno 1 z 4")).toBeInTheDocument();
+      expect(screen.getByText("Přeskočeno 3")).toBeInTheDocument();
+    });
+
+    it("drops the skipped count once everything is answered", () => {
+      renderPage({ answers: questionIds.map(yes) });
+      expect(screen.getByText("Zodpovězeno 4 z 4")).toBeInTheDocument();
+      expect(screen.queryByText(/Přeskočeno/)).toBeNull();
+    });
+
+    it("names the election and the calculator in the header", () => {
+      renderPage();
+      expect(appHeader()).toHaveTextContent("Sněmovní volby Volební kalkulačka 2025");
+    });
+
+    it("renders the header actions and the attribution link when given", () => {
+      renderPage({ props: { headerActions: <button type="button">Zavřít</button>, attributionHref: "https://www.volebnikalkulacka.cz" } });
+      expect(appHeader()).toContainElement(screen.getByRole("button", { name: "Zavřít" }));
+      expect(screen.getByRole("link")).toHaveAttribute("href", "https://www.volebnikalkulacka.cz");
+    });
+
+    it("lists every question as a row wearing its mark", () => {
+      renderPage({ answers: [yes(q1), no(q2), { questionId: q3, answer: null }] });
+      expect(rows()).toHaveLength(4);
+      expect(mark("Otázka 1")).toHaveAccessibleName("Ano");
+      expect(mark("Otázka 2")).toHaveAccessibleName("Ne");
+      expect(mark("Otázka 3")).toHaveAccessibleName("Nevím");
+      expect(mark("Otázka 4")).toHaveAccessibleName("Bez odpovědi");
+    });
+
+    it("goes back to the questions", async () => {
+      const user = userEvent.setup();
+      const { onBackClick, onShowResultsClick } = renderPage();
+
+      await user.click(screen.getByRole("button", { name: "Zpět k otázkám" }));
+      expect(onBackClick).toHaveBeenCalledTimes(1);
+      expect(onShowResultsClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the results button", () => {
+    it("is disabled until something is answered", async () => {
+      const user = userEvent.setup();
+      const { onShowResultsClick } = renderPage({ answers: [{ questionId: q1 }] });
+
+      expect(results()).toBeDisabled();
+      await user.click(results());
+      expect(onShowResultsClick).not.toHaveBeenCalled();
+    });
+
+    it("shows the results once there is an answer", async () => {
+      const user = userEvent.setup();
+      const { onShowResultsClick } = renderPage({ answers: [{ questionId: q1, answer: null }] });
+
+      expect(results()).toBeEnabled();
+      await user.click(results());
+      expect(onShowResultsClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("filters", () => {
+    it("offers Vše and the topics always, Přeskočené and Důležité only when they would leave anything", () => {
+      renderPage();
+      expect(chips().map((button) => button.textContent)).toEqual(["Vše4", "Přeskočené4", "Doprava2", "Školství2"]);
+      expect(chip("Vše")).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("counts the answers into the chips", () => {
+      renderPage({ answers: [yes(q1), { questionId: q2, answer: false, isImportant: true }, yes(q3), yes(q4)] });
+      expect(chips().map((button) => button.textContent)).toEqual(["Vše4", "Důležité1", "Doprava2", "Školství2"]);
+    });
+
+    it("filters the rows", async () => {
+      const user = userEvent.setup();
+      renderPage({ answers: [yes(q1), { questionId: q2, answer: false, isImportant: true }] });
+
+      await user.click(chip("Důležité"));
+      expect(rows()).toHaveLength(1);
+      expect(row("Otázka 2")).toBeInTheDocument();
+
+      await user.click(chip("Školství"));
+      expect(rows().map((item) => item.textContent)).toEqual(["Otázka 3", "Otázka 4"]);
+
+      await user.click(chip("Přeskočené"));
+      expect(rows()).toHaveLength(2);
+
+      await user.click(chip("Vše"));
+      expect(rows()).toHaveLength(4);
+    });
+
+    it("keys the list on the filter, so switching replays the entrance", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      const before = list();
+
+      await user.click(chip("Doprava"));
+      expect(list()).not.toBe(before);
+      expect(list()).toHaveClass("koa:animate-(--ko-animate-recap-list-in)");
+    });
+
+    it("shows the empty state when the active filter runs dry, and Zobrazit vše returns to everything", async () => {
+      const user = userEvent.setup();
+      renderPage({ answers: [{ questionId: q1, answer: true, isImportant: true }] });
+
+      await user.click(chip("Důležité"));
+      expect(rows()).toHaveLength(1);
+
+      await user.click(star("Otázka 1"));
+      expect(screen.queryByRole("list")).toBeNull();
+      expect(screen.getByText("V tomto výběru nejsou žádné otázky.")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Zobrazit vše" }));
+      expect(rows()).toHaveLength(4);
+      expect(chip("Vše")).toHaveAttribute("aria-pressed", "true");
+      expect(screen.queryByRole("button", { name: /^Důležité/ })).toBeNull();
+    });
+  });
+
+  describe("the star", () => {
+    it("toggles important right from the row", async () => {
+      const user = userEvent.setup();
+      const { stored } = renderPage({ answers: [yes(q1)] });
+
+      await user.click(star("Otázka 1"));
+      expect(stored(q1)).toEqual({ questionId: q1, answer: true, isImportant: true });
+      expect(star("Otázka 1")).toHaveAttribute("aria-pressed", "true");
+      expect(statement()).toBeNull();
+
+      await user.click(star("Otázka 1"));
+      expect(stored(q1)).toEqual({ questionId: q1, answer: true, isImportant: false });
+    });
+
+    it("is locked on a question passed over, but not on one only looked at or never reached", () => {
+      renderPage({ answers: [{ questionId: q1, answer: undefined, isImportant: false }, { questionId: q2 }] });
+      expect(star("Otázka 1")).toBeDisabled();
+      expect(row("Otázka 1")?.firstElementChild).toHaveAttribute("data-secondary");
+      expect(star("Otázka 2")).toBeEnabled();
+      expect(star("Otázka 3")).toBeEnabled();
+    });
+
+    it("stays armable on a question starred before it was answered, and after the star is taken back", async () => {
+      const user = userEvent.setup();
+      const { stored } = renderPage();
+
+      await user.click(star("Otázka 1"));
+      expect(stored(q1)).toEqual({ questionId: q1, isImportant: true });
+      expect(star("Otázka 1")).toBeEnabled();
+      expect(row("Otázka 1")?.firstElementChild).not.toHaveAttribute("data-secondary");
+
+      // Taking it back leaves the entry as an arrival would, not as a skip — the star must not lock on a mis-tap.
+      await user.click(star("Otázka 1"));
+      expect(stored(q1)).toEqual({ questionId: q1 });
+      expect(star("Otázka 1")).toBeEnabled();
+      expect(star("Otázka 1")).toHaveAttribute("aria-pressed", "false");
+    });
+  });
+
+  describe("the dialog", () => {
+    it("opens the full question from a row", async () => {
+      const user = userEvent.setup();
+      renderPage({ answers: [yes(q2)] });
+      expect(statement()).toBeNull();
+
+      await user.click(opener("Otázka 2"));
+      expect(dialog().open).toBe(true);
+      expect(statement()).toHaveTextContent("Tvrzení 2");
+      expect(within(dialog()).getByRole("button", { name: "Ano" })).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("writes an answer taken in the dialog, updates the row and closes", () => {
+      vi.useFakeTimers();
+      try {
+        const { stored } = renderPage();
+
+        fireEvent.click(opener("Otázka 2"));
+        fireEvent.click(within(dialog()).getByRole("button", { name: "Ne" }));
+        expect(stored(q2)).toEqual({ questionId: q2, answer: false });
+        expect(mark("Otázka 2")).toHaveAccessibleName("Ne");
+        expect(screen.getByText("Zodpovězeno 1 z 4")).toBeInTheDocument();
+
+        // The card flies out on the answer; the dialog closes behind the flight.
+        act(() => {
+          vi.runAllTimers();
+        });
+        expect(statement()).toBeNull();
+        expect(dialog().open).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clears an answer chosen a second time and stays open on the now-empty row", async () => {
+      const user = userEvent.setup();
+      const { stored } = renderPage({ answers: [{ questionId: q1, answer: true, isImportant: true }] });
+
+      await user.click(opener("Otázka 1"));
+      await user.click(within(dialog()).getByRole("button", { name: "Ano" }));
+      expect(stored(q1)).toEqual({ questionId: q1, answer: undefined, isImportant: false });
+      expect(mark("Otázka 1")).toHaveAccessibleName("Bez odpovědi");
+      expect(statement()).toHaveTextContent("Tvrzení 1");
+      expect(dialog().open).toBe(true);
+    });
+
+    it("skips from the dialog, dropping the star with the position", () => {
+      const { stored } = renderPage({ answers: [{ questionId: q1, answer: true, isImportant: true }] });
+
+      fireEvent.click(opener("Otázka 1"));
+      fireEvent.keyDown(dialog(), { key: "ArrowDown" });
+      expect(stored(q1)).toEqual({ questionId: q1, answer: undefined, isImportant: false });
+      expect(mark("Otázka 1")).toHaveAccessibleName("Bez odpovědi");
+      expect(star("Otázka 1")).toBeDisabled();
+    });
+
+    it("stars from the dialog", async () => {
+      const user = userEvent.setup();
+      const { stored } = renderPage({ answers: [yes(q3)] });
+
+      await user.click(opener("Otázka 3"));
+      await user.click(within(dialog()).getByRole("button", { name: "Pro mě důležité" }));
+      expect(stored(q3)).toEqual({ questionId: q3, answer: true, isImportant: true });
+      expect(star("Otázka 3")).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("closes on Escape and on the corner close without touching the answer", async () => {
+      const user = userEvent.setup();
+      const { stored } = renderPage({ answers: [yes(q1)] });
+
+      await user.click(opener("Otázka 1"));
+      fireEvent.keyDown(dialog(), { key: "Escape" });
+      // The card fades out; the dialog closes once that animation has ended.
+      fireEvent.animationEnd(dialog().firstElementChild as Element);
+      expect(dialog().open).toBe(false);
+      expect(statement()).toBeNull();
+
+      await user.click(opener("Otázka 1"));
+      await user.click(within(dialog()).getByRole("button", { name: "Zavřít" }));
+      fireEvent.animationEnd(dialog().firstElementChild as Element);
+      expect(dialog().open).toBe(false);
+      expect(stored(q1)).toEqual({ questionId: q1, answer: true });
+    });
+  });
+
+  describe("scrolling the list", () => {
+    /* jsdom lays nothing out, so the list's extent has to be stated. */
+    function scrollable(height: number, viewport: number) {
+      Object.defineProperty(scroller(), "scrollHeight", { configurable: true, value: height });
+      Object.defineProperty(scroller(), "clientHeight", { configurable: true, value: viewport });
+    }
+
+    const scrollTo = (top: number) => fireEvent.scroll(scroller(), { target: { scrollTop: top } });
+
+    it("collapses the header scrolling down and expands it scrolling back up", () => {
+      renderPage();
+      scrollable(1000, 400);
+      expect(recapHeader()).not.toHaveAttribute("data-collapsed");
+      expect(topFade()).not.toHaveAttribute("data-visible");
+
+      scrollTo(100);
+      expect(recapHeader()).toHaveAttribute("data-collapsed");
+      expect(topFade()).toHaveAttribute("data-visible");
+
+      scrollTo(80);
+      expect(recapHeader()).not.toHaveAttribute("data-collapsed");
+
+      scrollTo(300);
+      expect(recapHeader()).toHaveAttribute("data-collapsed");
+    });
+
+    it("ignores small movements and the dead zones at either end", () => {
+      renderPage();
+      scrollable(1000, 400);
+
+      scrollTo(100);
+      scrollTo(96);
+      expect(recapHeader()).toHaveAttribute("data-collapsed");
+
+      // The bottom's elastic bounce reports a reverse scroll — not a reason to reopen.
+      scrollTo(590);
+      scrollTo(585);
+      expect(recapHeader()).toHaveAttribute("data-collapsed");
+
+      // Back near the top the header is simply open, whichever way the last move went.
+      scrollTo(10);
+      expect(recapHeader()).not.toHaveAttribute("data-collapsed");
+      expect(topFade()).toHaveAttribute("data-visible");
+      scrollTo(0);
+      expect(topFade()).not.toHaveAttribute("data-visible");
+    });
+  });
+});

--- a/packages/app/src/components/review-page.tsx
+++ b/packages/app/src/components/review-page.tsx
@@ -1,0 +1,438 @@
+"use client";
+
+// Ported from kalkulacka-2026/apps/web/components/recap.tsx (+ recap.module.css)
+import { Button, FilterChips, QuestionDialog, RecapRow } from "@kalkulacka-one/design-system/client";
+import { icons } from "@kalkulacka-one/design-system/icons";
+import { AppHeader, EdgeFade, Shell, StickyBar } from "@kalkulacka-one/design-system/server";
+import type { Answer } from "@kalkulacka-one/schema";
+
+import { useTranslations } from "next-intl";
+import { type ReactNode, useCallback, useRef, useState } from "react";
+
+import { answersByQuestion, answerTone, hasAnswer, isSkipped } from "@/answers";
+import { useAnswersStore } from "@/client/stores";
+import { useQuestions, useRecapTotals } from "@/client/view-models";
+import { buildRecapFilters, filterRecapQuestions, RECAP_FILTER_ALL, type RecapFilterId } from "@/recap";
+
+import { toCardContent } from "./question-page";
+
+export type ReviewPage = {
+  /** The header wordmark text, e.g. "Volební kalkulačka" — the product name, owned by the app. */
+  appTitle: string;
+  /** The election's display name, e.g. "Sněmovní volby 2025". */
+  electionName?: string;
+  /** The calculator's display name — the header's subtitle. */
+  calculatorName: string;
+  /** Right side of the header: today the app's close button, later the menu. */
+  headerActions?: ReactNode;
+  /** Embeds: makes the wordmark an outbound link to the full site. */
+  attributionHref?: string;
+  logoMonochrome?: boolean;
+  /** "Zpět k otázkám" — the app takes the reader to the last question, the card this screen follows. */
+  onBackClick: () => void;
+  /** "Zobrazit výsledky" — the app takes the reader to the result. Never called with nothing answered; the control is disabled then. */
+  onShowResultsClick: () => void;
+};
+
+/*
+ * The recap is a fixed composition, like the deck — not a document.
+ *
+ * `Screen` (the scroll-the-whole-page shell the other content screens use) is
+ * deliberately not used here. This screen follows the last question directly,
+ * and having the title and the primary action scroll away made the transition
+ * out of the deck feel like leaving the app. So the frame holds still and the
+ * list is the only thing that moves.
+ *
+ * On a wide screen the deck leaves room below itself on a tall viewport rather
+ * than stretching to fill it (the question page's stage caps the same way);
+ * the recap matches that instead of using every last pixel just because a
+ * flex box will happily give it away.
+ */
+const screenClasses =
+  "koa:flex-1 koa:min-h-0 koa:flex koa:pl-[calc(var(--ko-spacing-fluid-gutter)+env(safe-area-inset-left,0px))] koa:pr-[calc(var(--ko-spacing-fluid-gutter)+env(safe-area-inset-right,0px))] koa:min-[56rem]:pb-8";
+
+/*
+ * A *pinned* shell's app bar carries no bottom padding of its own — in
+ * `document` mode the bar adds 0.75rem there (`.ko-shell-bar` in the design
+ * system's `styles.css`), so the top padding here makes up the difference over
+ * the screens' usual head clearance (1rem, 2rem from `lg`, as `Screen` has
+ * it) and every screen's back link lands on the same line regardless of
+ * scroll mode.
+ */
+const innerClasses = "koa:flex-1 koa:min-h-0 koa:flex koa:flex-col koa:gap-4 koa:w-full koa:max-w-[62rem] koa:mx-auto koa:pt-7 koa:lg:pt-11";
+
+/*
+ * Arriving from the deck, the screen assembles rather than appears: the header
+ * leads, the filters and the list follow a beat later. The stagger is small on
+ * purpose — this is a transition between two steps of one task, not a curtain
+ * going up. The keyframes are the design system's (`--ko-animate-recap-rise`).
+ */
+const riseClasses = "koa:animate-(--ko-animate-recap-rise) koa:motion-reduce:animate-none";
+
+/*
+ * Collapses to just the filter row below while scrolling forward on a phone
+ * (`data-collapsed`, mobile-only) — `.ko-recap-header` in the design system's
+ * `styles.css` is the grid that lets that animate to and from an unknown
+ * content height instead of a guessed `max-height`.
+ */
+const headerClasses = `ko-recap-header koa:flex-none ${riseClasses}`;
+const headerInnerClasses = "koa:flex koa:flex-col koa:gap-4";
+
+/*
+ * Every screen puts the way back at the top of a flex column, whose default
+ * `align-items: stretch` would pull the button to the full width of the page.
+ * `Button` deliberately does not accept a `className`, so the alignment lives
+ * on a wrapper — the same one the guide wears.
+ */
+const backClasses = "koa:inline-flex koa:self-start koa:max-w-full";
+
+/*
+ * Title and tally share a line from `wide` (56rem, the design system's "the
+ * recap's two columns" breakpoint — spelled out here because the app package
+ * has no named breakpoints of its own): the header stops being a stack of four
+ * paragraphs and becomes one band, which is where the extra whitespace on a
+ * desktop actually comes from.
+ */
+const headlineClasses = "koa:flex koa:flex-col koa:gap-3 koa:min-[56rem]:flex-row koa:min-[56rem]:items-end koa:min-[56rem]:justify-between koa:min-[56rem]:gap-6";
+const titlesClasses = "koa:flex koa:flex-col koa:gap-2 koa:min-w-0";
+const titleClasses =
+  "koa:m-0 koa:font-(family-name:--ko-font-display) koa:text-(length:--ko-text-title) koa:font-bold koa:tracking-[-0.045em] koa:leading-[1.1] koa:text-(--ko-color-text) koa:text-balance";
+
+/*
+ * Wide enough for one line from `wide`. Every line the header takes is a row
+ * of questions the list doesn't get, and on this screen the list is the point.
+ */
+const descriptionClasses = "koa:m-0 koa:max-w-[32rem] koa:min-[56rem]:max-w-[42rem] koa:text-[0.9375rem] koa:leading-[1.45] koa:text-(--ko-color-text-muted) koa:text-pretty";
+
+/*
+ * The tally sits beside the title on a wide screen rather than under it: it is
+ * the answer to "am I done?", and putting it on the same line as the question
+ * makes the header one statement instead of four stacked ones.
+ */
+const tallyClasses =
+  "koa:flex koa:flex-wrap koa:items-baseline koa:gap-x-2 koa:gap-y-1 koa:m-0 koa:min-[56rem]:flex-none koa:min-[56rem]:flex-col koa:min-[56rem]:items-end koa:min-[56rem]:text-right";
+const countClasses = "koa:text-[0.9375rem] koa:font-bold koa:text-(--ko-color-text-strong) koa:whitespace-nowrap";
+const mutedClasses = "koa:text-sm koa:text-(--ko-color-text-muted)";
+
+const filtersClasses = `koa:flex-none ${riseClasses} koa:[animation-delay:60ms]`;
+
+/*
+ * Everything below the filters lives in this one positioned box: the list (or
+ * the empty state) fills it, the `EdgeFade` bands sit over its edges (they
+ * position against this box), and the control panel floats over the bottom
+ * band rather than taking a row of its own beneath it. `min-h-0` is what lets
+ * it shrink inside the flex column instead of pushing past the viewport.
+ */
+const listShellClasses = `koa:relative koa:flex-1 koa:min-h-0 ${riseClasses} koa:[animation-delay:110ms]`;
+
+/*
+ * The scroller. The 3px of padding, pulled back with a matching negative
+ * margin, is room for row focus rings, which a tight scroll box would clip;
+ * the bottom padding keeps the last row clear of the floating button — it
+ * tracks the action band's height.
+ */
+const listWrapClasses =
+  "koa:absolute koa:inset-0 koa:overflow-y-auto koa:overscroll-contain koa:[-webkit-overflow-scrolling:touch] koa:scroll-smooth koa:px-[3px] koa:-mx-[3px] koa:pb-[calc(var(--ko-spacing-fade-action)-0.5rem)]";
+
+/*
+ * Two columns once there is width for them — the point is not density but
+ * *less scrolling*: forty-two rows in one column is a long haul past the very
+ * viewport edge this screen is trying to hold still.
+ *
+ * The entrance (`--ko-animate-recap-list-in`) is replayed on every filter
+ * change via the `key={filter}` remount below — a new result set deserves its
+ * own small entrance, not a silent swap.
+ */
+const listClasses = "koa:grid koa:grid-cols-1 koa:min-[56rem]:grid-cols-2 koa:gap-3 koa:m-0 koa:p-0 koa:list-none koa:animate-(--ko-animate-recap-list-in) koa:motion-reduce:animate-none";
+
+/*
+ * Clears the floating control panel the same way the list's own bottom padding
+ * does, so "Zobrazit vše" never sits under "Zobrazit výsledky".
+ */
+const emptyClasses = "koa:absolute koa:inset-0 koa:pb-(--ko-spacing-fade-action) koa:flex koa:flex-col koa:items-center koa:justify-center koa:gap-3 koa:text-center";
+const emptyTextClasses = "koa:m-0 koa:text-[0.9375rem] koa:text-(--ko-color-text-muted)";
+
+/*
+ * The control panel — floating over the bottom `EdgeFade` band rather than in
+ * a row beneath it, so the list reads as continuing underneath it instead of
+ * stopping to make room. Its height is the same `--ko-spacing-fade-action`
+ * token the band uses, so the two stay one number by construction.
+ * Bottom-aligned within the band rather than centred in it: the shell's
+ * content is already sized to `100dvh`, the live-tracking edge just above the
+ * browser's own chrome, so the button only needs a small margin off that
+ * edge, not half the band's height. Centred horizontally on a phone; from
+ * `wide` it sits under the list's own right edge, not centred beneath a
+ * column-and-a-half of rows it has no relationship to. `z-3` keeps it above
+ * the band (the fade paints at 2). Transparent to pointers except for the bar
+ * itself, so the rows showing through the band stay reachable.
+ */
+const footerClasses =
+  "koa:absolute koa:left-0 koa:right-0 koa:bottom-0 koa:h-(--ko-spacing-fade-action) koa:z-3 koa:flex koa:items-end koa:justify-center koa:min-[56rem]:justify-end koa:pb-[max(0.75rem,env(safe-area-inset-bottom,0px))] koa:pointer-events-none koa:[&>*]:w-fit koa:[&>*]:pointer-events-auto";
+
+/**
+ * Every question at once — as a list you scan, not a stack you re-read.
+ *
+ * Two things shape this screen. First, edits go straight to the same store the
+ * deck writes to, so this is a second *view* of the answers rather than a copy:
+ * there is no save step and no way for the two screens to disagree. Second, the
+ * screen does not scroll — only the list inside it does. The deck is a fixed,
+ * balanced composition, and a recap that scrolled the title and the call to
+ * action off the top made the step after it feel like a different product.
+ *
+ * A button rather than a link for the way back and the results, like the other
+ * screens: the app owns the routes, and the recap only says where the reader
+ * wants to go.
+ */
+export function ReviewPage({ appTitle, electionName, calculatorName, headerActions, attributionHref, logoMonochrome, onBackClick, onShowResultsClick }: ReviewPage) {
+  const t = useTranslations("koa.components.reviewPage");
+  const { questions } = useQuestions();
+  const answers = useAnswersStore((state) => state.answers);
+  const setAnswer = useAnswersStore((state) => state.setAnswer);
+  const { total, answered, remaining } = useRecapTotals();
+
+  const [filter, setFilter] = useState<RecapFilterId>(RECAP_FILTER_ALL);
+  /** The question the dialog is showing, as an index into `questions`. */
+  const [openIndex, setOpenIndex] = useState<number | undefined>();
+
+  /** Whether the list has been scrolled away from its top edge — drives the top fade (there's more above). */
+  const [scrolled, setScrolled] = useState(false);
+  /**
+   * On a phone, the header (back link, title, description, tally) collapses
+   * to just the filter row while scrolling forward through the list, and
+   * re-expands the moment the scroll reverses — the common "toolbar hides
+   * advancing, reappears on the way back" pattern, not merely "hidden until
+   * you're back at the very top". `lastScrollTopRef` is what makes it
+   * direction-aware rather than distance-from-top-aware.
+   */
+  const [headerCollapsed, setHeaderCollapsed] = useState(false);
+  const lastScrollTopRef = useRef(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = useCallback(() => {
+    const el = listRef.current;
+    const top = el?.scrollTop ?? 0;
+    setScrolled(top > 4);
+
+    // A dead zone at *both* ends, not just the top: the elastic overscroll
+    // bounce at the bottom of the list reports a few small reverse-direction
+    // scroll events while it springs back, and without this a scroll that
+    // simply reaches the end reads as "scrolled up" and flickers the header
+    // back open for a frame before it re-collapses.
+    const maxTop = el ? el.scrollHeight - el.clientHeight : 0;
+    if (top <= 24) {
+      setHeaderCollapsed(false);
+      lastScrollTopRef.current = top;
+      return;
+    }
+    if (top >= maxTop - 24) {
+      lastScrollTopRef.current = top;
+      return;
+    }
+
+    const delta = top - lastScrollTopRef.current;
+    if (delta > 8) setHeaderCollapsed(true);
+    else if (delta < -8) setHeaderCollapsed(false);
+    lastScrollTopRef.current = top;
+  }, []);
+
+  // Which questions a filter leaves, and what each chip counts, is `@/recap`'s
+  // to decide — this screen only lays the answer out.
+  const options = buildRecapFilters(questions, answers, {
+    all: t("filterAll"),
+    unanswered: t("filterUnanswered"),
+    important: t("filterImportant"),
+  });
+
+  const visible = filterRecapQuestions(questions, answers, filter);
+  const lookup = answersByQuestion(answers);
+
+  const openQuestion = openIndex === undefined ? undefined : questions[openIndex];
+  const openAnswer = openQuestion ? lookup.get(openQuestion.id) : undefined;
+
+  /**
+   * How an answer reads aloud — the accessible name behind a row's mark. The
+   * mark is a bare coloured circle, so this string *is* the answer as far as a
+   * screen reader is concerned; the tone that draws it is `answerTone`'s, and
+   * this is its counterpart for the words.
+   */
+  const answerLabel = (answer?: Answer) => {
+    const tone = answerTone(answer);
+    if (tone === "agree") return t("yes");
+    if (tone === "disagree") return t("no");
+    if (tone === "neutral") return t("neutral");
+    return t("none");
+  };
+
+  /**
+   * Toggle "pro mě důležité" — from a row's star or from the dialog. Can be
+   * armed before answering, like on the deck: the flag is carried into
+   * whichever answer is then given.
+   */
+  const toggleImportant = (questionId: string) => {
+    const current = lookup.get(questionId);
+    const next = !current?.isImportant;
+    // Un-starring a question with no position leaves the entry as an arrival
+    // would: `false` beside a missing position is the record of a skip (see
+    // `isSkipped`), and a mis-tapped star must not lock the row.
+    setAnswer({ questionId, isImportant: next ? true : hasAnswer(current) ? false : undefined });
+  };
+
+  const handleAnswer = (agree: boolean) => {
+    if (!openQuestion) return;
+
+    // Re-choosing the same answer clears it — an undo, not a decision — so the
+    // dialog stays open to show the row's mark go empty. Same rule the deck
+    // uses to decide whether an answer counts as progress. 2026 dropped the
+    // entry outright; here it stays (an entry without a position is how this
+    // platform records "visited"), but the flag goes with the position as it
+    // did there — "important" only makes sense attached to a real one.
+    const isClearing = openAnswer?.answer === agree;
+    if (isClearing) {
+      setAnswer({ questionId: openQuestion.id, answer: undefined, isImportant: false });
+      return;
+    }
+
+    setAnswer({ questionId: openQuestion.id, answer: agree });
+    setOpenIndex(undefined);
+  };
+
+  /** Explicitly skip — the position and the flag both go, as the flow's own skip does. */
+  const handleSkip = () => {
+    if (!openQuestion) return;
+    setAnswer({ questionId: openQuestion.id, answer: undefined, isImportant: false });
+    setOpenIndex(undefined);
+  };
+
+  const handleClose = useCallback(() => setOpenIndex(undefined), []);
+
+  return (
+    <Shell
+      scroll="pinned"
+      header={<AppHeader title={appTitle} electionName={electionName} calculatorName={calculatorName} href={attributionHref} logoMonochrome={logoMonochrome} actions={headerActions} />}
+    >
+      <main className={screenClasses}>
+        <div className={innerClasses}>
+          {/*
+            Collapses to just the filter row below while scrolling forward on
+            a phone (`data-collapsed`, mobile-only in the CSS) — the grid
+            wrapping the inner element is what lets that animate to and from an
+            unknown content height instead of a guessed `max-height`.
+          */}
+          <header className={headerClasses} data-collapsed={headerCollapsed || undefined}>
+            <div className={headerInnerClasses}>
+              <span className={backClasses}>
+                <Button variant="plate" size="small" iconStart={icons.chevronLeftThin} onClick={onBackClick}>
+                  {t("back")}
+                </Button>
+              </span>
+
+              <div className={headlineClasses}>
+                <div className={titlesClasses}>
+                  <h1 className={titleClasses}>{t("title")}</h1>
+                  <p className={descriptionClasses}>{t("description")}</p>
+                </div>
+
+                {/*
+                  The tally sits beside the title on a wide screen rather than
+                  under it: it is the answer to "am I done?", and putting it on
+                  the same line as the question makes the header one statement
+                  instead of four stacked ones.
+                */}
+                <p className={tallyClasses}>
+                  <span className={countClasses}>{t("tally", { answered, total })}</span>
+                  {remaining > 0 ? <span className={mutedClasses}>{t("skipped", { remaining })}</span> : null}
+                </p>
+              </div>
+            </div>
+          </header>
+
+          <div className={filtersClasses}>
+            <FilterChips label={t("filterLabel")} options={options} value={filter} onChange={(id) => setFilter(id as RecapFilterId)} />
+          </div>
+
+          <div className={listShellClasses}>
+            {visible.length === 0 ? (
+              <div className={emptyClasses}>
+                <p className={emptyTextClasses}>{t("empty")}</p>
+                <Button variant="surface" size="small" onClick={() => setFilter(RECAP_FILTER_ALL)}>
+                  {t("showAll")}
+                </Button>
+              </div>
+            ) : (
+              <>
+                {/* Only there to say "there's more above" — invisible at rest,
+                    faded in once the list has actually moved. */}
+                <EdgeFade edge="top" visible={scrolled} />
+
+                <div ref={listRef} className={listWrapClasses} onScroll={handleScroll}>
+                  {/* Keyed on the filter so switching it replays the entrance
+                      animation — the rows on screen after a filter change are a
+                      new result, not a continuation of the old list. */}
+                  <ul className={listClasses} key={filter}>
+                    {visible.map(({ question, index }) => {
+                      const answer = lookup.get(question.id);
+
+                      return (
+                        <RecapRow
+                          key={question.id}
+                          title={question.title}
+                          tone={answerTone(answer)}
+                          important={answer?.isImportant === true}
+                          skipped={isSkipped(answer)}
+                          labels={{
+                            answer: answerLabel(answer),
+                            important: t("important"),
+                          }}
+                          onOpen={() => setOpenIndex(index)}
+                          onToggleImportant={() => toggleImportant(question.id)}
+                        />
+                      );
+                    })}
+                  </ul>
+                </div>
+
+                {/* The tall `action` band, so the control panel below reads as
+                    floating over the list rather than sitting in a lane of its
+                    own underneath it. */}
+                <EdgeFade edge="bottom" size="action" />
+              </>
+            )}
+
+            <div className={footerClasses}>
+              <StickyBar>
+                {/*
+                  With nothing answered there is nothing to compare, so the control
+                  is a genuinely disabled button rather than a link wearing
+                  `aria-disabled` — which would still navigate on click.
+                */}
+                <Button variant="solid" color="neutral" size="large" iconEnd={icons.arrowRight} disabled={answered === 0} onClick={onShowResultsClick}>
+                  {t("showResults")}
+                </Button>
+              </StickyBar>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      <QuestionDialog
+        question={openQuestion ? toCardContent(openQuestion) : undefined}
+        selection={{
+          agree: openAnswer?.answer === true,
+          disagree: openAnswer?.answer === false,
+          important: openAnswer?.isImportant === true,
+        }}
+        labels={{
+          agree: t("yes"),
+          disagree: t("no"),
+          important: t("important"),
+          skip: t("skip"),
+          close: t("close"),
+        }}
+        onClose={handleClose}
+        onAnswer={handleAnswer}
+        onSkip={handleSkip}
+        onToggleImportant={() => openQuestion && toggleImportant(openQuestion.id)}
+      />
+    </Shell>
+  );
+}

--- a/packages/app/src/locales/cs.json
+++ b/packages/app/src/locales/cs.json
@@ -126,6 +126,27 @@
       "reviewNavigationCard": {
         "showResultsButton": "Zobrazit výsledky"
       },
+      "reviewPage": {
+        "title": "Rekapitulace",
+        "description": "Zkontrolujte odpovědi, než se podíváte na výsledek. Klepnutím na otázku ji můžete změnit.",
+        "tally": "Zodpovězeno {answered} z {total}",
+        "skipped": "Přeskočeno {remaining}",
+        "filterLabel": "Filtrovat otázky",
+        "filterAll": "Vše",
+        "filterUnanswered": "Přeskočené",
+        "filterImportant": "Důležité",
+        "empty": "V tomto výběru nejsou žádné otázky.",
+        "showAll": "Zobrazit vše",
+        "showResults": "Zobrazit výsledky",
+        "back": "Zpět k otázkám",
+        "yes": "Ano",
+        "no": "Ne",
+        "neutral": "Nevím",
+        "none": "Bez odpovědi",
+        "important": "Pro mě důležité",
+        "skip": "Přeskočit",
+        "close": "Zavřít"
+      },
       "reviewQuestionCard": {
         "yes": "Ano",
         "no": "Ne",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -126,6 +126,27 @@
       "reviewNavigationCard": {
         "showResultsButton": "Show results"
       },
+      "reviewPage": {
+        "title": "Recap",
+        "description": "Check your answers before you look at the result. Tap a question to change it.",
+        "tally": "Answered {answered} of {total}",
+        "skipped": "Skipped {remaining}",
+        "filterLabel": "Filter questions",
+        "filterAll": "All",
+        "filterUnanswered": "Skipped",
+        "filterImportant": "Important",
+        "empty": "There are no questions in this selection.",
+        "showAll": "Show all",
+        "showResults": "Show results",
+        "back": "Back to questions",
+        "yes": "Yes",
+        "no": "No",
+        "neutral": "Don't know",
+        "none": "No answer",
+        "important": "Important to me",
+        "skip": "Skip",
+        "close": "Close"
+      },
       "reviewQuestionCard": {
         "yes": "Yes",
         "no": "No",

--- a/packages/app/src/locales/mk.json
+++ b/packages/app/src/locales/mk.json
@@ -126,6 +126,27 @@
       "reviewNavigationCard": {
         "showResultsButton": "Прикажи резултати"
       },
+      "reviewPage": {
+        "title": "Рекапитулација",
+        "description": "Проверете ги одговорите пред да го видите резултатот. Допрете на прашање за да го промените.",
+        "tally": "Одговорени {answered} од {total}",
+        "skipped": "Прескокнати {remaining}",
+        "filterLabel": "Филтрирај прашања",
+        "filterAll": "Сите",
+        "filterUnanswered": "Прескокнати",
+        "filterImportant": "Важни",
+        "empty": "Во овој избор нема прашања.",
+        "showAll": "Прикажи сè",
+        "showResults": "Прикажи резултати",
+        "back": "Назад кон прашањата",
+        "yes": "Да",
+        "no": "Не",
+        "neutral": "Не знам",
+        "none": "Без одговор",
+        "important": "Важно за мене",
+        "skip": "Прескокни",
+        "close": "Затвори"
+      },
       "reviewQuestionCard": {
         "yes": "Да",
         "no": "Не",

--- a/packages/app/src/locales/sk.json
+++ b/packages/app/src/locales/sk.json
@@ -126,6 +126,27 @@
       "reviewNavigationCard": {
         "showResultsButton": "Zobraziť výsledky"
       },
+      "reviewPage": {
+        "title": "Rekapitulácia",
+        "description": "Skontrolujte odpovede, než sa pozriete na výsledok. Klepnutím na otázku ju môžete zmeniť.",
+        "tally": "Zodpovedané {answered} z {total}",
+        "skipped": "Preskočené {remaining}",
+        "filterLabel": "Filtrovať otázky",
+        "filterAll": "Všetko",
+        "filterUnanswered": "Preskočené",
+        "filterImportant": "Dôležité",
+        "empty": "V tomto výbere nie sú žiadne otázky.",
+        "showAll": "Zobraziť všetko",
+        "showResults": "Zobraziť výsledky",
+        "back": "Späť k otázkam",
+        "yes": "Áno",
+        "no": "Nie",
+        "neutral": "Neviem",
+        "none": "Bez odpovede",
+        "important": "Pre mňa dôležité",
+        "skip": "Preskočiť",
+        "close": "Zavrieť"
+      },
       "reviewQuestionCard": {
         "yes": "Áno",
         "no": "Nie",

--- a/packages/design-system/src/styles.css
+++ b/packages/design-system/src/styles.css
@@ -377,6 +377,37 @@
     }
   }
 
+  /*
+   * The recap (the app's `ReviewPage`) arriving from the deck: the screen
+   * assembles rather than appears — the header leads, the filters and the
+   * list follow a beat later, each through `animate-(--ko-animate-recap-rise)`
+   * with its own delay. The stagger is small on purpose: this is a transition
+   * between two steps of one task, not a curtain going up. The second is the
+   * list's own, smaller entrance, replayed on every filter change (the list is
+   * keyed on the filter): a new result set deserves its own small entrance,
+   * not a silent swap. Literal timings, as in the source — these are one-shot
+   * entrances rather than the control tempo the duration tokens describe — so
+   * the consumer switches them off under reduced motion
+   * (`motion-reduce:animate-none`) instead of relying on the collapse.
+   * Ported from kalkulacka-2026/apps/web/components/recap.module.css (`rise`, `listIn`).
+   */
+  --animate-recap-rise: ko-recap-rise 420ms var(--ko-ease-spring) backwards;
+  --animate-recap-list-in: ko-recap-list-in 260ms var(--ko-ease-spring) backwards;
+
+  @keyframes ko-recap-rise {
+    from {
+      opacity: 0;
+      transform: translateY(12px);
+    }
+  }
+
+  @keyframes ko-recap-list-in {
+    from {
+      opacity: 0;
+      transform: translateY(6px) scale(0.99);
+    }
+  }
+
   /* Elevation, tinted with the neutral so shadows belong to the theme. */
   --shadow-card: 0 4px 12px -2px oklch(from var(--ko-shadow-color) l c h / 0.1), 0 16px 36px -8px oklch(from var(--ko-shadow-color) l c h / 0.18);
   --shadow-card-next: 0 2px 8px -2px oklch(from var(--ko-shadow-color) l c h / 0.08), 0 10px 24px -6px oklch(from var(--ko-shadow-color) l c h / 0.14);
@@ -1360,5 +1391,46 @@
 
   .ko-question-dialog[data-closing]::backdrop {
     animation: var(--ko-animate-veil-out);
+  }
+
+  /* --- Recap header ----------------------------------------------------------
+   * Ported from kalkulacka-2026/apps/web/components/recap.module.css
+   * (`.header`, `.headerInner`). The one hook the app's `ReviewPage` needs
+   * from here — the rest of that screen is `koa:` utilities in
+   * review-page.tsx. It lives in this layer because the collapse keys on an
+   * attribute of the header and reaches into its child, and because both
+   * elements switch layout under one media query — which a utility on each
+   * would spell out twice and could drift on.
+   *
+   * Phone-only: while scrolling forward through the list, the header collapses
+   * to just the filter row below it, and re-expands the moment the scroll
+   * reverses (`review-page.tsx` tracks direction, not just distance from the
+   * top — the common "toolbar hides advancing, reappears on the way back"
+   * pattern). Same breakpoint as the recap's two columns (`wide`, 56rem): past
+   * it the list has the room and the header never collapses.
+   *
+   * The grid-rows trick, not `max-height`: the header's content — the back
+   * link, the title, the description, the tally — has no fixed height to guess
+   * at, and `max-height` transitions either overshoot (guess too high, the
+   * animation has dead time at the end) or clip (guess too low). Animating
+   * `grid-template-rows` from `1fr` to `0fr` instead sizes to the *actual*
+   * content every time, with the inner element's `overflow: hidden` doing the
+   * clipping as the row shrinks.
+   */
+  @media (width < 56rem) {
+    .ko-recap-header {
+      display: grid;
+      grid-template-rows: 1fr;
+      transition: grid-template-rows var(--ko-duration-slow) ease;
+    }
+
+    .ko-recap-header[data-collapsed] {
+      grid-template-rows: 0fr;
+    }
+
+    .ko-recap-header > * {
+      overflow: hidden;
+      min-height: 0;
+    }
   }
 }


### PR DESCRIPTION
Part 13 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #525. **Checkpoint C5.**

Ported from `kalkulacka-2026/apps/web/components/recap.tsx`:

- **`ReviewPage`** ("Rekapitulace"): the tally ("Zodpovězeno n z 42", muted "Přeskočeno"), filter chips (Vše / Přeskočené / Důležité / one per topic, the conditional ones only when non-empty), every question as a row with its answer mark and star, the question dialog to change an answer in place (re-choosing clears it and keeps the dialog open; skipping and starring write through), an empty-filter state with "Zobrazit vše", and the floating "Zobrazit výsledky" band, disabled until something is answered. The list is keyed on the filter so switching replays the entrance. On phones the header collapses on scroll-down and returns on scroll-up with 24 px dead zones at both ends (the source's reasoning is kept); from 56 rem the list runs in two columns and the header stays put.
- A skipped row is one whose only record is the one a skip writes (visited, no position, importance cleared), so starring a question that was never reached arms it instead of locking it; `isSkipped` joins the answer helpers.
- **Czech app**: the review wrapper renders the new page (back → the last question, results → the result route, prefetched).

Verified headlessly against the 2026 app at 375 and 1280 px after answering the same questions on both: tally, chips and counts, header collapse geometry, two columns, the dialog flow, the star, bounding boxes within a few pixels. 24 new tests.

**Checks:** typecheck, lint, tests (app 273, design-system 329), Czech app build, Czech Playwright flow (30 passed).

**Stack:** based on #525 → next: `port/14-result-primitives`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
