### PR TITLE
Add Meter, MatchRow, AvatarStack, Donut and Calculating

### DIFF
--- a/apps/design-system.kalkulacka.one/stories/Avatar.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/Avatar.stories.tsx
@@ -1,3 +1,4 @@
+// Ported from kalkulacka-2026/packages/ui/src/avatar/avatar.stories.tsx
 import { Avatar } from "@kalkulacka-one/design-system/server";
 
 import type { Meta, StoryObj } from "@storybook/nextjs";
@@ -5,183 +6,112 @@ import type { Meta, StoryObj } from "@storybook/nextjs";
 const meta: Meta<typeof Avatar> = {
   title: "Components/Avatar",
   component: Avatar,
+  tags: ["autodocs"],
+  args: { name: "Piráti a Starostové" },
   argTypes: {
-    shape: {
-      control: "select",
-      options: ["circle", "square"],
-    },
+    name: { control: "text" },
+    src: { control: "text" },
+    accent: { control: "color" },
     size: {
       control: "select",
       options: ["small", "medium", "large"],
+      defaultValue: { summary: "medium" },
     },
-    alignment: {
+    shape: {
       control: "select",
-      options: ["center", "top"],
+      options: ["circle", "square"],
+      defaultValue: { summary: "circle" },
     },
-    padding: {
-      control: "boolean",
-    },
-    backgroundColor: {
-      control: "color",
-    },
+    image: { control: "object" },
+    backgroundColor: { control: "color" },
+    alignment: { control: "select", options: ["center", "top"] },
+    padding: { control: "boolean" },
+    fit: { control: "select", options: ["cover", "contain"] },
+    className: { control: false },
   },
 };
 
 type AvatarStory = StoryObj<typeof meta>;
 
-export const PersonWithImage: AvatarStory = {
-  name: "Person with image",
-  args: {
-    shape: "circle",
-    size: "medium",
-    backgroundColor: "#ffffff",
-    alignment: "center",
-    image: {
-      original: "https://i.pravatar.cc/300?img=12",
-      md: "https://i.pravatar.cc/100?img=12",
-      sm: "https://i.pravatar.cc/80?img=12",
-    },
-  },
-};
-
-export const OrganizationWithImage: AvatarStory = {
-  name: "Organization with image",
-  args: {
-    shape: "square",
-    size: "medium",
-    backgroundColor: "#ffffff",
-    image: {
-      original: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/ODS_logo.svg/200px-ODS_logo.svg.png",
-    },
-  },
-};
+/** No logo in the data — the initials carry it. */
+export const Initials: AvatarStory = {};
 
 export const Sizes: AvatarStory = {
-  name: "Size variants",
+  render: (args) => (
+    <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+      <Avatar {...args} size="small" />
+      <Avatar {...args} size="medium" />
+      <Avatar {...args} size="large" />
+    </div>
+  ),
+};
+
+/** A picture covers the initials opaquely when it loads. */
+export const WithPicture: AvatarStory = {
+  args: { name: "Portrét", src: "https://i.pravatar.cc/128?img=12" },
+};
+
+/**
+ * A URL that cannot load. The 2026 source promised the initials would show
+ * through; in practice the failed picture keeps its box and its surface fill
+ * (see the component's comment), so this renders as a blank disc with the ring.
+ */
+export const BrokenImage: AvatarStory = {
+  args: { src: "https://archiv.volebnikalkulacka.cz/does-not-exist.png" },
+};
+
+/** The candidate's accent: a ring around the face and a wash behind it, from the same colour the match bar uses. */
+export const Accent: AvatarStory = {
+  render: (args) => (
+    <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
+      <Avatar {...args} accent="light-dark(#2563eb, #3b82f6)" />
+      <Avatar {...args} name="ANO 2011" accent="light-dark(#7c3aed, #a78bfa)" />
+      <Avatar {...args} name="ODS" accent="light-dark(#d97706, #fbbf24)" size="large" />
+      <Avatar {...args} name="Portrét" src="https://i.pravatar.cc/128?img=12" accent="light-dark(#db2777, #f472b6)" size="large" />
+    </div>
+  ),
+};
+
+/**
+ * The legacy match card's props, still honoured until it is replaced by
+ * `MatchRow`: a responsive `image` set, a square shape for organisations, a
+ * padded and contained logo over its own fill, and a portrait cropped to its
+ * top edge.
+ */
+export const Legacy: AvatarStory = {
+  name: "Legacy match card props",
   render: () => (
-    <div className="flex items-end gap-4">
-      <Avatar
-        shape="circle"
-        size="small"
-        backgroundColor="#ffffff"
-        image={{
-          original: "https://i.pravatar.cc/300?img=12",
-          md: "https://i.pravatar.cc/100?img=12",
-          sm: "https://i.pravatar.cc/80?img=12",
-        }}
-      />
-      <Avatar
-        shape="circle"
-        size="medium"
-        backgroundColor="#ffffff"
-        image={{
-          original: "https://i.pravatar.cc/300?img=12",
-          md: "https://i.pravatar.cc/100?img=12",
-          sm: "https://i.pravatar.cc/80?img=12",
-        }}
-      />
+    <div style={{ display: "flex", alignItems: "center", gap: "1rem" }}>
       <Avatar
         shape="circle"
         size="large"
-        backgroundColor="#ffffff"
+        backgroundColor="#e2e8f0"
+        alignment="top"
         image={{
           original: "https://i.pravatar.cc/300?img=12",
           md: "https://i.pravatar.cc/100?img=12",
           sm: "https://i.pravatar.cc/80?img=12",
         }}
       />
-    </div>
-  ),
-};
-
-export const CircleVsSquare: AvatarStory = {
-  name: "Circle vs Square",
-  render: () => (
-    <div className="flex items-center gap-4">
-      <div className="flex flex-col items-center gap-2">
-        <Avatar
-          shape="circle"
-          size="large"
-          backgroundColor="#ffffff"
-          image={{
-            original: "https://i.pravatar.cc/300?img=12",
-            md: "https://i.pravatar.cc/100?img=12",
-            sm: "https://i.pravatar.cc/80?img=12",
-          }}
-        />
-        <span className="text-sm text-slate-600">Circle</span>
-      </div>
-      <div className="flex flex-col items-center gap-2">
-        <Avatar
-          shape="square"
-          size="large"
-          backgroundColor="#ffffff"
-          image={{
-            original: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/ODS_logo.svg/200px-ODS_logo.svg.png",
-          }}
-        />
-        <span className="text-sm text-slate-600">Square</span>
-      </div>
-    </div>
-  ),
-};
-
-export const PortraitAlignment: AvatarStory = {
-  name: "Portrait with top alignment",
-  args: {
-    shape: "circle",
-    size: "medium",
-    backgroundColor: "#ffffff",
-    alignment: "top",
-    image: {
-      original: "https://i.pravatar.cc/300?img=12",
-      md: "https://i.pravatar.cc/100?img=12",
-      sm: "https://i.pravatar.cc/80?img=12",
-    },
-  },
-};
-
-export const WithPadding: AvatarStory = {
-  name: "Organization logo with padding",
-  args: {
-    shape: "square",
-    size: "medium",
-    backgroundColor: "#ffffff",
-    padding: true,
-    image: {
-      original: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/ODS_logo.svg/200px-ODS_logo.svg.png",
-    },
-  },
-};
-
-export const PaddingComparison: AvatarStory = {
-  name: "With vs without padding",
-  render: () => (
-    <div className="flex items-center gap-4">
-      <div className="flex flex-col items-center gap-2">
-        <Avatar
-          shape="square"
-          size="large"
-          backgroundColor="#ffffff"
-          padding={false}
-          image={{
-            original: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/ODS_logo.svg/200px-ODS_logo.svg.png",
-          }}
-        />
-        <span className="text-sm text-slate-600">No padding</span>
-      </div>
-      <div className="flex flex-col items-center gap-2">
-        <Avatar
-          shape="square"
-          size="large"
-          backgroundColor="#ffffff"
-          padding={true}
-          image={{
-            original: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/ODS_logo.svg/200px-ODS_logo.svg.png",
-          }}
-        />
-        <span className="text-sm text-slate-600">With padding</span>
-      </div>
+      <Avatar
+        shape="square"
+        size="large"
+        backgroundColor="#e2e8f0"
+        fit="contain"
+        padding
+        image={{
+          original: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/ODS_logo.svg/200px-ODS_logo.svg.png",
+        }}
+      />
+      <Avatar
+        shape="square"
+        size="large"
+        backgroundColor="#e2e8f0"
+        fit="contain"
+        image={{
+          original: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/ODS_logo.svg/200px-ODS_logo.svg.png",
+        }}
+      />
     </div>
   ),
 };

--- a/apps/design-system.kalkulacka.one/stories/AvatarStack.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/AvatarStack.stories.tsx
@@ -1,0 +1,81 @@
+// Ported from kalkulacka-2026/packages/ui/src/avatar-stack/avatar-stack.stories.tsx
+import { AvatarStack } from "@kalkulacka-one/design-system/client";
+import { partyColor } from "@kalkulacka-one/design-system/utilities";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+const PARTIES = ["ANO 2011", "Piráti a Starostové", "ODS", "Společně pro Pardubice", "SPD", "KDU-ČSL", "TOP 09", "Zelení", "ČSSD", "Svobodní", "Volba pro město", "Nezávislí"].map((name, index) => ({
+  id: `p${index}`,
+  name,
+}));
+
+const meta: Meta<typeof AvatarStack> = {
+  title: "Components/AvatarStack",
+  component: AvatarStack,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  args: {
+    items: PARTIES.slice(0, 5),
+    label: "Strany, které s vámi souhlasí",
+  },
+  argTypes: {
+    items: { control: "object" },
+    max: { control: "number" },
+    size: {
+      control: "select",
+      options: ["small", "medium"],
+      defaultValue: { summary: "small" },
+    },
+    label: { control: "text" },
+    popover: { control: "object" },
+  },
+};
+
+type AvatarStackStory = StoryObj<typeof meta>;
+
+export const Few: AvatarStackStory = {};
+
+/** One over the limit keeps its face — a "+1" disc costs the same room and says less. */
+export const AtTheLimit: AvatarStackStory = {
+  args: { items: PARTIES.slice(0, 9) },
+};
+
+export const Overflowing: AvatarStackStory = {
+  args: { items: PARTIES },
+};
+
+export const Medium: AvatarStackStory = {
+  args: { items: PARTIES.slice(0, 6), size: "medium" },
+};
+
+/** Each face in its own accent, the way the dashboard draws the parties that agreed with you. */
+export const Accented: AvatarStackStory = {
+  args: { items: PARTIES.slice(0, 7).map((item) => ({ ...item, accent: partyColor(item.name) })) },
+};
+
+/** Nobody took your side — the stack renders nothing rather than an empty rail. */
+export const Empty: AvatarStackStory = {
+  args: { items: [] },
+};
+
+/** Hover (mouse) or tap (touch/keyboard) opens a popover naming every face. */
+export const WithPopover: AvatarStackStory = {
+  args: { items: PARTIES, popover: { closeLabel: "Zavřít" } },
+};
+
+/** In a card, over content below it — the open panel rises above its neighbours. */
+export const InCards: AvatarStackStory = {
+  args: { items: PARTIES.slice(0, 7), popover: { closeLabel: "Zavřít" } },
+  render: (args) => (
+    <div style={{ display: "grid", gap: "0.75rem", maxWidth: "24rem" }}>
+      {["Omezení vánoční výzdoby", "Regulace zábavní pyrotechniky"].map((title) => (
+        <div key={title} style={{ padding: "1rem", borderRadius: "var(--ko-radius-control)", background: "var(--ko-color-surface)", boxShadow: "var(--ko-shadow-surface)" }}>
+          <p style={{ margin: "0 0 0.5rem", fontFamily: "var(--ko-font-sans)", fontSize: "0.9375rem", fontWeight: 600, color: "var(--ko-color-text-strong)" }}>{title}</p>
+          <AvatarStack {...args} />
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export default meta;

--- a/apps/design-system.kalkulacka.one/stories/Calculating.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/Calculating.stories.tsx
@@ -1,0 +1,59 @@
+// Ported from kalkulacka-2026/packages/ui/src/calculating/calculating.stories.tsx
+import { Calculating } from "@kalkulacka-one/design-system/client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useState } from "react";
+
+const meta: Meta<typeof Calculating> = {
+  title: "Components/Calculating",
+  component: Calculating,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  args: { label: "Počítáme vaši shodu" },
+  argTypes: {
+    label: { control: "text" },
+    className: { control: false },
+  },
+};
+
+type CalculatingStory = StoryObj<typeof meta>;
+
+/**
+ * Runs once on mount. Re-render the story (the toolbar's reload) to watch it
+ * again — the animation is deliberately not looped, because it resolves.
+ *
+ * Under `prefers-reduced-motion: reduce` (toggle it in the OS, or emulate it
+ * in the browser's rendering panel) nothing moves: the gate and its film strip
+ * are removed outright, the ring is already full, and the percent mark and the
+ * label carry the moment on their own.
+ */
+export const Default: CalculatingStory = {};
+
+/** The same, with a button that remounts it so the sequence can be watched repeatedly. */
+export const Replay: CalculatingStory = {
+  render: function ReplayStory(args) {
+    const [run, setRun] = useState(0);
+    return (
+      <div style={{ display: "grid", gap: "1.5rem", justifyItems: "center" }}>
+        <Calculating key={run} {...args} />
+        <button
+          type="button"
+          onClick={() => setRun((current) => current + 1)}
+          style={{
+            font: "inherit",
+            padding: "0.5rem 1rem",
+            borderRadius: "var(--ko-radius-pill)",
+            border: "1.5px solid var(--ko-color-border)",
+            background: "var(--ko-color-surface)",
+            color: "var(--ko-color-text)",
+            cursor: "pointer",
+          }}
+        >
+          Přehrát znovu
+        </button>
+      </div>
+    );
+  },
+};
+
+export default meta;

--- a/apps/design-system.kalkulacka.one/stories/Donut.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/Donut.stories.tsx
@@ -1,0 +1,78 @@
+// Ported from kalkulacka-2026/packages/ui/src/donut/donut.stories.tsx
+import { Donut } from "@kalkulacka-one/design-system/server";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+const meta: Meta<typeof Donut> = {
+  title: "Components/Donut",
+  component: Donut,
+  tags: ["autodocs"],
+  parameters: { layout: "centered" },
+  args: {
+    centerValue: "42",
+    centerLabel: "otázek",
+    segments: [
+      { tone: "agree", value: 24, label: "Souhlas" },
+      { tone: "disagree", value: 12, label: "Nesouhlas" },
+      { tone: "none", value: 6, label: "Bez odpovědi" },
+    ],
+  },
+  argTypes: {
+    segments: { control: "object" },
+    centerValue: { control: "text" },
+    centerLabel: { control: "text" },
+    size: { control: "number" },
+    className: { control: false },
+  },
+};
+
+type DonutStory = StoryObj<typeof meta>;
+
+/** The real Pardubice shape for someone who answered 36 of 42. */
+export const Default: DonutStory = {};
+
+/** With explicit "nevím" answers in the mix — all four tones at once. */
+export const WithNeutral: DonutStory = {
+  args: {
+    segments: [
+      { tone: "agree", value: 18, label: "Souhlas" },
+      { tone: "disagree", value: 11, label: "Nesouhlas" },
+      { tone: "neutral", value: 7, label: "Nevím" },
+      { tone: "none", value: 6, label: "Bez odpovědi" },
+    ],
+  },
+};
+
+/** Answered everything one way — a single segment gets no gap cut into it. */
+export const Single: DonutStory = {
+  args: { segments: [{ tone: "agree", value: 42, label: "Souhlas" }] },
+};
+
+/** Segments worth nothing are dropped rather than drawn as stray dots, from the legend too. */
+export const WithEmptySegments: DonutStory = {
+  args: {
+    segments: [
+      { tone: "agree", value: 30, label: "Souhlas" },
+      { tone: "disagree", value: 0, label: "Nesouhlas" },
+      { tone: "neutral", value: 0, label: "Nevím" },
+      { tone: "none", value: 12, label: "Bez odpovědi" },
+    ],
+  },
+};
+
+/** Nothing answered yet: the track alone, and no legend. */
+export const Nothing: DonutStory = {
+  args: {
+    centerValue: "0",
+    segments: [
+      { tone: "agree", value: 0, label: "Souhlas" },
+      { tone: "disagree", value: 0, label: "Nesouhlas" },
+    ],
+  },
+};
+
+export const Larger: DonutStory = {
+  args: { size: 180 },
+};
+
+export default meta;

--- a/apps/design-system.kalkulacka.one/stories/MatchRow.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/MatchRow.stories.tsx
@@ -1,0 +1,168 @@
+// Ported from kalkulacka-2026/packages/ui/src/match-row/match-row.stories.tsx
+import { MatchRow } from "@kalkulacka-one/design-system/client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useState } from "react";
+
+/* Locale work happens above the row: "74 %" with the no-break space Czech puts before the sign. */
+const percent = (value: number) => `${value}\u00a0%`;
+
+const meta: Meta<typeof MatchRow> = {
+  title: "Components/MatchRow",
+  component: MatchRow,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  args: {
+    rank: 2,
+    name: "Žijeme Pardubice",
+    matchPercentage: 74,
+    percentLabel: percent(74),
+    noAnswerLabel: "Neodpověděli",
+    onSelect: () => {},
+  },
+  argTypes: {
+    rank: { control: "number" },
+    name: { control: "text" },
+    avatarUrl: { control: "text" },
+    avatarImage: { control: false },
+    color: { control: "color" },
+    matchPercentage: { control: { type: "range", min: 0, max: 100 } },
+    percentLabel: { control: "text" },
+    noAnswerLabel: { control: "text" },
+    winner: { control: "boolean" },
+    winnerLabel: { control: "text" },
+    selected: { control: "boolean" },
+    delay: { control: "number" },
+    onSelect: { control: false },
+  },
+  /* A row is an `<li>`; the results lay them out in a grid list. */
+  decorators: [
+    (Story) => (
+      <ul style={{ display: "grid", gap: "0.5rem", margin: 0, padding: 0, maxWidth: "26rem" }}>
+        <Story />
+      </ul>
+    ),
+  ],
+};
+
+type MatchRowStory = StoryObj<typeof meta>;
+
+export const Default: MatchRowStory = {};
+
+/** The top match: same row, one step up in scale. */
+export const Winner: MatchRowStory = {
+  args: {
+    rank: 1,
+    name: "Piráti: 42projektu.cz",
+    matchPercentage: 81,
+    percentLabel: percent(81),
+    winner: true,
+    winnerLabel: "Největší shoda",
+  },
+};
+
+/** The row whose comparison is currently open. */
+export const Selected: MatchRowStory = {
+  args: { selected: true },
+};
+
+/**
+ * KSČM: no answers at all, so no bar, no percentage, and nothing to open. Never
+ * 0 %, which would read as "opposed on everything".
+ */
+export const NoAnswers: MatchRowStory = {
+  args: {
+    rank: undefined,
+    name: "Komunistická strana Čech a Moravy",
+    matchPercentage: undefined,
+    percentLabel: undefined,
+  },
+};
+
+/** Archive party names run to 85 characters; two lines is the ceiling. */
+export const LongName: MatchRowStory = {
+  args: {
+    rank: 6,
+    name: "SPOLEČNĚ PRO PARDUBICE (Pardubáci společně, Sdružení pro Pardubice, Pardubice pro lidi)",
+    matchPercentage: 48,
+    percentLabel: percent(48),
+  },
+};
+
+/** A candidate with a picture and a data colour of their own, which the bar and the avatar's ring share. */
+export const WithPictureAndColor: MatchRowStory = {
+  args: {
+    rank: 3,
+    name: "Portrét",
+    avatarUrl: "https://i.pravatar.cc/128?img=12",
+    color: "#db2777",
+    matchPercentage: 66,
+    percentLabel: percent(66),
+  },
+};
+
+const RANKING = [
+  { name: "Piráti: 42projektu.cz", match: 81 },
+  { name: "Žijeme Pardubice", match: 74 },
+  { name: "Společně pro Pardubice", match: 63 },
+  { name: "ANO 2011", match: 55 },
+  { name: "SPD", match: 31 },
+  { name: "Komunistická strana Čech a Moravy", match: undefined },
+];
+
+/**
+ * The ranking as the results draw it: staggered so the rows rise bottom-up
+ * and the winner lands last, and tapping a row opens (floats) it. Re-render
+ * the story (the toolbar's reload) to watch the entrance again.
+ */
+export const Ranking: MatchRowStory = {
+  render: function RankingStory(args) {
+    const [selected, setSelected] = useState<string | undefined>(undefined);
+    const comparable = RANKING.filter((row) => row.match !== undefined);
+    return (
+      <>
+        {RANKING.map((row, index) => {
+          const rank = row.match === undefined ? undefined : index + 1;
+          return (
+            <MatchRow
+              {...args}
+              key={row.name}
+              rank={rank}
+              name={row.name}
+              matchPercentage={row.match}
+              percentLabel={row.match === undefined ? undefined : percent(row.match)}
+              winner={index === 0}
+              winnerLabel="Největší shoda"
+              selected={selected === row.name}
+              onSelect={() => setSelected((current) => (current === row.name ? undefined : row.name))}
+              delay={Math.max(0, comparable.length - 1 - index) * 0.06}
+            />
+          );
+        })}
+      </>
+    );
+  },
+};
+
+/** A result already shown once: `delay = -1` is an entrance that has finished before the first frame. */
+export const AlreadyShown: MatchRowStory = {
+  render: (args) => (
+    <>
+      {RANKING.slice(0, 3).map((row, index) => (
+        <MatchRow
+          {...args}
+          key={row.name}
+          rank={index + 1}
+          name={row.name}
+          matchPercentage={row.match}
+          percentLabel={row.match === undefined ? undefined : percent(row.match)}
+          winner={index === 0}
+          winnerLabel="Největší shoda"
+          delay={-1}
+        />
+      ))}
+    </>
+  ),
+};
+
+export default meta;

--- a/apps/design-system.kalkulacka.one/stories/Meter.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/Meter.stories.tsx
@@ -1,0 +1,85 @@
+// Ported from kalkulacka-2026/packages/ui/src/meter/meter.stories.tsx
+import { Meter, ProgressBar } from "@kalkulacka-one/design-system/server";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+
+const meta: Meta<typeof Meter> = {
+  title: "Components/Meter",
+  component: Meter,
+  tags: ["autodocs"],
+  args: { value: 72 },
+  argTypes: {
+    value: { control: { type: "range", min: -20, max: 140 } },
+    tone: {
+      control: "select",
+      options: ["agree", "neutral"],
+      defaultValue: { summary: "agree" },
+    },
+    size: {
+      control: "select",
+      options: ["small", "medium"],
+      defaultValue: { summary: "medium" },
+    },
+    delay: { control: "number" },
+    label: { control: "text" },
+    accent: { control: "color" },
+    className: { control: false },
+    color: { control: false },
+    corner: { control: false },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: "min(90vw, 16rem)" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+type MeterStory = StoryObj<typeof meta>;
+
+export const Agree: MeterStory = {};
+
+export const Neutral: MeterStory = {
+  args: { tone: "neutral" },
+};
+
+export const Small: MeterStory = {
+  args: { size: "small" },
+};
+
+/** Values outside 0–100 are clamped rather than overflowing the track. */
+export const Clamped: MeterStory = {
+  args: { value: 140 },
+};
+
+/** The results list staggers these so the bars arrive with their rows. */
+export const Delayed: MeterStory = {
+  args: { delay: 0.6 },
+};
+
+/** Labelled bars are announced as a meter; unlabelled ones are decorative only. */
+export const Labelled: MeterStory = {
+  args: { value: 63, label: "Shoda 63 %" },
+};
+
+/** The ranking paints each candidate's own colour over the tone's ink. */
+export const Accent: MeterStory = {
+  args: { accent: "light-dark(#d97706, #fbbf24)" },
+};
+
+/**
+ * The retired `ProgressBar` name and its `color` / `corner` props still work
+ * for the legacy match card — `primary` is the agree tone, `corner` is ignored.
+ */
+export const LegacyProgressBar: MeterStory = {
+  name: "Legacy ProgressBar alias",
+  render: () => (
+    <div style={{ display: "grid", gap: "0.75rem" }}>
+      <ProgressBar value={85} color="primary" corner="sharp" />
+      <ProgressBar value={42} color="neutral" corner="rounded" />
+    </div>
+  ),
+};
+
+export default meta;

--- a/packages/design-system/src/components/client/avatarStack.test.tsx
+++ b/packages/design-system/src/components/client/avatarStack.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AvatarStack, type AvatarStackItem } from "./avatarStack";
+
+const PARTIES: AvatarStackItem[] = ["ANO 2011", "Piráti a Starostové", "ODS", "Společně pro Pardubice", "SPD", "KDU-ČSL", "TOP 09", "Zelení", "ČSSD", "Svobodní", "Volba pro město", "Nezávislí"].map(
+  (name, index) => ({ id: `p${index}`, name }),
+);
+
+const label = "Strany, které s vámi souhlasí";
+
+describe("AvatarStack", () => {
+  it("renders nothing for an empty list", () => {
+    const { container } = render(<AvatarStack items={[]} label={label} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  describe("without a popover", () => {
+    it("is an inert list named by the label, announcing every name", () => {
+      render(<AvatarStack items={PARTIES.slice(0, 3)} label={label} />);
+      const list = screen.getByRole("list", { name: label });
+      expect(within(list).getAllByRole("listitem")).toHaveLength(3);
+      expect(within(list).getByText("Piráti a Starostové")).toHaveClass("ko:sr-only");
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("keeps a face for one over the limit — a +1 disc would cost the same room", () => {
+      render(<AvatarStack items={PARTIES.slice(0, 9)} label={label} />);
+      expect(screen.getAllByRole("listitem")).toHaveLength(9);
+      expect(screen.queryByText(/^\+/)).not.toBeInTheDocument();
+    });
+
+    it("collapses the overflow into a +n disc that still announces the hidden names", () => {
+      render(<AvatarStack items={PARTIES} label={label} />);
+      const items = screen.getAllByRole("listitem");
+      expect(items).toHaveLength(9);
+      const disc = screen.getByText("+4");
+      expect(disc).toHaveAttribute("aria-hidden", "true");
+      expect(within(items[8] as HTMLElement).getByText("ČSSD, Svobodní, Volba pro město, Nezávislí")).toHaveClass("ko:sr-only");
+    });
+
+    it("honours a custom max", () => {
+      render(<AvatarStack items={PARTIES.slice(0, 6)} max={3} label={label} />);
+      expect(screen.getAllByRole("listitem")).toHaveLength(4);
+      expect(screen.getByText("+3")).toBeInTheDocument();
+    });
+
+    it("overlaps by size, with the first face back on the left edge", () => {
+      const { container, rerender } = render(<AvatarStack items={PARTIES.slice(0, 2)} label={label} />);
+      expect(container.firstElementChild).toHaveClass("ko:pl-2");
+      expect(screen.getAllByRole("listitem")[0]).toHaveClass("ko:-ml-2");
+
+      rerender(<AvatarStack items={PARTIES.slice(0, 2)} label={label} size="medium" />);
+      expect(container.firstElementChild).toHaveClass("ko:pl-3");
+      expect(screen.getAllByRole("listitem")[0]).toHaveClass("ko:-ml-3");
+    });
+  });
+
+  describe("with a popover", () => {
+    const popover = { closeLabel: "Zavřít" };
+
+    it("is a collapsed trigger named by the label", () => {
+      render(<AvatarStack items={PARTIES.slice(0, 3)} label={label} popover={popover} />);
+      const trigger = screen.getByRole("button", { name: label });
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+      expect(trigger).not.toHaveAttribute("aria-controls");
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
+
+    it("opens a captioned list of every face on tap and closes on a second tap", () => {
+      render(<AvatarStack items={PARTIES} label={label} popover={popover} />);
+      const trigger = screen.getByRole("button", { name: label });
+      fireEvent.click(trigger);
+
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+      const panel = document.getElementById(trigger.getAttribute("aria-controls") ?? "") as HTMLElement;
+      expect(panel).toBeInTheDocument();
+      expect(within(panel).getAllByRole("listitem")).toHaveLength(12);
+      expect(within(panel).getByText("Nezávislí")).toBeInTheDocument();
+      expect(within(panel).getByText(label)).toBeInTheDocument();
+
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+      expect(screen.queryByRole("list")).not.toBeInTheDocument();
+    });
+
+    it("closes from its own X", () => {
+      render(<AvatarStack items={PARTIES.slice(0, 3)} label={label} popover={popover} />);
+      fireEvent.click(screen.getByRole("button", { name: label }));
+      fireEvent.click(screen.getByRole("button", { name: "Zavřít" }));
+      expect(screen.getByRole("button", { name: label })).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("closes on Escape", () => {
+      render(<AvatarStack items={PARTIES.slice(0, 3)} label={label} popover={popover} />);
+      const trigger = screen.getByRole("button", { name: label });
+      fireEvent.click(trigger);
+      fireEvent.keyDown(trigger, { key: "Escape" });
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("closes on a pointer-down outside, but not inside", () => {
+      render(
+        <>
+          <AvatarStack items={PARTIES.slice(0, 3)} label={label} popover={popover} />
+          <p>elsewhere</p>
+        </>,
+      );
+      const trigger = screen.getByRole("button", { name: label });
+      fireEvent.click(trigger);
+
+      fireEvent.pointerDown(screen.getByText("ODS"));
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+
+      fireEvent.pointerDown(screen.getByText("elsewhere"));
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("opens on a mouse hovering and closes when it leaves, ignoring touch", () => {
+      render(<AvatarStack items={PARTIES.slice(0, 3)} label={label} popover={popover} />);
+      const trigger = screen.getByRole("button", { name: label });
+      const root = trigger.parentElement as HTMLElement;
+
+      fireEvent.pointerEnter(root, { pointerType: "touch" });
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+
+      fireEvent.pointerEnter(root, { pointerType: "mouse" });
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+      expect(root).toHaveClass("ko:z-6");
+
+      fireEvent.pointerLeave(root, { pointerType: "mouse" });
+      expect(trigger).toHaveAttribute("aria-expanded", "false");
+      expect(root).not.toHaveClass("ko:z-6");
+    });
+
+    it("keeps a tapped-open popover open when the mouse wanders off", () => {
+      render(<AvatarStack items={PARTIES.slice(0, 3)} label={label} popover={popover} />);
+      const trigger = screen.getByRole("button", { name: label });
+      const root = trigger.parentElement as HTMLElement;
+      fireEvent.click(trigger);
+      fireEvent.pointerLeave(root, { pointerType: "mouse" });
+      expect(trigger).toHaveAttribute("aria-expanded", "true");
+    });
+  });
+});

--- a/packages/design-system/src/components/client/avatarStack.tsx
+++ b/packages/design-system/src/components/client/avatarStack.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+// Ported from kalkulacka-2026/packages/ui/src/avatar-stack/avatar-stack.tsx and avatar-stack.module.css
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { useCallback, useEffect, useId, useRef, useState } from "react";
+
+import { icons } from "../icons";
+import { Avatar } from "../server/avatar";
+import { VisuallyHidden } from "../server/visuallyHidden";
+import { IconButton } from "./icon-button";
+
+export type AvatarStackItem = {
+  id: string;
+  name: string;
+  src?: string;
+  /** The candidate's accent — the ring around their face. See `Avatar`. */
+  accent?: string;
+};
+
+export type AvatarStackSize = "small" | "medium";
+
+export type AvatarStack = {
+  items: AvatarStackItem[];
+  /** How many faces are drawn before the rest collapse into a "+n" disc. */
+  max?: number;
+  size?: AvatarStackSize;
+  /** Names the whole group for a screen reader, e.g. "Strany, které s vámi souhlasí". */
+  label: string;
+  /**
+   * When provided, the stack becomes a trigger for a popover that captions
+   * every face: hovering shows it on a mouse, tapping toggles it elsewhere,
+   * and `closeLabel` names the popover's own X. Without it the stack stays
+   * the inert row it always was.
+   */
+  popover?: { closeLabel: string };
+};
+
+/*
+ * The overlap, per size. The stack's left padding is paired with the negative
+ * margin on every item: the two cancel on the first face of each line, so a
+ * stack that wraps starts both of its lines on the card's own left edge.
+ * Hanging the margin off `.item + .item` instead would pull every wrapped
+ * line half an avatar to the left. Each avatar carries its own hairline ring
+ * and an opaque background, which is what keeps a dozen of these reading as
+ * separate faces rather than one smear; no extra ring is drawn here.
+ */
+const stackClasses = "ko:flex ko:flex-wrap ko:items-center ko:gap-y-1 ko:m-0 ko:list-none";
+
+const stackSizeClasses: Record<AvatarStackSize, string> = {
+  small: "ko:pl-2",
+  medium: "ko:pl-3",
+};
+
+/* Faces later in the list sit on top of earlier ones — DOM order does this on
+   its own; the stacking context is only here so a hover/focus ring inside an
+   avatar isn't clipped under the next face. */
+const itemClasses = "ko:inline-flex ko:flex-none ko:relative ko:rounded-pill ko:hover:z-1 ko:focus-within:z-1";
+
+const itemSizeClasses: Record<AvatarStackSize, string> = {
+  small: "ko:-ml-2",
+  medium: "ko:-ml-3",
+};
+
+const overflowDiscClasses =
+  "ko:inline-flex ko:items-center ko:justify-center ko:rounded-pill ko:bg-surface ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)] ko:font-sans ko:font-semibold ko:text-text-muted ko:tabular-nums";
+
+const overflowDiscSizeClasses: Record<AvatarStackSize, string> = {
+  small: "ko:size-8 ko:text-[0.6875rem]",
+  medium: "ko:size-11 ko:text-xs",
+};
+
+/*
+ * The expandable variant: the stack becomes a real button and the popover
+ * hangs off this wrapper. `inline-flex` so the trigger takes only the room the
+ * faces do — the whole point of a stack is being narrow. While the popover is
+ * open, the whole trigger+panel unit rises above its surroundings (the toast's
+ * layer, 6): the panel's own z-index is not enough on its own, because in a
+ * list of cards each carrying a stack, the cards are siblings in one stacking
+ * context, so a *later* card's content would paint over an earlier card's open
+ * panel purely by DOM order.
+ */
+const rootClasses = "ko:relative ko:inline-flex";
+const rootOpenClasses = "ko:z-6";
+
+const triggerClasses = "ko:border-0 ko:bg-transparent ko:py-0 ko:cursor-pointer ko:rounded-pill ko:focus-visible:outline-3 ko:focus-visible:outline-offset-2 ko:focus-visible:outline-focus/55";
+
+const panelClasses = [
+  "ko:absolute ko:top-[calc(100%_+_0.5rem)] ko:left-0 ko:z-6",
+  "ko:min-w-56 ko:max-w-72 ko:pt-2 ko:px-3 ko:pb-3",
+  "ko:rounded-[calc(var(--ko-radius-chip)_*_1.5_+_0.5rem)] ko:bg-surface ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border),var(--ko-shadow-card-lifted)]",
+  "ko:origin-top-left ko:animate-stack-panel-in ko:motion-reduce:animate-none",
+].join(" ");
+
+const panelHeadClasses = "ko:flex ko:items-center ko:justify-between ko:gap-2";
+const panelTitleClasses = "ko:font-sans ko:text-[0.8125rem] ko:font-semibold ko:text-text-muted";
+const panelListClasses = "ko:flex ko:flex-col ko:gap-2 ko:mt-1 ko:mb-0 ko:p-0 ko:list-none ko:max-h-64 ko:overflow-y-auto";
+const panelRowClasses = "ko:flex ko:items-center ko:gap-2";
+const panelNameClasses = "ko:font-sans ko:text-[0.8125rem] ko:text-text-strong ko:min-w-0";
+
+/**
+ * A row of candidate faces, overlapped.
+ *
+ * A count ("souhlasí 7 z 12 stran") says how much company you had; this says
+ * *whose*. Overlapping rather than spacing them out is what keeps a dozen
+ * parties inside a dashboard card's width, and the ring each avatar carries is
+ * what stops the overlap reading as one smeared shape — it is drawn in the
+ * card's own background, so a face is separated from the one it sits on by a
+ * gap rather than by a line of some third colour.
+ *
+ * Order is the caller's. Overflow collapses into a "+n" disc at the end rather
+ * than truncating silently: the faces are a sample, and the disc is what says
+ * so. Every name is still announced, so nothing is lost when the disc appears.
+ *
+ * With `popover` set, the whole stack is one trigger for a list that captions
+ * every face. One trigger rather than one per avatar: at this size the faces
+ * are individually unhittable on a phone, and the question a reader has is
+ * "who are all of these", not "who is the third one".
+ */
+export function AvatarStack({ items, max = 8, size = "small", label, popover }: AvatarStack) {
+  /*
+   * Two reasons to be open, tracked apart: a mouse hovering, and a tap or
+   * Enter having toggled it. Separate so that a mouse wandering off doesn't
+   * close a popover a click deliberately opened — and so that a tap (which
+   * hovers nothing on a touch screen) has a state of its own.
+   */
+  const [hovered, setHovered] = useState(false);
+  const [pinned, setPinned] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const panelId = useId();
+
+  const open = hovered || pinned;
+
+  const close = useCallback(() => {
+    setPinned(false);
+    setHovered(false);
+  }, []);
+
+  // The tap-outside route out, same as the shell menu's. Registered only while
+  // pinned: a hover-opened popover already closes itself on mouse leave.
+  useEffect(() => {
+    if (!pinned) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      if (target instanceof Node && rootRef.current?.contains(target)) return;
+      setPinned(false);
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => document.removeEventListener("pointerdown", handlePointerDown);
+  }, [pinned]);
+
+  if (items.length === 0) return null;
+
+  /*
+   * With exactly one over the limit, the "+1" disc costs the same room as the
+   * face it replaces and says less — so the cut only happens once it buys
+   * something.
+   */
+  const shown = items.length > max + 1 ? items.slice(0, max) : items;
+  const hidden = items.length - shown.length;
+
+  const itemClassName = twMerge(itemClasses, itemSizeClasses[size]);
+  const overflowDiscClassName = twMerge(overflowDiscClasses, overflowDiscSizeClasses[size]);
+
+  if (!popover) {
+    return (
+      <ul className={twMerge(stackClasses, stackSizeClasses[size])} aria-label={label}>
+        {shown.map((item) => (
+          <li key={item.id} className={itemClassName}>
+            {/* `title` gives the pointer a way to read a face the layout has no
+                room to caption; the hidden text is what carries it elsewhere. */}
+            <span title={item.name}>
+              <Avatar name={item.name} src={item.src} accent={item.accent} size={size} />
+            </span>
+            <VisuallyHidden>{item.name}</VisuallyHidden>
+          </li>
+        ))}
+
+        {hidden > 0 ? (
+          <li className={itemClassName}>
+            <span className={overflowDiscClassName} aria-hidden="true">
+              +{hidden}
+            </span>
+            <VisuallyHidden>
+              {items
+                .slice(shown.length)
+                .map((item) => item.name)
+                .join(", ")}
+            </VisuallyHidden>
+          </li>
+        ) : null}
+      </ul>
+    );
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className={twMerge(rootClasses, open && rootOpenClasses)}
+      /* Gated to a real mouse: on a touch screen the emulated mouseenter and
+         the click arrive together, and letting both act would open on the
+         enter only to have the click toggle it shut again. */
+      onPointerEnter={(event) => {
+        if (event.pointerType === "mouse") setHovered(true);
+      }}
+      onPointerLeave={(event) => {
+        if (event.pointerType === "mouse") setHovered(false);
+      }}
+    >
+      <button
+        type="button"
+        className={twMerge(stackClasses, triggerClasses, stackSizeClasses[size])}
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={() => setPinned((value) => !value)}
+        onKeyDown={(event) => {
+          if (event.key === "Escape" && open) {
+            event.preventDefault();
+            close();
+          }
+        }}
+      >
+        {shown.map((item) => (
+          <span key={item.id} className={itemClassName}>
+            <Avatar name={item.name} src={item.src} accent={item.accent} size={size} />
+          </span>
+        ))}
+
+        {hidden > 0 ? (
+          <span className={itemClassName}>
+            <span className={overflowDiscClassName} aria-hidden="true">
+              +{hidden}
+            </span>
+          </span>
+        ) : null}
+
+        {/* The names live in the popover once there is one; the trigger only
+            has to say what pressing it reveals. */}
+        <VisuallyHidden>{label}</VisuallyHidden>
+      </button>
+
+      {open ? (
+        <div id={panelId} className={panelClasses}>
+          <div className={panelHeadClasses}>
+            <span className={panelTitleClasses}>{label}</span>
+            {/* The touch route out — a finger has no Escape and no hover to
+                withdraw. */}
+            <IconButton icon={icons.close} label={popover.closeLabel} onClick={close} />
+          </div>
+
+          <ul className={panelListClasses}>
+            {items.map((item) => (
+              <li key={item.id} className={panelRowClasses}>
+                <Avatar name={item.name} src={item.src} accent={item.accent} size="small" />
+                <span className={panelNameClasses}>{item.name}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/design-system/src/components/client/calculating.test.tsx
+++ b/packages/design-system/src/components/client/calculating.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Calculating, TAPE } from "./calculating";
+import { PERCENT_MARK_PATHS } from "./logo";
+
+describe("Calculating", () => {
+  it("is a status region that announces the label and nothing else", () => {
+    render(<Calculating label="Počítáme vaši shodu" />);
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("Počítáme vaši shodu");
+    expect(screen.getByText("Počítáme vaši shodu").tagName).toBe("P");
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("runs a fixed 24-frame tape of unlabelled marks through a hidden gate", () => {
+    const { container } = render(<Calculating label="Počítáme vaši shodu" />);
+    expect(TAPE).toHaveLength(24);
+    const gate = container.querySelector(".ko-calculating-gate") as HTMLElement;
+    expect(gate).toHaveAttribute("aria-hidden", "true");
+    const tape = gate.querySelector(".ko-calculating-tape") as HTMLElement;
+    expect(tape.children).toHaveLength(24);
+    for (const mark of Array.from(tape.children)) expect(mark).toHaveAttribute("aria-hidden", "true");
+    expect(tape.children[0]).toHaveClass("ko:bg-agree");
+    expect(tape.children[7]).toHaveClass("ko:border-dashed");
+  });
+
+  it("perforates the strip top and bottom, one hole per frame, on the tape's own keyframes", () => {
+    const { container } = render(<Calculating label="Počítáme vaši shodu" />);
+    const sprockets = container.querySelectorAll(".ko-calculating-sprockets");
+    expect(sprockets).toHaveLength(2);
+    expect(sprockets[0]).toHaveClass("ko:top-2");
+    expect(sprockets[1]).toHaveClass("ko:bottom-2");
+    expect(sprockets[0]?.children).toHaveLength(24);
+  });
+
+  it("counts a ring of the agree ink round a sunken track", () => {
+    const { container } = render(<Calculating label="Počítáme vaši shodu" />);
+    const circles = container.querySelectorAll("svg circle");
+    expect(circles).toHaveLength(2);
+    expect(circles[0]).toHaveClass("ko:stroke-surface-sunken");
+    expect(circles[1]).toHaveClass("ko-calculating-ring-fill", "ko:stroke-agree");
+    expect(circles[1]).toHaveAttribute("stroke-linecap", "round");
+  });
+
+  it("resolves onto the logo's own percent mark", () => {
+    const { container } = render(<Calculating label="Počítáme vaši shodu" />);
+    const mark = container.querySelector(".ko-calculating-percent") as SVGSVGElement;
+    expect(mark).toHaveAttribute("height", "34");
+    expect(Array.from(mark.querySelectorAll("path")).map((path) => path.getAttribute("d"))).toEqual([...PERCENT_MARK_PATHS]);
+  });
+});

--- a/packages/design-system/src/components/client/calculating.tsx
+++ b/packages/design-system/src/components/client/calculating.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// Ported from kalkulacka-2026/packages/ui/src/calculating/calculating.tsx and calculating.module.css
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { AnswerMark, type AnswerMarkTone } from "../server/answerMark";
+import { PercentMark } from "./logo";
+
+export type Calculating = {
+  /** What is being waited for, e.g. "Počítáme vaši shodu" — announced, not decorative. */
+  label: string;
+  className?: string;
+};
+
+/**
+ * The tape. Fixed rather than random so the animation is identical on the server
+ * and the client, and identical between two people comparing screens — it is
+ * decoration standing in for the answers, not a reading of them.
+ */
+export const TAPE: { id: string; tone: AnswerMarkTone }[] = (
+  [
+    "agree",
+    "disagree",
+    "agree",
+    "agree",
+    "neutral",
+    "disagree",
+    "agree",
+    "none",
+    "disagree",
+    "agree",
+    "agree",
+    "disagree",
+    "neutral",
+    "agree",
+    "disagree",
+    "agree",
+    "agree",
+    "none",
+    "disagree",
+    "agree",
+    "neutral",
+    "disagree",
+    "agree",
+    "agree",
+  ] as AnswerMarkTone[]
+).map((tone, index) => ({ id: `frame-${index}`, tone }));
+
+const wrapClasses = "ko:flex ko:flex-col ko:items-center ko:gap-4";
+const stageClasses = "ko:relative ko:size-38 ko:flex ko:items-center ko:justify-center";
+
+/* Starts at twelve o'clock rather than at three. */
+const ringClasses = "ko:absolute ko:inset-0 ko:size-full ko:-rotate-90";
+
+/*
+ * The gate: a circular aperture the tape is pulled through, sitting inside the
+ * ring. Everything that moves — the ring counting, the tape rolling, the gate
+ * shuttering and the mark landing — is `.ko-calculating-*` in `styles.css`.
+ */
+const gateClasses = "ko-calculating-gate ko:relative ko:size-28 ko:rounded-pill ko:overflow-hidden ko:bg-surface ko:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]";
+
+/* Starts clear of the aperture so the first mark travels in rather than being
+   there on frame one. */
+const tapeClasses = "ko-calculating-tape ko:flex ko:items-center ko:gap-2 ko:h-full ko:pl-28 ko:w-max";
+
+const sprocketsClasses = "ko-calculating-sprockets ko:absolute ko:left-0 ko:flex ko:gap-2 ko:pl-28 ko:w-max";
+
+/* One hole per frame, as wide as the mark it rides above, with the dot centred in it. */
+const holeClasses =
+  "ko:flex-none ko:w-[2.125rem] ko:h-[0.3125rem] ko:flex ko:items-center ko:justify-center ko:before:content-[''] ko:before:size-[0.3125rem] ko:before:rounded-pill ko:before:bg-border-strong";
+
+const percentClasses = "ko-calculating-percent ko:absolute ko:text-text-strong";
+
+const labelClasses = "ko:m-0 ko:font-sans ko:text-[0.9375rem] ko:text-text-muted ko:text-center";
+
+/**
+ * The wait before the results.
+ *
+ * Your answers run through a gate on a strip of film while a ring counts around
+ * it, and the whole thing resolves onto the percent sign out of the wordmark.
+ * The pause it fills is not fake work — the calculation finishes before the
+ * screen paints — it is the beat that lets someone register the result was
+ * produced *from their answers* rather than having been sitting there all along.
+ *
+ * Under `prefers-reduced-motion` nothing moves: the gate is removed, the ring is
+ * full, the percent mark is simply there, and the label carries the meaning.
+ * See `.ko-calculating-*` in `styles.css`.
+ */
+export function Calculating({ label, className }: Calculating) {
+  return (
+    <div className={twMerge(wrapClasses, className)} role="status">
+      <div className={stageClasses}>
+        <svg className={ringClasses} viewBox="0 0 100 100" aria-hidden="true">
+          <circle className="ko:stroke-surface-sunken" cx="50" cy="50" r="45" fill="none" strokeWidth={4} />
+          <circle className="ko-calculating-ring-fill ko:stroke-agree" cx="50" cy="50" r="45" fill="none" strokeWidth={4} strokeLinecap="round" />
+        </svg>
+
+        <div className={gateClasses} aria-hidden="true">
+          {/* Sprocket holes, top and bottom, running at the tape's own speed —
+              they are what makes the strip read as film being pulled through
+              rather than as icons sliding sideways. */}
+          <div className={twMerge(sprocketsClasses, "ko:top-2")}>
+            {TAPE.map((frame) => (
+              <span key={frame.id} className={holeClasses} />
+            ))}
+          </div>
+
+          <div className={tapeClasses}>
+            {TAPE.map((frame) => (
+              /* No labels: the strip stands in for the answers, it does not
+                 report them, and this whole region is hidden from assistive tech
+                 anyway. Naming all 24 would put a run of nonsense words in front
+                 of the one sentence that means something. */
+              <AnswerMark key={frame.id} tone={frame.tone} size="medium" />
+            ))}
+          </div>
+
+          <div className={twMerge(sprocketsClasses, "ko:bottom-2")}>
+            {TAPE.map((frame) => (
+              <span key={frame.id} className={holeClasses} />
+            ))}
+          </div>
+        </div>
+
+        <PercentMark className={percentClasses} size={34} />
+      </div>
+
+      <p className={labelClasses}>{label}</p>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/client/index.ts
+++ b/packages/design-system/src/components/client/index.ts
@@ -1,6 +1,8 @@
 "use client";
 
+export * from "./avatarStack";
 export * from "./button";
+export * from "./calculating";
 export * from "./clientTest";
 export * from "./description";
 export * from "./dialog";
@@ -14,6 +16,7 @@ export * from "./icon-button";
 export * from "./input";
 export * from "./label";
 export * from "./logo";
+export * from "./matchRow";
 export * from "./questionCard";
 export * from "./questionDeck/questionDeck";
 export { PHYSICS, type SwipeZone } from "./questionDeck/swipePhysics";

--- a/packages/design-system/src/components/client/logo.test.tsx
+++ b/packages/design-system/src/components/client/logo.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { Logo } from "./logo";
+import { Logo, PERCENT_MARK_PATHS, PercentMark } from "./logo";
 
 describe("Logo", () => {
   it("renders the SVG as an image", () => {
@@ -59,5 +59,33 @@ describe("Logo", () => {
       const title = screen.queryByTitle("Volební kalkulačka");
       expect(title).not.toBeInTheDocument();
     });
+  });
+});
+
+describe("PercentMark", () => {
+  it("draws the three percent paths, decoratively, in currentColor", () => {
+    const { container } = render(<PercentMark />);
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+    expect(svg).toHaveAttribute("focusable", "false");
+    const paths = Array.from(svg.querySelectorAll("path"));
+    expect(paths.map((path) => path.getAttribute("d"))).toEqual([...PERCENT_MARK_PATHS]);
+    for (const path of paths) expect(path).toHaveAttribute("fill", "currentColor");
+  });
+
+  it("is 24px tall by default and keeps the mark's own aspect ratio", () => {
+    const { container } = render(<PercentMark />);
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    expect(svg).toHaveAttribute("height", "24");
+    expect(svg).toHaveAttribute("width", "24");
+    expect(svg).toHaveAttribute("viewBox", "5 5 14.57 14.4");
+  });
+
+  it("scales by height and takes a class", () => {
+    const { container } = render(<PercentMark size={34} className="ko:absolute" />);
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    expect(svg).toHaveAttribute("height", "34");
+    expect(svg).toHaveAttribute("width", "34");
+    expect(svg).toHaveClass("ko:absolute");
   });
 });

--- a/packages/design-system/src/components/client/logo.tsx
+++ b/packages/design-system/src/components/client/logo.tsx
@@ -3,6 +3,8 @@ import { twMerge } from "@kalkulacka-one/design-system/utilities";
 import { cva, type VariantProps } from "class-variance-authority";
 import { useId } from "react";
 
+import { logoPercentageDenominator, logoPercentageNominator, logoPercentageSlash } from "../icons/icons";
+
 export type Logo = {
   title: string;
   text?: boolean;
@@ -24,6 +26,51 @@ const LogoVariants = cva("ko:flex ko:items-center ko:gap-[1.78125em]", {
     size: "default",
   },
 });
+
+/**
+ * The percent sign's own tight box on the icon set's 24-grid: the three paths
+ * in `icons.ts` span x 5–19.57 and y 5–19.4, so this is what renders the mark
+ * alone at its true size rather than floating in the grid's margins.
+ */
+export const PERCENT_MARK_VIEWBOX = { x: 5, y: 5, width: 14.57, height: 14.4 } as const;
+
+/** The mark's geometry, verbatim from the icon set — one source, so it cannot drift from the header's wordmark. */
+export const PERCENT_MARK_PATHS = [logoPercentageNominator, logoPercentageSlash, logoPercentageDenominator] as const;
+
+export type PercentMark = {
+  /** Height in px. Width follows the mark's own aspect ratio. */
+  size?: number;
+  className?: string;
+};
+
+/**
+ * The percent sign out of the wordmark, on its own.
+ *
+ * Ported from kalkulacka-2026/packages/ui/src/logo/logo.tsx (`PercentMark`).
+ * The mark reads `✓ / ✗ %` — a check, a cut, a cross, and this: two dots with a
+ * slash between them, in the same flat-cut geometry as the rest. Lifted verbatim
+ * from the icon set's logo paths rather than redrawn, so the calculating screen
+ * resolves onto a shape that is literally the logo's. Decorative always, and
+ * drawn in `currentColor` so it follows the surrounding text colour.
+ */
+export function PercentMark({ size = 24, className }: PercentMark) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      width={Math.round((size * PERCENT_MARK_VIEWBOX.width) / PERCENT_MARK_VIEWBOX.height)}
+      height={size}
+      viewBox={`${PERCENT_MARK_VIEWBOX.x} ${PERCENT_MARK_VIEWBOX.y} ${PERCENT_MARK_VIEWBOX.width} ${PERCENT_MARK_VIEWBOX.height}`}
+      fill="none"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {PERCENT_MARK_PATHS.map((d) => (
+        <path key={d} d={d} fill="currentColor" />
+      ))}
+    </svg>
+  );
+}
 
 export function Logo({ title, text, monochrome, size }: Logo) {
   const titleId = useId();

--- a/packages/design-system/src/components/client/matchRow.test.tsx
+++ b/packages/design-system/src/components/client/matchRow.test.tsx
@@ -1,0 +1,157 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { partyColor } from "../../utilities/partyColor";
+import { MatchRow } from "./matchRow";
+
+/** jsdom serialises a `light-dark(#hex, #hex)` it was given back as `rgb()` pairs; compare like with like. */
+function cssColor(value: string): string {
+  const probe = document.createElement("span");
+  probe.style.backgroundColor = value;
+  return probe.style.backgroundColor;
+}
+
+const base = {
+  rank: 2,
+  name: "Žijeme Pardubice",
+  matchPercentage: 74,
+  /* The caller formats the label; the no-break space is what keeps "74 %" on one line. */
+  percentLabel: "74\u00a0%",
+  noAnswerLabel: "Neodpověděli",
+  onSelect: () => {},
+};
+
+function renderRow(props: Partial<React.ComponentProps<typeof MatchRow>> = {}) {
+  const result = render(
+    <ul>
+      <MatchRow {...base} {...props} />
+    </ul>,
+  );
+  const item = screen.getByRole("listitem");
+  const button = screen.getByRole("button");
+  return { ...result, item, button };
+}
+
+describe("MatchRow", () => {
+  it("is a pressable list item wrapping one button", () => {
+    const { item, button } = renderRow();
+    expect(item).toHaveClass("ko-pressable", "ko:animate-match-row-rise", "ko:motion-reduce:animate-none");
+    expect(item.firstElementChild).toBe(button);
+    expect(button).not.toBeDisabled();
+  });
+
+  it("writes the rank as an ordinal before the name", () => {
+    renderRow();
+    expect(screen.getByText("2.")).toHaveClass("ko:tabular-nums");
+    expect(screen.getByText("Žijeme Pardubice")).toHaveClass("ko:line-clamp-2");
+  });
+
+  it("shows the pre-formatted percentage as given", () => {
+    renderRow();
+    // The default normaliser folds the no-break space into a plain one; the DOM still carries U+00A0.
+    expect(screen.getByText("74 %")).toHaveClass("ko:font-display", "ko:whitespace-nowrap");
+    expect(screen.getByText("74 %").textContent).toBe("74\u00a0%");
+  });
+
+  it("draws the match as a small Meter along the top edge in the candidate's accent", () => {
+    const { button } = renderRow();
+    const meter = button.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(meter).toHaveClass("ko:absolute", "ko:top-0", "ko:rounded-none", "ko:bg-border", "ko:h-[0.3125rem]");
+    const fill = meter.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe("74%");
+    expect(fill.style.backgroundColor).toBe(cssColor(partyColor("Žijeme Pardubice")));
+    expect(button).toHaveClass("ko:pt-[calc(1rem_+_0.3125rem)]");
+  });
+
+  it("takes the data colour over the seeded palette", () => {
+    const { button } = renderRow({ color: "#ff0000" });
+    expect(button.style.getPropertyValue("--row-accent")).toBe(partyColor("Žijeme Pardubice", "#ff0000"));
+    const avatar = button.querySelector("[style*='--avatar-ring']") as HTMLElement;
+    expect(avatar.style.getPropertyValue("--avatar-ring")).toContain(partyColor("Žijeme Pardubice", "#ff0000"));
+  });
+
+  it("calls onSelect when pressed", () => {
+    const onSelect = vi.fn();
+    const { button } = renderRow({ onSelect });
+    fireEvent.click(button);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  describe("selected", () => {
+    it("presses the button and floats the whole card", () => {
+      const { item, button } = renderRow({ selected: true });
+      expect(button).toHaveAttribute("aria-pressed", "true");
+      expect(item).toHaveAttribute("data-open", "");
+    });
+
+    it("is neither pressed nor open at rest", () => {
+      const { item, button } = renderRow();
+      expect(button).toHaveAttribute("aria-pressed", "false");
+      expect(item).not.toHaveAttribute("data-open");
+    });
+  });
+
+  describe("winner", () => {
+    it("is the same row one step up, captioned with a tag", () => {
+      const { button } = renderRow({ rank: 1, winner: true, winnerLabel: "Největší shoda", matchPercentage: 81, percentLabel: "81\u00a0%" });
+      expect(screen.getByText("Největší shoda")).toHaveClass("ko:rounded-pill");
+      expect(screen.getByText("Žijeme Pardubice")).toHaveClass("ko:text-base");
+      expect(screen.getByText("81 %")).toHaveClass("ko:text-2xl");
+      expect(button).toHaveClass("ko:py-6", "ko:pt-[calc(1.5rem_+_0.3125rem)]", "ko:lg:pt-[calc(2rem_+_0.3125rem)]");
+    });
+
+    it("gets the large avatar", () => {
+      const { button } = renderRow({ winner: true });
+      expect(button.querySelector(".ko\\:size-16")).toBeInTheDocument();
+    });
+
+    it("is not captioned without a label", () => {
+      renderRow({ winner: true });
+      expect(screen.queryByText("Největší shoda")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("a candidate who never answered", () => {
+    it("has no bar, no percentage, no ordinal, and says so instead", () => {
+      const { item, button } = renderRow({ rank: undefined, matchPercentage: undefined, percentLabel: undefined, name: "Komunistická strana Čech a Moravy" });
+      expect(button).toBeDisabled();
+      expect(button.querySelector('[aria-hidden="true"].ko\\:absolute')).not.toBeInTheDocument();
+      expect(screen.getByText("Neodpověděli")).toHaveClass("ko:text-text-subtle");
+      expect(screen.queryByText(/^\d+\.$/)).not.toBeInTheDocument();
+      expect(screen.queryByText("74 %")).not.toBeInTheDocument();
+      expect(button).toHaveClass("ko:p-4");
+      expect(button).not.toHaveClass("ko:pt-[calc(1rem_+_0.3125rem)]");
+      expect(item).not.toHaveClass("ko-pressable");
+    });
+
+    it("never floats, even when marked selected", () => {
+      const { item, button } = renderRow({ matchPercentage: undefined, selected: true });
+      expect(button).toHaveAttribute("aria-pressed", "true");
+      expect(item).not.toHaveAttribute("data-open");
+    });
+  });
+
+  describe("delay", () => {
+    it("staggers the row and its bar together", () => {
+      const { item, button } = renderRow({ delay: 0.3 });
+      expect(item.style.animationDelay).toBe("0.3s");
+      const fill = button.querySelector('[aria-hidden="true"] > div') as HTMLElement;
+      expect(fill.style.animationDelay).toBe("0.3s");
+    });
+
+    it("sets none at zero", () => {
+      const { item } = renderRow();
+      expect(item.getAttribute("style")).toBeNull();
+    });
+
+    it("passes -1 through as an entrance already over", () => {
+      const { item } = renderRow({ delay: -1 });
+      expect(item.style.animationDelay).toBe("-1s");
+    });
+  });
+
+  it("renders the legacy responsive picture set", () => {
+    const { button } = renderRow({ avatarImage: { original: "https://example.test/o.png", xs: "https://example.test/xs.png" } });
+    expect(button.querySelector("img")).toHaveAttribute("srcset", "https://example.test/xs.png 100w");
+  });
+});

--- a/packages/design-system/src/components/client/matchRow.tsx
+++ b/packages/design-system/src/components/client/matchRow.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+// Ported from kalkulacka-2026/packages/ui/src/match-row/match-row.tsx and match-row.module.css
+import { partyColor, twMerge } from "../../utilities";
+import { Avatar, type ImageUrls } from "../server/avatar";
+import { Meter } from "../server/progressBar";
+import { Tag } from "../server/tag";
+
+export type MatchRowProps = {
+  /** 1-based position among candidates that could be compared. */
+  rank?: number;
+  name: string;
+  avatarUrl?: string;
+  /** The legacy responsive picture set, for candidates loaded through the existing data layer. */
+  avatarImage?: ImageUrls;
+  /** The candidate's own accent colour — from data, or derived server-side from the logo. */
+  color?: string;
+  /** 0–100, or `undefined` for a candidate who never answered. */
+  matchPercentage?: number;
+  /** Pre-formatted, e.g. "74 %" — number formatting is locale work, so it happens above. */
+  percentLabel?: string;
+  /** Shown instead of a percentage, e.g. "Neodpověděli". */
+  noAnswerLabel: string;
+  /** The top match: larger, and captioned. */
+  winner?: boolean;
+  /** The winner's caption, e.g. "Největší shoda". */
+  winnerLabel?: string;
+  /** Whether this row's comparison is the one currently open. */
+  selected?: boolean;
+  onSelect: () => void;
+  /**
+   * Seconds before the row rises into place. Ignored under reduced motion. A
+   * negative delay (`-1` for a result already shown once) is an entrance that
+   * has already finished: the row is simply there.
+   */
+  delay?: number;
+};
+
+/* The bar along the top edge, shared by the Meter and the padding compensation below. */
+const EDGE_HEIGHT = "0.3125rem";
+
+/*
+ * The row rises into place from below (`--ko-animate-match-row-rise`, in
+ * `styles.css`), and the list staggers the delays so the ranking assembles
+ * bottom-up with the winner landing last.
+ *
+ * Everything about how the card answers a pointer — the hover lift, the press,
+ * the float while its comparison is open — is `.ko-pressable` in `styles.css`,
+ * carried on this element in the markup. It is the outer one, which is what the
+ * utility wants: the button inside clips its own shadow (see `rowClasses`), and
+ * hover/active propagate up to here from it anyway.
+ *
+ * Radius matches the brand's signature asymmetric card (square top-left,
+ * rounded elsewhere), scaled to this row's size via `--ko-radius-control`
+ * rather than the fixed 30px the big question card uses.
+ */
+const itemClasses = "ko:list-none ko:flex ko:rounded-[0_var(--ko-radius-control)_var(--ko-radius-control)_var(--ko-radius-control)] ko:animate-match-row-rise ko:motion-reduce:animate-none";
+
+/*
+ * `overflow-hidden` clips the top-edge bar to the card's rounded corners — and
+ * that is *all* it does. It cannot also carry the box-shadow: an element's own
+ * `overflow: hidden` clips its own box-shadow along with its content, which is
+ * what silently cropped every row's shadow before. The shadow lives on the
+ * `<li>` (`.ko-pressable`), which has no overflow of its own and can show it in
+ * full; `rounded-[inherit]` keeps the two shapes identical without repeating
+ * the asymmetric formula twice.
+ */
+const rowClasses = [
+  "ko:relative ko:overflow-hidden ko:rounded-[inherit]",
+  "ko:grid ko:grid-cols-[auto_minmax(0,1fr)_auto] ko:items-center ko:gap-4",
+  "ko:w-full ko:p-4",
+  "ko:border-0 ko:bg-surface ko:text-left ko:cursor-pointer",
+  "ko:transition-[background-color] ko:duration-[var(--ko-duration-base)] ko:ease-[ease]",
+  "ko:focus-visible:outline-3 ko:focus-visible:outline-offset-2 ko:focus-visible:outline-focus/55",
+  /*
+   * The open comparison's row: a wash tint over the surface rather than a ring
+   * drawn around it — a coloured border reads as decoration competing with the
+   * match bar above it, where a tinted card reads as a state the card itself is
+   * in. Layered over the solid surface colour rather than swapped in for it:
+   * the wash is translucent, and a bare `background: wash` leaves the row
+   * seeing through to whatever sits behind it in the stack — including its own
+   * and its neighbours' shadows — which showed up as a smudged halo at the
+   * corners. A flat gradient is how a colour becomes a *layer*: the source
+   * wrote `background: <wash>, <surface>`, which is not valid shorthand (only
+   * the final layer may be a colour) and never painted. The scale and the
+   * lifted shadow are `.ko-pressable`'s, on the `<li>`.
+   */
+  "ko:aria-pressed:bg-[linear-gradient(oklch(from_var(--row-accent,var(--ko-color-agree))_l_c_h_/_0.14),oklch(from_var(--row-accent,var(--ko-color-agree))_l_c_h_/_0.14))]",
+  /*
+   * A candidate who answered nothing can't be compared, so there is no
+   * comparison to open. The row still lists them — being absent from the
+   * results entirely would be its own kind of misrepresentation — it just
+   * isn't a button that does anything. Outlined rather than blanked out:
+   * stripping the surface entirely left this row floating on the page with
+   * nothing to read against — on the dark theme it all but disappeared, which
+   * is the opposite of the point. A party that answered nothing has to be
+   * visibly *present and unrankable*, not visibly missing.
+   */
+  "ko:disabled:cursor-default ko:disabled:bg-surface/40 ko:disabled:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
+].join(" ");
+
+/*
+ * The bar eats into the top padding, so equal paddings left the contents
+ * sitting visibly high on the card. Compensated by exactly the bar's height —
+ * and only on rows that have a bar: the no-answer row draws none and needs
+ * none. Desktop gets the room: the ranking is the answer this screen exists to
+ * give, and on a phone the same padding would spend the whole viewport on four
+ * rows. The top match is bigger, not differently built — the same row one step
+ * up in scale, so it reads as the head of this list rather than a separate
+ * kind of card above it.
+ */
+const paddingClasses = {
+  default: {
+    plain: "ko:p-4 ko:lg:p-6",
+    edged: `ko:p-4 ko:pt-[calc(1rem_+_${EDGE_HEIGHT})] ko:lg:p-6 ko:lg:pt-[calc(1.5rem_+_${EDGE_HEIGHT})]`,
+  },
+  winner: {
+    plain: "ko:px-4 ko:py-6 ko:lg:px-6 ko:lg:py-8",
+    edged: `ko:px-4 ko:py-6 ko:pt-[calc(1.5rem_+_${EDGE_HEIGHT})] ko:lg:px-6 ko:lg:py-8 ko:lg:pt-[calc(2rem_+_${EDGE_HEIGHT})]`,
+  },
+} as const;
+
+/*
+ * The unfilled remainder has to stay visible, or the bar reads as a stripe of
+ * arbitrary length rather than a proportion of something. `surface-sunken` is
+ * near-invisible against a dark card; the border tone holds in both modes. So
+ * the Meter is squared off, recoloured and pinned to the top edge here.
+ */
+const edgeClasses = "ko:absolute ko:inset-x-0 ko:top-0 ko:rounded-none ko:bg-border";
+
+const identityClasses = "ko:flex ko:flex-col ko:items-start ko:gap-1 ko:min-w-0";
+const nameLineClasses = "ko:flex ko:items-baseline ko:gap-1.5 ko:min-w-0";
+
+/* An ordinal in front of the name; the avatar stays clean. */
+const rankClasses = "ko:flex-none ko:font-sans ko:text-[0.8125rem] ko:font-bold ko:text-text-muted ko:tabular-nums";
+
+/* Party names in the archive run to 85 characters. Two lines is the ceiling;
+   past that the rows stop sharing a rhythm and the ranking is hard to scan. */
+const nameClasses = "ko:min-w-0 ko:font-sans ko:text-sm ko:font-semibold ko:leading-[1.3] ko:tracking-[-0.01em] ko:text-text-strong ko:line-clamp-2";
+const winnerNameClasses = "ko:text-base";
+
+/* Only ever inside a disabled row, so always in the subtle ink the source gave it there. */
+const noAnswerClasses = "ko:font-sans ko:text-xs ko:text-text-subtle";
+
+const percentClasses = "ko:font-display ko:text-xl ko:font-bold ko:tracking-[-0.01em] ko:text-text-strong ko:tabular-nums ko:whitespace-nowrap";
+const winnerPercentClasses = "ko:text-2xl";
+
+/**
+ * One candidate in the ranking.
+ *
+ * The percentage is drawn as a bar along the card's top edge rather than inside
+ * it. Two reasons, and the second is the important one: it frees the card's
+ * interior for whitespace, and — because every card in the column is the same
+ * width — every bar is measured against the same scale. Sitting inside the
+ * layout, the winner's bar shared a row with a larger avatar and a larger
+ * number, so the widest match drew the *shortest* bar.
+ *
+ * Circles are spent on the avatar, where they identify rather than measure.
+ *
+ * A candidate who answered nothing gets no bar and no percentage: showing 0 %
+ * would read as "opposed on everything" when the truth is "nothing to compare",
+ * and that distinction is the difference between a fair result and a libel.
+ */
+export function MatchRow({
+  rank,
+  name,
+  avatarUrl,
+  avatarImage,
+  color,
+  matchPercentage,
+  percentLabel,
+  noAnswerLabel,
+  winner = false,
+  winnerLabel,
+  selected = false,
+  onSelect,
+  delay = 0,
+}: MatchRowProps) {
+  const comparable = matchPercentage !== undefined;
+  /*
+   * `color` carries the data colour or the server-derived one when the
+   * candidate has either; `partyColor` falls back to its seeded palette
+   * otherwise, which is also what covers every party with no picture at all.
+   */
+  const accent = partyColor(name, color);
+  const padding = paddingClasses[winner ? "winner" : "default"][comparable ? "edged" : "plain"];
+
+  return (
+    <li
+      /*
+       * A candidate nobody can compare doesn't float above the page like an
+       * answer card, and doesn't answer the pointer at all — so it simply
+       * isn't pressable. The source kept the class and overrode its shadow
+       * and transform at rest and on hover; leaving it off is the same thing
+       * said once.
+       *
+       * The float belongs to the whole card; `aria-pressed` belongs on the
+       * button that opens the comparison. `data-open` is what joins them —
+       * see `.ko-pressable` in `styles.css`.
+       */
+      className={twMerge(itemClasses, comparable && "ko-pressable")}
+      data-open={selected && comparable ? "" : undefined}
+      style={delay ? { animationDelay: `${delay}s` } : undefined}
+    >
+      <button type="button" className={twMerge(rowClasses, padding)} aria-pressed={selected} onClick={onSelect} disabled={!comparable} style={{ "--row-accent": accent } as React.CSSProperties}>
+        {/* Decorative: the percentage is text a few pixels away, and a screen
+            reader announcing the bar as well would read the same number twice —
+            the unlabelled Meter is `aria-hidden` on its own. */}
+        {comparable ? <Meter value={matchPercentage} size="small" accent={accent} delay={delay} className={edgeClasses} /> : null}
+
+        <Avatar name={name} src={avatarUrl} image={avatarImage} accent={accent} size={winner ? "large" : "medium"} />
+
+        <span className={identityClasses}>
+          {winner && winnerLabel ? <Tag tone="neutral">{winnerLabel}</Tag> : null}
+          {/* The rank rides the name as an ordinal — "2." is how Czech writes
+              one — rather than sitting in its own column, which spent a whole
+              grid track on one or two digits. An unranked candidate simply has
+              no ordinal: a bold "–" would shout on the one row that is meant
+              to stay quiet. */}
+          <span className={nameLineClasses}>
+            {rank === undefined ? null : <span className={rankClasses}>{rank}.</span>}
+            <span className={twMerge(nameClasses, winner && winnerNameClasses)}>{name}</span>
+          </span>
+          {comparable ? null : <span className={noAnswerClasses}>{noAnswerLabel}</span>}
+        </span>
+
+        <span className={twMerge(percentClasses, winner && winnerPercentClasses)}>{comparable ? percentLabel : null}</span>
+      </button>
+    </li>
+  );
+}

--- a/packages/design-system/src/components/server/avatar.test.tsx
+++ b/packages/design-system/src/components/server/avatar.test.tsx
@@ -1,0 +1,103 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Avatar, AvatarVariants, initialsOf } from "./avatar";
+
+describe("initialsOf", () => {
+  it("takes the first letter of the first two words, whatever they are", () => {
+    expect(initialsOf("Žijeme Pardubice")).toBe("ŽP");
+    expect(initialsOf("Piráti a Starostové")).toBe("PA");
+  });
+
+  it("keeps digits and skips punctuation", () => {
+    expect(initialsOf("ANO 2011")).toBe("A2");
+    expect(initialsOf("KDU-ČSL")).toBe("K");
+    expect(initialsOf("Piráti: 42projektu.cz")).toBe("P4");
+  });
+
+  it("upper-cases and copes with an empty name", () => {
+    expect(initialsOf("zelení")).toBe("Z");
+    expect(initialsOf("")).toBe("");
+  });
+});
+
+describe("Avatar", () => {
+  it("renders the initials, hidden from assistive tech, as a span", () => {
+    const { container } = render(<Avatar name="Žijeme Pardubice" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.tagName).toBe("SPAN");
+    const initials = root.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(initials).toHaveTextContent("ŽP");
+    expect(root.querySelector("img")).not.toBeInTheDocument();
+  });
+
+  it("is a medium circle by default", () => {
+    const { container } = render(<Avatar name="ODS" />);
+    expect(container.firstElementChild).toHaveClass("ko:size-11", "ko:rounded-pill");
+    expect(AvatarVariants().split(" ")).toEqual(expect.arrayContaining(["ko:bg-[var(--avatar-wash,var(--ko-color-neutral-soft))]", "ko:after:rounded-[inherit]"]));
+  });
+
+  it("scales to the 2026 sizes", () => {
+    const { container } = render(
+      <>
+        <Avatar name="ODS" size="small" />
+        <Avatar name="ODS" size="large" />
+      </>,
+    );
+    expect(container.children[0]).toHaveClass("ko:size-8");
+    expect(container.children[1]).toHaveClass("ko:size-16");
+  });
+
+  it("keeps the picture as a sibling after the initials, with an empty alt", () => {
+    const { container } = render(<Avatar name="ODS" src="https://example.test/ods.png" />);
+    const root = container.firstElementChild as HTMLElement;
+    const image = root.querySelector("img") as HTMLImageElement;
+    expect(image).toHaveAttribute("src", "https://example.test/ods.png");
+    expect(image).toHaveAttribute("alt", "");
+    expect(image).toHaveClass("ko:absolute", "ko:inset-0", "ko:bg-surface", "ko:object-cover");
+    expect(root.lastElementChild).toBe(image);
+    expect(root.firstElementChild).toHaveTextContent("O");
+  });
+
+  it("pre-mixes the accent into the ring and wash variables", () => {
+    const { container } = render(<Avatar name="ODS" accent="light-dark(#2563eb, #3b82f6)" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.getPropertyValue("--avatar-ring")).toBe("oklch(from light-dark(#2563eb, #3b82f6) l c h / 0.6)");
+    expect(root.style.getPropertyValue("--avatar-wash")).toBe("oklch(from light-dark(#2563eb, #3b82f6) l c h / 0.16)");
+  });
+
+  it("sets no variables without an accent, so an ancestor's still apply", () => {
+    const { container } = render(<Avatar name="ODS" />);
+    expect((container.firstElementChild as HTMLElement).getAttribute("style")).toBeNull();
+  });
+
+  describe("legacy match card", () => {
+    const image = { original: "https://example.test/original.png", xs: "https://example.test/xs.png", md: "https://example.test/md.png" };
+
+    it("renders the responsive set as a srcset with the smallest source", () => {
+      const { container } = render(<Avatar image={image} shape="circle" size="large" />);
+      const element = container.querySelector("img") as HTMLImageElement;
+      expect(element).toHaveAttribute("src", "https://example.test/xs.png");
+      expect(element).toHaveAttribute("srcset", "https://example.test/xs.png 100w, https://example.test/md.png 400w");
+      expect(element).toHaveAttribute("sizes", "64px");
+    });
+
+    it("keeps square, padded, contained logos over a fill of their own", () => {
+      const { container } = render(<Avatar image={image} backgroundColor="#e2e8f0" shape="square" fit="contain" padding alignment="top" size="large" />);
+      const root = container.firstElementChild as HTMLElement;
+      expect(root).toHaveClass("ko:rounded-2xl");
+      const fill = root.firstElementChild as HTMLElement;
+      expect(fill.style.backgroundColor).toBe("rgb(226, 232, 240)");
+      const element = root.querySelector("img") as HTMLImageElement;
+      expect(element).toHaveClass("ko:inset-2", "ko:object-contain", "ko:object-top");
+      expect(element).not.toHaveClass("ko:inset-0", "ko:bg-surface");
+    });
+
+    it("prefers src over the responsive set when both are given", () => {
+      const { container } = render(<Avatar name="ODS" src="https://example.test/ods.png" image={image} />);
+      const element = container.querySelector("img") as HTMLImageElement;
+      expect(element).toHaveAttribute("src", "https://example.test/ods.png");
+      expect(element).not.toHaveAttribute("srcset");
+    });
+  });
+});

--- a/packages/design-system/src/components/server/avatar.tsx
+++ b/packages/design-system/src/components/server/avatar.tsx
@@ -1,3 +1,4 @@
+// Ported from kalkulacka-2026/packages/ui/src/avatar/avatar.tsx and avatar.module.css
 import { cva, type VariantProps } from "class-variance-authority";
 
 import { twMerge } from "../../utilities";
@@ -9,32 +10,107 @@ export type ImageUrls = {
   md?: string;
 };
 
+export type AvatarSize = NonNullable<VariantProps<typeof AvatarVariants>["size"]>;
+
 export type Avatar = {
-  image: ImageUrls;
+  /**
+   * Full name — the initials fallback behind the picture. Optional only for
+   * the legacy match card, which passes `image` alone; every 2026 consumer
+   * passes it, and an avatar without it has nothing to show when its picture
+   * fails to load.
+   */
+  name?: string;
+  /** A single picture URL. */
+  src?: string;
+  /** The legacy responsive set — rendered as a `srcset`. `src` wins when both are given. */
+  image?: ImageUrls;
+  /**
+   * The candidate's accent colour: a ring around the face and a wash behind
+   * it, pre-mixed here at fixed alphas from the same colour the match bar
+   * uses. Unset, the avatar keeps the plain neutral look — a value handed
+   * down as `--avatar-ring` / `--avatar-wash` from an ancestor (the way 2026's
+   * `MatchRow` did it) still applies.
+   */
+  accent?: string;
+  /**
+   * The retired design's fill behind a padded logo. Kept for the legacy
+   * match card; when set, the picture sits transparent over it as it always
+   * did rather than painting its own surface.
+   *
+   * @deprecated Removed with the cleanup PR together with the legacy match card.
+   */
   backgroundColor?: string;
-  shape: "circle" | "square";
+  /** @deprecated Every 2026 avatar is a circle; `square` stays for the legacy match card's organisations. */
+  shape?: "circle" | "square" | null;
+  /** @deprecated Legacy match card only: crops a portrait to its top edge. */
   alignment?: "top" | "center";
+  /** @deprecated Legacy match card only: insets a logo from the edge. */
   padding?: boolean;
+  /** @deprecated Legacy match card only: `contain` for a logo, `cover` for a face. */
   fit?: "cover" | "contain";
   className?: string;
 } & VariantProps<typeof AvatarVariants>;
 
-const AvatarVariants = cva("ko:relative ko:flex ko:items-center ko:justify-center ko:overflow-hidden ko:shrink-0", {
-  variants: {
-    size: {
-      small: "ko:h-10 ko:w-10",
-      medium: "ko:h-14 ko:w-14",
-      large: "ko:h-20 ko:w-20",
+/*
+ * `--avatar-wash` / `--avatar-ring` are read with the plain neutral look as
+ * the fallback rather than derived from a fallback colour here, because
+ * applying the same alpha to the fallback too would quietly wash out every
+ * avatar with no accent at all (Storybook's, chiefly). The ring lives on a
+ * pseudo-element rather than the avatar's own box-shadow: a logo image sits
+ * `inset: 0`, flush with the same edge, and an absolutely positioned child
+ * paints over its parent's box-shadow — so the ring vanished on every avatar
+ * that actually had a picture and only survived on the initials fallback.
+ * `after` is generated last, which is what keeps it on top of the image.
+ */
+export const AvatarVariants = cva(
+  [
+    "ko:relative ko:inline-flex ko:flex-none ko:items-center ko:justify-center ko:overflow-hidden",
+    "ko:bg-[var(--avatar-wash,var(--ko-color-neutral-soft))]",
+    "ko:after:content-[''] ko:after:absolute ko:after:inset-0 ko:after:rounded-[inherit] ko:after:pointer-events-none",
+    "ko:after:shadow-[inset_0_0_0_1.5px_var(--avatar-ring,var(--ko-color-border))]",
+  ],
+  {
+    variants: {
+      /* The 2026 pixel sizes, with the initials' type scaled to each. */
+      size: {
+        small: "ko:size-8 ko:text-xs",
+        medium: "ko:size-11 ko:text-[0.9375rem]",
+        large: "ko:size-16 ko:text-xl",
+      },
+      shape: {
+        circle: "ko:rounded-pill",
+        square: "ko:rounded-2xl",
+      },
     },
-    shape: {
-      circle: "ko:rounded-full",
-      square: "ko:rounded-2xl",
+    defaultVariants: {
+      size: "medium",
+      shape: "circle",
     },
   },
-  defaultVariants: {
-    size: "medium",
-  },
-});
+);
+
+/* The `sizes` hint for the legacy `srcset`, in the same pixels as the variants above. */
+const sizesAttr: Record<AvatarSize, string> = {
+  small: "32px",
+  medium: "44px",
+  large: "64px",
+};
+
+/**
+ * Take at most two initials, skipping the punctuation that party names are full
+ * of ("ANO 2011" -> "A2", "KDU-ČSL" -> "K"). The first two *words*, whatever
+ * they are: "Piráti a Starostové" is "PA". (The 2026 source's own comment
+ * promised "PS", which its code never produced; the code is ported as it ran.)
+ */
+export function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((word) => word.replace(/[^\p{L}\p{N}]/gu, ""))
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? "")
+    .join("");
+}
 
 function getSmallestImageUrl(imageUrls: ImageUrls): string {
   return imageUrls.xs || imageUrls.sm || imageUrls.md || imageUrls.original;
@@ -48,23 +124,64 @@ function buildSrcSet(imageUrls: ImageUrls): string {
   return entries.join(", ");
 }
 
-export function Avatar({ image, backgroundColor, shape, alignment = "center", padding = false, fit = "cover", size, className }: Avatar) {
-  const sizeMap = {
-    small: "40px",
-    medium: "56px",
-    large: "80px",
-  };
+/**
+ * A candidate's picture, with initials behind it.
+ *
+ * The initials are rendered as a sibling rather than swapped in on error: a
+ * transparent logo sitting over its own initials looks wrong, so the picture
+ * carries an opaque surface of its own and covers them when it loads. The 2026
+ * source also expected a picture that *fails* to reveal them — "no JavaScript
+ * involved" — but that is not what browsers do: an absolutely positioned
+ * `<img alt="">` that errors keeps its full box and still paints its
+ * background (verified in Chrome), so a 404 logo shows a blank surface disc,
+ * not the initials. Without an `onError` handler — which a server component
+ * cannot carry — the two wishes cannot both be met in CSS, and the opaque
+ * backing serves every transparent archive logo where the fallback would serve
+ * only broken ones. Ported as the source ran; see the report for the follow-up.
+ *
+ * A `<span>`, not a `<div>`: the match row puts one of these inside a
+ * `<button>`, which admits phrasing content only.
+ */
+export function Avatar({ name, src, image, accent, backgroundColor, shape, alignment = "center", padding = false, fit = "cover", size, className }: Avatar) {
+  const style = accent
+    ? ({
+        "--avatar-wash": `oklch(from ${accent} l c h / 0.16)`,
+        "--avatar-ring": `oklch(from ${accent} l c h / 0.6)`,
+      } as React.CSSProperties)
+    : undefined;
 
-  const sizesAttr = sizeMap[size || "medium"];
-  const alignmentClass = alignment === "top" ? "ko:object-top" : "ko:object-center";
-  const paddingClass = padding ? "ko:p-2" : "";
-  const fitClass = fit === "contain" ? "ko:object-contain" : "ko:object-cover";
+  /*
+   * Absolutely positioned over the initials, so a picture that fails leaves
+   * them in view. Its own surface fill is what covers them opaquely when it
+   * loads — unless the legacy card has painted a fill of its own underneath,
+   * in which case the picture stays transparent over it as it always did.
+   * The legacy `padding` is an inset on the picture rather than padding on
+   * the box, which an absolute child would ignore.
+   */
+  const imageClasses = twMerge(
+    "ko:absolute ko:inset-0 ko:size-full",
+    backgroundColor ? "" : "ko:bg-surface",
+    padding && "ko:inset-2",
+    fit === "contain" ? "ko:object-contain" : "ko:object-cover",
+    alignment === "top" ? "ko:object-top" : "ko:object-center",
+  );
 
   return (
-    <div className={twMerge(AvatarVariants({ size, shape }), paddingClass, className)}>
-      {backgroundColor && <div className="ko:absolute ko:inset-0" style={{ backgroundColor }} />}
+    <span className={twMerge(AvatarVariants({ size, shape }), className)} style={style}>
+      {backgroundColor && <span className="ko:absolute ko:inset-0" style={{ backgroundColor }} />}
 
-      <img src={getSmallestImageUrl(image)} srcSet={buildSrcSet(image)} sizes={sizesAttr} alt="" loading="lazy" className={`ko:relative ko:z-10 ko:h-full ko:w-full ${fitClass} ${alignmentClass}`} />
-    </div>
+      {/* Positioned, so it paints above the legacy fill (a positioned sibling before it) and below the picture. */}
+      {name && (
+        <span className="ko:relative ko:font-sans ko:font-bold ko:tracking-[0.01em] ko:text-text-muted" aria-hidden="true">
+          {initialsOf(name)}
+        </span>
+      )}
+
+      {src ? (
+        <img className={imageClasses} src={src} alt="" loading="lazy" />
+      ) : image ? (
+        <img className={imageClasses} src={getSmallestImageUrl(image)} srcSet={buildSrcSet(image)} sizes={sizesAttr[size ?? "medium"]} alt="" loading="lazy" />
+      ) : null}
+    </span>
   );
 }

--- a/packages/design-system/src/components/server/donut.test.tsx
+++ b/packages/design-system/src/components/server/donut.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CIRCUMFERENCE, Donut, type DonutSegment, GAP } from "./donut";
+
+const segments: DonutSegment[] = [
+  { tone: "agree", value: 24, label: "Souhlas" },
+  { tone: "disagree", value: 12, label: "Nesouhlas" },
+  { tone: "none", value: 6, label: "Bez odpovědi" },
+];
+
+function segmentsOf(container: HTMLElement): SVGCircleElement[] {
+  // The first circle is the track.
+  return Array.from(container.querySelectorAll("circle")).slice(1);
+}
+
+describe("Donut", () => {
+  it("draws the centre figure and its caption", () => {
+    render(<Donut segments={segments} centerValue="42" centerLabel="otázek" />);
+    expect(screen.getByText("42")).toHaveClass("ko:font-display");
+    expect(screen.getByText("otázek")).toBeInTheDocument();
+  });
+
+  it("hides the ring from assistive tech and sizes it in px", () => {
+    const { container } = render(<Donut segments={segments} centerValue="42" centerLabel="otázek" size={100} />);
+    const svg = container.querySelector("svg") as SVGSVGElement;
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+    expect(svg).toHaveClass("ko:-rotate-90");
+    expect((svg.parentElement as HTMLElement).style.width).toBe("100px");
+  });
+
+  it("draws one segment per non-zero value, each shortened by the gap and offset by what came before", () => {
+    const { container } = render(<Donut segments={segments} centerValue="42" centerLabel="otázek" />);
+    const circles = segmentsOf(container);
+    expect(circles).toHaveLength(3);
+
+    const agreeArc = (24 / 42) * CIRCUMFERENCE;
+    const disagreeArc = (12 / 42) * CIRCUMFERENCE;
+    expect(circles[0]).toHaveAttribute("stroke-dasharray", `${agreeArc - GAP} ${CIRCUMFERENCE - (agreeArc - GAP)}`);
+    expect(circles[0]).toHaveAttribute("stroke-dashoffset", "0");
+    expect(circles[1]).toHaveAttribute("stroke-dashoffset", `${-agreeArc}`);
+    expect(circles[2]).toHaveAttribute("stroke-dashoffset", `${-(agreeArc + disagreeArc)}`);
+    expect(circles[0]).toHaveClass("ko:stroke-agree");
+    expect(circles[1]).toHaveClass("ko:stroke-disagree");
+    expect(circles[2]).toHaveClass("ko:stroke-text-muted/55");
+    expect(circles[0]).toHaveAttribute("stroke-linecap", "butt");
+  });
+
+  it("drops zero-value segments rather than drawing stray dots", () => {
+    const { container } = render(
+      <Donut
+        segments={[
+          { tone: "agree", value: 30, label: "Souhlas" },
+          { tone: "disagree", value: 0, label: "Nesouhlas" },
+          { tone: "neutral", value: 0, label: "Nevím" },
+          { tone: "none", value: 12, label: "Bez odpovědi" },
+        ]}
+        centerValue="42"
+        centerLabel="otázek"
+      />,
+    );
+    const circles = segmentsOf(container);
+    expect(circles).toHaveLength(2);
+    expect(circles[0]).toHaveClass("ko:stroke-agree");
+    expect(circles[1]).toHaveClass("ko:stroke-text-muted/55");
+  });
+
+  it("gives a lone segment the full ring, without a gap", () => {
+    const { container } = render(<Donut segments={[{ tone: "agree", value: 42, label: "Souhlas" }]} centerValue="42" centerLabel="otázek" />);
+    const circles = segmentsOf(container);
+    expect(circles).toHaveLength(1);
+    expect(circles[0]).toHaveAttribute("stroke-dasharray", `${CIRCUMFERENCE} 0`);
+  });
+
+  it("draws only the track when nothing has a value", () => {
+    const { container } = render(<Donut segments={[{ tone: "agree", value: 0, label: "Souhlas" }]} centerValue="0" centerLabel="otázek" />);
+    expect(segmentsOf(container)).toHaveLength(0);
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+
+  it("lists the non-zero segments in a legend with their counts", () => {
+    render(
+      <Donut
+        segments={[
+          { tone: "agree", value: 18, label: "Souhlas" },
+          { tone: "disagree", value: 0, label: "Nesouhlas" },
+          { tone: "neutral", value: 7, label: "Nevím" },
+        ]}
+        centerValue="42"
+        centerLabel="otázek"
+      />,
+    );
+    const items = within(screen.getByRole("list")).getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("Souhlas18");
+    expect(items[1]).toHaveTextContent("Nevím7");
+    expect(items[0]?.querySelector('[aria-hidden="true"]')).toHaveClass("ko:bg-agree");
+    expect(items[1]?.querySelector('[aria-hidden="true"]')).toHaveClass("ko:bg-neutral-ink");
+    expect(screen.queryByText("Nesouhlas")).not.toBeInTheDocument();
+  });
+});

--- a/packages/design-system/src/components/server/donut.tsx
+++ b/packages/design-system/src/components/server/donut.tsx
@@ -1,0 +1,154 @@
+// Ported from kalkulacka-2026/packages/ui/src/donut/donut.tsx and donut.module.css, with the
+// legend from kalkulacka-2026/apps/web/components/results-dashboard.tsx (`.legend*`, `.swatch`)
+import { twMerge } from "@kalkulacka-one/design-system/utilities";
+
+import { cva } from "class-variance-authority";
+
+/** The same four tones as the answer marks, so the ring reads against the recap without a key. */
+export type DonutTone = "agree" | "disagree" | "neutral" | "none";
+
+export type DonutSegment = {
+  tone: DonutTone;
+  value: number;
+  label: string;
+};
+
+export type Donut = {
+  segments: DonutSegment[];
+  /** The figure in the hole — usually the total. */
+  centerValue: string;
+  /** Its caption, e.g. "otázek". */
+  centerLabel: string;
+  /** Outer diameter in px. */
+  size?: number;
+  className?: string;
+};
+
+const RADIUS = 40;
+export const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+/** Units of arc dropped between segments so two adjacent colours stay legible. */
+export const GAP = 3;
+
+/*
+ * The ring's four inks. `none` — unanswered — reads as absence without
+ * disappearing: at 0.28 it was all but invisible on the dark theme, where the
+ * muted ink is already close to the surface behind it, and a segment nobody
+ * can see is a share of the whole silently unaccounted for. The legend's
+ * swatches wear the same four, so the key can't drift from the ring it
+ * explains.
+ */
+export const DonutSegmentVariants = cva("", {
+  variants: {
+    tone: {
+      agree: "ko:stroke-agree",
+      disagree: "ko:stroke-disagree",
+      neutral: "ko:stroke-neutral-ink",
+      none: "ko:stroke-text-muted/55",
+    },
+  },
+});
+
+export const DonutSwatchVariants = cva("ko:size-2.5 ko:rounded-pill", {
+  variants: {
+    tone: {
+      agree: "ko:bg-agree",
+      disagree: "ko:bg-disagree",
+      neutral: "ko:bg-neutral-ink",
+      none: "ko:bg-text-muted/55",
+    },
+  },
+});
+
+/*
+ * The figure in the hole is off the type scale on purpose: it is sized to the
+ * hole in the ring, not to the reading column, so it answers to the donut's
+ * geometry rather than to the step above or below it. A scale step here would
+ * be a coincidence.
+ */
+const valueClasses = "ko:font-display ko:text-[1.75rem] ko:font-semibold ko:leading-none ko:tracking-[-0.02em] ko:text-text-strong ko:tabular-nums";
+const centerLabelClasses = "ko:font-sans ko:text-xs ko:text-text-muted";
+
+const legendClasses = "ko:flex ko:flex-col ko:gap-2 ko:m-0 ko:p-0 ko:list-none ko:min-w-0";
+const legendItemClasses = "ko:grid ko:grid-cols-[0.625rem_minmax(0,1fr)_auto] ko:items-center ko:gap-2";
+const legendLabelClasses = "ko:font-sans ko:text-[0.8125rem] ko:text-text";
+const legendValueClasses = "ko:font-sans ko:text-[0.8125rem] ko:font-semibold ko:text-text-strong ko:tabular-nums";
+
+/**
+ * How the answers split, as one ring, with a key beside it.
+ *
+ * The counterpart to the bars elsewhere on the dashboard: those compare parties
+ * against each other, this one shows a single whole divided up, which is the
+ * shape a proportion of a fixed 42 questions actually has. Segments carry the
+ * same four tones as the answer marks, so the ring is readable against the recap
+ * without a colour key — the legend beside it names the counts, not the colours.
+ *
+ * Segments worth nothing are dropped rather than drawn as zero-length arcs,
+ * which would otherwise show up as stray dots where their gaps fall; the legend
+ * drops them too, so it lists what the ring shows.
+ *
+ * The ring is decorative and the centre figure is plain text; the legend is a
+ * real list, which is what a screen reader gets the split from.
+ */
+export function Donut({ segments, centerValue, centerLabel, size = 132, className }: Donut) {
+  const visible = segments.filter((segment) => segment.value > 0);
+  const total = visible.reduce((sum, segment) => sum + segment.value, 0);
+
+  let cumulative = 0;
+
+  return (
+    <div className={twMerge("ko:flex ko:flex-wrap ko:items-center ko:gap-4", className)}>
+      <div className="ko:relative ko:flex-none" style={{ width: size, height: size }}>
+        {/* Rotated so the first segment starts at twelve o'clock rather than at three,
+            which is where a stroke-dash ring would otherwise begin. */}
+        <svg viewBox="0 0 100 100" className="ko:size-full ko:-rotate-90" aria-hidden="true">
+          <circle className="ko:stroke-surface-sunken" cx="50" cy="50" r={RADIUS} fill="none" strokeWidth={13} />
+
+          {total > 0
+            ? visible.map((segment) => {
+                const arc = (segment.value / total) * CIRCUMFERENCE;
+                // A lone segment is a full ring; giving it a gap would cut a
+                // notch in something that has no neighbour to be separated from.
+                const drawn = visible.length > 1 ? Math.max(arc - GAP, 0.5) : arc;
+                const offset = cumulative;
+                cumulative += arc;
+
+                return (
+                  /* Butt caps, not round: rounded ends would eat into the gaps and make two
+                     adjacent segments touch again at exactly the size the gap was added to fix. */
+                  <circle
+                    key={segment.tone}
+                    className={twMerge(DonutSegmentVariants({ tone: segment.tone }))}
+                    cx="50"
+                    cy="50"
+                    r={RADIUS}
+                    fill="none"
+                    strokeWidth={13}
+                    strokeLinecap="butt"
+                    strokeDasharray={`${drawn} ${CIRCUMFERENCE - drawn}`}
+                    strokeDashoffset={-offset}
+                  />
+                );
+              })
+            : null}
+        </svg>
+
+        <div className="ko:absolute ko:inset-0 ko:flex ko:flex-col ko:items-center ko:justify-center ko:gap-[0.0625rem]">
+          <span className={valueClasses}>{centerValue}</span>
+          <span className={centerLabelClasses}>{centerLabel}</span>
+        </div>
+      </div>
+
+      {visible.length > 0 ? (
+        <ul className={legendClasses}>
+          {visible.map((segment) => (
+            <li key={segment.tone} className={legendItemClasses}>
+              <span className={twMerge(DonutSwatchVariants({ tone: segment.tone }))} aria-hidden="true" />
+              <span className={legendLabelClasses}>{segment.label}</span>
+              <span className={legendValueClasses}>{segment.value}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/design-system/src/components/server/index.ts
+++ b/packages/design-system/src/components/server/index.ts
@@ -5,6 +5,7 @@ export * from "./backdrop";
 export * from "./badge";
 export * from "./card";
 export * from "./chip";
+export * from "./donut";
 export * from "./dotIndicator";
 export * from "./edgeFade";
 export * from "./iconBadge";

--- a/packages/design-system/src/components/server/progressBar.test.tsx
+++ b/packages/design-system/src/components/server/progressBar.test.tsx
@@ -1,32 +1,104 @@
+// Ported from kalkulacka-2026/packages/ui/src/meter/meter.test.tsx
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { ProgressBar } from "./progressBar";
+import { Meter, MeterFillVariants, MeterTrackVariants, ProgressBar } from "./progressBar";
 
-describe("ProgressBar", () => {
-  describe("when given valid value", () => {
-    it("should render with the correct width and aria-attributes based on value", () => {
-      render(<ProgressBar value={50} />);
-      const progressBar = screen.getByRole("progressbar");
-      const innerBar = progressBar.firstChild as HTMLElement;
-      expect(innerBar.style.width).toBe("50%");
-      expect(progressBar).toHaveAttribute("aria-valuenow", "50");
-      expect(progressBar).toHaveAttribute("aria-valuemin", "0");
-      expect(progressBar).toHaveAttribute("aria-valuemax", "100");
+function fillOf(container: HTMLElement): HTMLElement {
+  return container.querySelector("[style]") as HTMLElement;
+}
+
+describe("Meter", () => {
+  it("is decorative (aria-hidden) without a label", () => {
+    const { container } = render(<Meter value={72} />);
+    expect(container.querySelector('[aria-hidden="true"]')).toBeInTheDocument();
+    expect(screen.queryByRole("meter")).not.toBeInTheDocument();
+  });
+
+  it("exposes itself as a meter with rounded aria-valuenow when labelled", () => {
+    render(<Meter value={63.4} label="Shoda 63 %" />);
+    const meter = screen.getByRole("meter", { name: "Shoda 63 %" });
+    expect(meter).toHaveAttribute("aria-valuenow", "63");
+    expect(meter).toHaveAttribute("aria-valuemin", "0");
+    expect(meter).toHaveAttribute("aria-valuemax", "100");
+  });
+
+  it("clamps values above 100", () => {
+    const { container } = render(<Meter value={140} />);
+    expect(fillOf(container).style.width).toBe("100%");
+  });
+
+  it("clamps values below 0", () => {
+    const { container } = render(<Meter value={-20} />);
+    expect(fillOf(container).style.width).toBe("0%");
+  });
+
+  it("is an agree-toned medium bar by default", () => {
+    const { container } = render(<Meter value={50} />);
+    expect(container.firstElementChild).toHaveClass("ko:h-2", "ko:rounded-pill", "ko:bg-surface-sunken");
+    expect(fillOf(container)).toHaveClass("ko:bg-agree", "ko:animate-meter-grow", "ko:motion-reduce:animate-none");
+  });
+
+  it("takes the neutral ink and the small height", () => {
+    const { container } = render(<Meter value={50} tone="neutral" size="small" />);
+    expect(container.firstElementChild).toHaveClass("ko:h-[0.3125rem]");
+    expect(fillOf(container)).toHaveClass("ko:bg-neutral-ink");
+    expect(MeterFillVariants({ tone: "neutral" }).split(" ")).not.toContain("ko:bg-agree");
+  });
+
+  describe("delay", () => {
+    it("staggers the entrance through the animation delay", () => {
+      const { container } = render(<Meter value={50} delay={0.6} />);
+      expect(fillOf(container).style.animationDelay).toBe("0.6s");
+    });
+
+    it("sets no delay at zero", () => {
+      const { container } = render(<Meter value={50} />);
+      expect(fillOf(container).style.animationDelay).toBe("");
+    });
+
+    it("passes a negative delay through, which is an entrance already over", () => {
+      const { container } = render(<Meter value={50} delay={-1} />);
+      expect(fillOf(container).style.animationDelay).toBe("-1s");
     });
   });
 
-  it("should clamp the value to 100 if value is greater than 100", () => {
-    render(<ProgressBar value={150} />);
-    const progressBar = screen.getByRole("progressbar");
-    const innerBar = progressBar.firstChild as HTMLElement;
-    expect(innerBar.style.width).toBe("100%");
+  it("paints an accent over the tone's ink", () => {
+    const { container } = render(<Meter value={50} accent="light-dark(#2563eb, #3b82f6)" />);
+    // jsdom serialises the hex pair back as rgb(); the light-dark() wrapper is what matters.
+    expect(fillOf(container).style.backgroundColor).toMatch(/^light-dark\(rgb\(37, 99, 235\), rgb\(59, 130, 246\)\)$/);
   });
 
-  it("should apply the primary color variant by default", () => {
-    render(<ProgressBar value={50} />);
-    const progressBar = screen.getByRole("progressbar");
-    const innerBar = progressBar.firstChild as HTMLElement;
-    expect(innerBar).toHaveClass("ko:bg-primary");
+  it("merges a class onto the track", () => {
+    const { container } = render(<Meter value={50} className="ko:rounded-none ko:bg-border" />);
+    expect(container.firstElementChild).toHaveClass("ko:rounded-none", "ko:bg-border");
+    expect(container.firstElementChild).not.toHaveClass("ko:rounded-pill", "ko:bg-surface-sunken");
+  });
+
+  describe("legacy aliases", () => {
+    it("is exported as ProgressBar too", () => {
+      expect(ProgressBar).toBe(Meter);
+    });
+
+    it("maps color=primary to the agree tone", () => {
+      const { container } = render(<ProgressBar value={50} color="primary" corner="sharp" />);
+      expect(fillOf(container)).toHaveClass("ko:bg-agree");
+    });
+
+    it("maps color=neutral to the neutral tone", () => {
+      const { container } = render(<ProgressBar value={50} color="neutral" />);
+      expect(fillOf(container)).toHaveClass("ko:bg-neutral-ink");
+    });
+
+    it("lets tone win over color", () => {
+      const { container } = render(<ProgressBar value={50} color="primary" tone="neutral" />);
+      expect(fillOf(container)).toHaveClass("ko:bg-neutral-ink");
+    });
+
+    it("ignores corner — the track is always a pill", () => {
+      const { container } = render(<ProgressBar value={50} corner="sharp" />);
+      expect(container.firstElementChild).toHaveClass("ko:rounded-pill");
+      expect(MeterTrackVariants().split(" ")).toContain("ko:rounded-pill");
+    });
   });
 });

--- a/packages/design-system/src/components/server/progressBar.tsx
+++ b/packages/design-system/src/components/server/progressBar.tsx
@@ -1,40 +1,128 @@
+// Ported from kalkulacka-2026/packages/ui/src/meter/meter.tsx and meter.module.css
 import { twMerge } from "@kalkulacka-one/design-system/utilities";
 
 import { cva, type VariantProps } from "class-variance-authority";
 
-export type ProgressBar = {
-  value: number;
-} & VariantProps<typeof ProgressBarVariants>;
+export type MeterTone = NonNullable<VariantProps<typeof MeterFillVariants>["tone"]>;
+export type MeterSize = NonNullable<VariantProps<typeof MeterTrackVariants>["size"]>;
 
-const ProgressBarVariants = cva("ko:h-full ko:w-full", {
+/**
+ * Colour names of the retired `ProgressBar`, accepted so the legacy match card
+ * keeps compiling: `primary` is the `agree` tone, `neutral` is `neutral`.
+ *
+ * @deprecated Removed with the cleanup PR once the legacy match card is gone; use `tone`.
+ */
+export type LegacyMeterColor = "primary" | "neutral";
+
+/** @deprecated Removed with the cleanup PR together with `LegacyMeterColor`. */
+const legacyTones = {
+  primary: "agree",
+  neutral: "neutral",
+} as const satisfies Record<LegacyMeterColor, MeterTone>;
+
+export type Meter = {
+  /** 0–100. Values outside the range are clamped rather than overflowing the track. */
+  value: number;
+  /**
+   * Which ink the fill uses. `agree` is the match colour; `neutral` is for bars
+   * that rank something without taking a side.
+   */
+  tone?: MeterTone | null;
+  size?: MeterSize | null;
+  /**
+   * Seconds to wait before growing from zero. The results list staggers these so
+   * the bars arrive with their rows. Ignored under `prefers-reduced-motion`. A
+   * negative delay (the ranking passes `-1` for a result already shown once)
+   * is an animation that has already finished: the bar is simply full.
+   */
+  delay?: number;
+  /**
+   * Decorative by default: the percentage is almost always text within a few
+   * pixels of the bar, and announcing both reads the same number twice. Pass a
+   * label only where the bar is genuinely the sole statement of the value.
+   */
+  label?: string;
+  /**
+   * A colour for the fill instead of the tone's ink — the ranking paints each
+   * candidate's own (see `MatchRow` and `partyColor`). Any CSS colour,
+   * `light-dark()` included.
+   */
+  accent?: string;
+  /** For the track — the match row squares it off and pins it to the card's top edge. */
+  className?: string;
+  /** @deprecated Use `tone`. `primary` is `agree`. */
+  color?: LegacyMeterColor | null;
+  /**
+   * The retired design's corner switch. Accepted and ignored: the Meter is
+   * always a pill, and the one consumer that asked for `sharp` (the legacy
+   * match card) is replaced by `MatchRow`.
+   *
+   * @deprecated Removed with the cleanup PR.
+   */
+  corner?: "rounded" | "sharp" | null;
+};
+
+export const MeterTrackVariants = cva("ko:w-full ko:rounded-pill ko:bg-surface-sunken ko:overflow-hidden", {
   variants: {
-    color: {
-      primary: "ko:bg-primary",
-      neutral: "ko:bg-neutral",
-    },
-    corner: {
-      rounded: "",
-      sharp: "",
+    size: {
+      medium: "ko:h-2",
+      small: "ko:h-[0.3125rem]",
     },
   },
   defaultVariants: {
-    color: "primary",
-    corner: "rounded",
+    size: "medium",
   },
 });
 
-export function ProgressBar({ value, color, corner }: ProgressBar) {
-  const width = value > 100 ? 100 : value < 0 ? 0 : value;
+/*
+ * The growth is a theme animation (`--ko-animate-meter-grow` in `styles.css`)
+ * grown from the left edge with `transform`, so the width is right on the
+ * first frame. Switched off outright under reduced motion — the collapsed
+ * duration alone would still honour a stagger delay and leave the bar
+ * invisible for that long — and anyone who has asked for less motion gets
+ * the final state on frame one.
+ */
+export const MeterFillVariants = cva("ko:h-full ko:rounded-pill ko:origin-left ko:animate-meter-grow ko:motion-reduce:animate-none", {
+  variants: {
+    tone: {
+      agree: "ko:bg-agree",
+      neutral: "ko:bg-neutral-ink",
+    },
+  },
+  defaultVariants: {
+    tone: "agree",
+  },
+});
+
+/**
+ * A horizontal proportion — the match percentage, and the dashboard's topic
+ * rows. This is the retired `ProgressBar` restyled to the 2026 Meter; the old
+ * name and its `color` and `corner` props survive as aliases for the legacy
+ * match card until the cleanup PR.
+ */
+export function Meter({ value, tone, size, delay = 0, label, accent, className, color, corner: _corner }: Meter) {
+  const clamped = Math.max(0, Math.min(100, value));
+  const resolvedTone = tone ?? (color ? legacyTones[color] : undefined);
 
   return (
     <div
-      role="progressbar"
-      aria-valuenow={width}
-      aria-valuemin={0}
-      aria-valuemax={100}
-      className={twMerge("ko:h-1.5 ko:w-full ko:overflow-hidden ko:bg-neutral-inactive", corner === "rounded" ? "ko:rounded-full" : "")}
+      className={twMerge(MeterTrackVariants({ size }), className)}
+      {...(label
+        ? {
+            role: "meter",
+            "aria-valuenow": Math.round(clamped),
+            "aria-valuemin": 0,
+            "aria-valuemax": 100,
+            "aria-label": label,
+          }
+        : { "aria-hidden": "true" })}
     >
-      <div className={twMerge(ProgressBarVariants({ color, corner }))} style={{ width: `${width}%` }} />
+      <div className={twMerge(MeterFillVariants({ tone: resolvedTone }))} style={{ width: `${clamped}%`, animationDelay: delay ? `${delay}s` : undefined, backgroundColor: accent }} />
     </div>
   );
 }
+
+/** @deprecated The retired name of `Meter`; removed with the cleanup PR. */
+export const ProgressBar = Meter;
+/** @deprecated The retired name of `Meter`'s props; removed with the cleanup PR. */
+export type ProgressBar = Meter;

--- a/packages/design-system/src/styles.css
+++ b/packages/design-system/src/styles.css
@@ -408,6 +408,67 @@
     }
   }
 
+  /*
+   * The Meter's fill growing from nothing (`Meter`, and through it the bar
+   * along the top edge of every `MatchRow`). Grown with `transform` rather
+   * than by animating `width`: the width is already correct on the first
+   * frame, so the bar can never be measured mid-animation and nothing reflows
+   * on each tick; the component sets `origin-left`, which is what makes it
+   * read as filling rather than sliding in. `both`, so a delayed bar holds
+   * at zero through its stagger. The bar's job is to be comparable at a
+   * glance, and it does that standing still: the component adds
+   * `motion-reduce:animate-none`, because a collapsed duration alone would
+   * still honour the delay and leave a delayed bar invisible for that long.
+   * Ported from kalkulacka-2026/packages/ui/src/meter/meter.module.css (`grow`).
+   */
+  --animate-meter-grow: ko-meter-grow var(--ko-duration-slow) var(--ko-ease-spring) both;
+
+  @keyframes ko-meter-grow {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+
+  /*
+   * A `MatchRow` rising into place from below; the results list staggers the
+   * delays so the ranking assembles bottom-up with the winner landing last.
+   * `backwards`, not `both`: a forwards-filled `transform: none` from this
+   * keyframe would outrank every declarative transform and leave the card
+   * permanently inert under the pointer (see `.ko-pressable` below);
+   * `backwards` still holds the `from` state through the stagger delay, which
+   * is the only part that was ever needed. Switched off outright under reduced
+   * motion by the component, for the same reason as the Meter's.
+   * Ported from kalkulacka-2026/packages/ui/src/match-row/match-row.module.css (`rise`).
+   */
+  --animate-match-row-rise: ko-match-row-rise var(--ko-duration-slow) var(--ko-ease-spring) backwards;
+
+  @keyframes ko-match-row-rise {
+    from {
+      opacity: 0;
+      transform: translateY(1.75rem);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  /*
+   * The `AvatarStack` popover arriving under its trigger.
+   * Ported from kalkulacka-2026/packages/ui/src/avatar-stack/avatar-stack.module.css (`stack-panel-in`).
+   */
+  --animate-stack-panel-in: ko-stack-panel-in var(--ko-duration-base) var(--ko-ease-spring);
+
+  @keyframes ko-stack-panel-in {
+    from {
+      opacity: 0;
+      transform: translateY(-4px) scale(0.96);
+    }
+  }
+
   /* Elevation, tinted with the neutral so shadows belong to the theme. */
   --shadow-card: 0 4px 12px -2px oklch(from var(--ko-shadow-color) l c h / 0.1), 0 16px 36px -8px oklch(from var(--ko-shadow-color) l c h / 0.18);
   --shadow-card-next: 0 2px 8px -2px oklch(from var(--ko-shadow-color) l c h / 0.08), 0 10px 24px -6px oklch(from var(--ko-shadow-color) l c h / 0.14);
@@ -1431,6 +1492,107 @@
     .ko-recap-header > * {
       overflow: hidden;
       min-height: 0;
+    }
+  }
+
+  /* --- Calculating -----------------------------------------------------------
+   * Ported from kalkulacka-2026/packages/ui/src/calculating/calculating.module.css.
+   *
+   * The choreography of the wait before the results: a ring counts around a
+   * circular gate while a strip of answer marks is pulled through it, then
+   * the gate shutters and the logo's percent sign lands in its place. The
+   * static arrangement is `ko:` utilities in calculating.tsx; what lives here
+   * is everything that moves, because it moves on literal timings measured
+   * against each other (the shutter closes at 1.15s exactly as the tape stops,
+   * the mark lands 70ms later) rather than on the control tempo the duration
+   * tokens describe — so the blanket reduction in @layer base does not reach
+   * it, and reduced motion has to be stated below.
+   */
+
+  /* The ring. 2πr for r=45. */
+  .ko-calculating-ring-fill {
+    stroke-dasharray: 282.74;
+    animation: ko-calculating-count 1.3s cubic-bezier(0.6, 0, 0.35, 1) both;
+  }
+
+  @keyframes ko-calculating-count {
+    from {
+      stroke-dashoffset: 282.74;
+    }
+    to {
+      stroke-dashoffset: 0;
+    }
+  }
+
+  /*
+   * The gate: a circular aperture the tape is pulled through, sitting inside
+   * the ring. The round clip is what marries the two ideas — the same circle
+   * that counts the progress is the window the answers are read through. It
+   * shutters (fades) as the tape comes to rest.
+   */
+  .ko-calculating-gate {
+    animation: ko-calculating-shutter 0.22s ease 1.15s both;
+  }
+
+  @keyframes ko-calculating-shutter {
+    to {
+      opacity: 0;
+    }
+  }
+
+  /*
+   * The tape and its sprocket holes are pulled by the same keyframes, so holes
+   * and marks stay locked to each other — a strip whose perforations drift
+   * against its frames reads as two layers rather than one piece of film.
+   */
+  .ko-calculating-tape,
+  .ko-calculating-sprockets {
+    animation: ko-calculating-roll 1.15s linear both;
+  }
+
+  @keyframes ko-calculating-roll {
+    to {
+      transform: translateX(-48rem);
+    }
+  }
+
+  /*
+   * The resolve: the logo's own percent sign, landing as the gate closes. The
+   * overshoot is what makes it read as arriving rather than fading up.
+   */
+  .ko-calculating-percent {
+    animation: ko-calculating-land 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) 1.22s both;
+  }
+
+  @keyframes ko-calculating-land {
+    from {
+      opacity: 0;
+      transform: scale(0.55);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  /*
+   * Nothing moves. The tape is the part that would be unpleasant — a strip of
+   * high-contrast marks travelling at speed is exactly the motion this
+   * preference exists to switch off — so the gate is not merely stopped but
+   * removed, and the percent mark and the label carry the moment on their own.
+   */
+  @media (prefers-reduced-motion: reduce) {
+    .ko-calculating-gate {
+      display: none;
+    }
+
+    .ko-calculating-ring-fill {
+      animation: none;
+      stroke-dashoffset: 0;
+    }
+
+    .ko-calculating-percent {
+      animation: none;
     }
   }
 }

--- a/packages/design-system/src/utilities/index.ts
+++ b/packages/design-system/src/utilities/index.ts
@@ -1,2 +1,3 @@
+export * from "./partyColor";
 export * from "./prefersReducedMotion";
 export * from "./tailwind";

--- a/packages/design-system/src/utilities/partyColor.test.ts
+++ b/packages/design-system/src/utilities/partyColor.test.ts
@@ -1,0 +1,118 @@
+// Ported from kalkulacka-2026/packages/ui/src/party-color.test.ts
+import { describe, expect, it } from "vitest";
+
+import { partyColor } from "./partyColor";
+
+const LIGHT_DARK = /^light-dark\((#[0-9a-f]{6}), (#[0-9a-f]{6})\)$/;
+
+/** Independent oracle for the assertions below — deliberately not the module's own algorithm. */
+function hexLightness(hex: string): number {
+  const value = Number.parseInt(hex.slice(1), 16);
+  const r = (value >> 16) & 255;
+  const g = (value >> 8) & 255;
+  const b = value & 255;
+  return (Math.max(r, g, b) + Math.min(r, g, b)) / 2 / 255;
+}
+
+function hexChannels(hex: string): { r: number; g: number; b: number } {
+  const value = Number.parseInt(hex.slice(1), 16);
+  return { r: (value >> 16) & 255, g: (value >> 8) & 255, b: value & 255 };
+}
+
+describe("partyColor — no data colour", () => {
+  it("returns a light-dark() pair, deterministically, for the same seed", () => {
+    const first = partyColor("Piráti");
+    const second = partyColor("Piráti");
+    expect(first).toMatch(LIGHT_DARK);
+    expect(first).toBe(second);
+  });
+
+  it("picks from the fixed palette regardless of name — not every seed collides", () => {
+    const a = partyColor("ANO 2011");
+    const b = partyColor("Česká pirátská strana");
+    // Not asserting they differ (a hash can collide), just that both are valid.
+    expect(a).toMatch(LIGHT_DARK);
+    expect(b).toMatch(LIGHT_DARK);
+  });
+});
+
+describe("partyColor — data colour present", () => {
+  it("clamps the light-mode half into the [0.35, 0.55] lightness band", () => {
+    // #ff0000 is HSL(0, 100%, 50%) — already inside the band, so this also
+    // covers "no clamping needed" alongside the boundary cases below.
+    const [, lightHex] = LIGHT_DARK.exec(partyColor("seed", "#ff0000")) ?? [];
+    expect(lightHex).toBeDefined();
+    expect(hexLightness(lightHex as string)).toBeGreaterThanOrEqual(0.34);
+    expect(hexLightness(lightHex as string)).toBeLessThanOrEqual(0.56);
+  });
+
+  it("clamps the dark-mode half into the [0.55, 0.72] lightness band", () => {
+    const [, , darkHex] = LIGHT_DARK.exec(partyColor("seed", "#ff0000")) ?? [];
+    expect(darkHex).toBeDefined();
+    expect(hexLightness(darkHex as string)).toBeGreaterThanOrEqual(0.54);
+    expect(hexLightness(darkHex as string)).toBeLessThanOrEqual(0.73);
+  });
+
+  it("pulls a near-black data colour up into both bands rather than passing it through", () => {
+    const result = partyColor("seed", "#0a0a12");
+    const [, lightHex, darkHex] = LIGHT_DARK.exec(result) ?? [];
+    expect(hexLightness(lightHex as string)).toBeGreaterThanOrEqual(0.34);
+    expect(hexLightness(darkHex as string)).toBeGreaterThanOrEqual(0.54);
+  });
+
+  it("pulls a near-white data colour down into both bands rather than passing it through", () => {
+    const result = partyColor("seed", "#fafaf5");
+    const [, lightHex, darkHex] = LIGHT_DARK.exec(result) ?? [];
+    expect(hexLightness(lightHex as string)).toBeLessThanOrEqual(0.56);
+    expect(hexLightness(darkHex as string)).toBeLessThanOrEqual(0.73);
+  });
+
+  it("keeps the hue rather than replacing it with a palette colour", () => {
+    // Pure red (hue 0): in RGB terms that means red is the max channel and
+    // green/blue stay equal to each other at any lightness — an independent
+    // check on hue that doesn't require reimplementing HSL conversion.
+    const result = partyColor("seed", "#ff0000");
+    const [, lightHex, darkHex] = LIGHT_DARK.exec(result) ?? [];
+    for (const hex of [lightHex, darkHex]) {
+      const { r, g, b } = hexChannels(hex as string);
+      expect(g).toBe(b);
+      expect(r).toBeGreaterThan(g);
+    }
+  });
+
+  it("keeps a grey (zero-saturation) data colour grey in both halves", () => {
+    const result = partyColor("seed", "#888888");
+    const [, lightHex, darkHex] = LIGHT_DARK.exec(result) ?? [];
+    for (const hex of [lightHex, darkHex]) {
+      const { r, g, b } = hexChannels(hex as string);
+      expect(r).toBe(g);
+      expect(g).toBe(b);
+    }
+  });
+
+  it("accepts the 3-digit shorthand form", () => {
+    expect(partyColor("seed", "#f00")).toMatch(LIGHT_DARK);
+  });
+
+  it("produces the same normalized pair regardless of seed — the data colour, not the hash, drives it", () => {
+    expect(partyColor("Piráti", "#2563eb")).toBe(partyColor("ANO 2011", "#2563eb"));
+  });
+});
+
+describe("partyColor — malformed or absent data colour falls back to the hash palette", () => {
+  it("falls back on a value with no leading #", () => {
+    expect(partyColor("Piráti", "ff0000")).toBe(partyColor("Piráti"));
+  });
+
+  it("falls back on a non-hex value", () => {
+    expect(partyColor("Piráti", "red")).toBe(partyColor("Piráti"));
+  });
+
+  it("falls back on a wrong-length hex value", () => {
+    expect(partyColor("Piráti", "#ff00")).toBe(partyColor("Piráti"));
+  });
+
+  it("falls back on an empty string, same as omitting the argument", () => {
+    expect(partyColor("Piráti", "")).toBe(partyColor("Piráti"));
+  });
+});

--- a/packages/design-system/src/utilities/partyColor.ts
+++ b/packages/design-system/src/utilities/partyColor.ts
@@ -1,0 +1,156 @@
+// Ported from kalkulacka-2026/packages/ui/src/party-color.ts
+
+/**
+ * A stable accent colour per candidate, so the same party reads as the same
+ * colour everywhere it appears in a ranking — the match bar and the avatar's
+ * ring share this rather than each guessing independently.
+ *
+ * Priority order, resolved by the caller and handed in as `dataColor`:
+ * authored in the source data, else derived server-side from the logo
+ * (2026's `apps/web/lib/logo-color.ts`, run once per calculator load and
+ * cached), else this module's own hash palette.
+ *
+ * The hash palette used to be the only option, precisely because reading the
+ * logo *client-side* doesn't work: most marks are transparent or
+ * white-on-white PNGs, fetched from a CDN rather than this origin, so pulling
+ * a dominant colour out of them in the browser means a canvas read that's
+ * async, sometimes CORS-blocked, and still wrong for a monochrome mark.
+ * Deriving it on the server sidesteps all three — the fetch has no CORS
+ * concern, it runs once at calculator-load time rather than once per visit,
+ * and a mark with no real colour in it (checked directly, not guessed from
+ * pixels a browser already decoded) is left `undefined` there too. This
+ * module's job is unchanged: a name-seeded pick from a fixed palette, instant
+ * and always available, for whatever's left over.
+ */
+const PALETTE = [
+  "light-dark(#2563eb, #3b82f6)", // blue
+  "light-dark(#7c3aed, #a78bfa)", // violet
+  "light-dark(#0d9488, #2dd4bf)", // teal
+  "light-dark(#d97706, #fbbf24)", // amber
+  "light-dark(#db2777, #f472b6)", // pink
+  "light-dark(#059669, #34d399)", // emerald
+  "light-dark(#4f46e5, #818cf8)", // indigo
+  "light-dark(#ea580c, #fb923c)", // orange
+  "light-dark(#0891b2, #22d3ee)", // cyan
+  "light-dark(#65a30d, #a3e635)", // lime
+];
+
+const FALLBACK = PALETTE[0] as string;
+
+function hash(value: string): number {
+  let result = 0;
+  for (let i = 0; i < value.length; i++) {
+    result = (result * 31 + value.charCodeAt(i)) | 0;
+  }
+  return Math.abs(result);
+}
+
+type Rgb = { r: number; g: number; b: number };
+type Hsl = { h: number; s: number; l: number };
+
+const HEX_PATTERN = /^#(?:([0-9a-fA-F]{3})|([0-9a-fA-F]{6}))$/;
+
+function parseHex(hex: string): Rgb | undefined {
+  const match = HEX_PATTERN.exec(hex);
+  if (!match) return undefined;
+  const full = match[2] ?? (match[1] as string).replace(/(.)/g, "$1$1");
+  const value = Number.parseInt(full, 16);
+  return { r: (value >> 16) & 255, g: (value >> 8) & 255, b: value & 255 };
+}
+
+function toHex(n: number): string {
+  return Math.max(0, Math.min(255, Math.round(n)))
+    .toString(16)
+    .padStart(2, "0");
+}
+
+function rgbToHex({ r, g, b }: Rgb): string {
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function rgbToHsl({ r, g, b }: Rgb): Hsl {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  if (max === min) return { h: 0, s: 0, l };
+
+  const d = max - min;
+  const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+  let h: number;
+  if (max === rn) h = (gn - bn) / d + (gn < bn ? 6 : 0);
+  else if (max === gn) h = (bn - rn) / d + 2;
+  else h = (rn - gn) / d + 4;
+
+  return { h: h * 60, s, l };
+}
+
+function hslToRgb({ h, s, l }: Hsl): Rgb {
+  if (s === 0) {
+    const v = l * 255;
+    return { r: v, g: v, b: v };
+  }
+
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const hueToChannel = (t: number): number => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1 / 6) return p + (q - p) * 6 * tt;
+    if (tt < 1 / 2) return q;
+    if (tt < 2 / 3) return p + (q - p) * (2 / 3 - tt) * 6;
+    return p;
+  };
+
+  const hn = h / 360;
+  return {
+    r: hueToChannel(hn + 1 / 3) * 255,
+    g: hueToChannel(hn) * 255,
+    b: hueToChannel(hn - 1 / 3) * 255,
+  };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/** Where a light-theme card keeps its accent legible against a near-white surface. */
+const LIGHT_LIGHTNESS_MIN = 0.35;
+const LIGHT_LIGHTNESS_MAX = 0.55;
+/** Where a dark-theme card keeps its accent legible against a near-black one. */
+const DARK_LIGHTNESS_MIN = 0.55;
+const DARK_LIGHTNESS_MAX = 0.72;
+
+/**
+ * A party's own colour, clamped into the same readable band the hand-picked
+ * palette above already occupies — same hue and saturation, lightness pulled
+ * into range for each theme independently. A party can hand this a colour
+ * that's unreadable on its own (near-white, near-black, too washed out); it
+ * can't hand the UI one that comes out that way.
+ */
+function normalizeDataColor(hex: string): string | undefined {
+  const rgb = parseHex(hex);
+  if (!rgb) return undefined;
+
+  const hsl = rgbToHsl(rgb);
+  const light = hslToRgb({ ...hsl, l: clamp(hsl.l, LIGHT_LIGHTNESS_MIN, LIGHT_LIGHTNESS_MAX) });
+  const dark = hslToRgb({ ...hsl, l: clamp(hsl.l, DARK_LIGHTNESS_MIN, DARK_LIGHTNESS_MAX) });
+  return `light-dark(${rgbToHex(light)}, ${rgbToHex(dark)})`;
+}
+
+/**
+ * A `light-dark()` colour for a candidate. `dataColor` — the source's own
+ * colour, or one derived server-side from the logo — wins when present and
+ * parses; otherwise a `light-dark()` pick made deterministically from `seed`
+ * (typically the candidate's name).
+ */
+export function partyColor(seed: string, dataColor?: string): string {
+  if (dataColor) {
+    const normalized = normalizeDataColor(dataColor);
+    if (normalized) return normalized;
+  }
+  return PALETTE[hash(seed) % PALETTE.length] ?? FALLBACK;
+}


### PR DESCRIPTION
Part 14 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #526.

The pieces the results screen is made of, ported from `kalkulacka-2026/packages/ui/src/{meter,match-row,avatar,avatar-stack,donut,calculating}` and `party-color.ts`:

- **Meter**: `ProgressBar` restyled to the prototype's thin bar (`tone`, `size`, `delay`, `aria-hidden` unless labelled); `ProgressBar` and its `color` prop remain as aliases.
- **Avatar**: initials fallback, single-URL `src`, `accent` ring and wash; the legacy `image` / `shape` / `fit` / `padding` props keep working for the old match card (verified by its tests).
- **AvatarStack**: overlapped faces, a "+n" disc only when it saves room, a popover of every name on hover or tap.
- **Donut**: the answer-distribution ring (gapped segments, zero values dropped) with its legend.
- **MatchRow**: one ranking row with the bar along its top edge so every bar shares a scale, the accent-tinted avatar via `partyColor`, ordinal rank, percent, winner tag, pressed and disabled (uncomparable) states, staggered entrance.
- **Calculating**: the 24-frame film strip of answer marks through a sprocketed gate with a counting ring resolving onto the logo's percent mark; nothing moves under reduced motion.
- **`partyColor`** (verbatim with its tests): a data colour normalised for contrast in both modes, else a deterministic palette pick.

Two things worth a reviewer's eye, both commented: the prototype's pressed-row wash was invalid CSS that never painted, ported here as the layer it was meant to be; and the prototype's avatar fallback does not actually reveal initials on a failed image in Chrome (an absolutely positioned broken `<img>` keeps painting), which is unchanged here and noted as a follow-up.

Stories for each (including a stateful ranking); 84 new tests.

**Checks:** typecheck, lint, tests (design-system 413, app 276, CZ 6, SK 6), design-system and Storybook builds; verified in Storybook.

**Stack:** based on #526 → next: `port/15-result-page` (checkpoint C6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
