### PR TITLE
Add the per-candidate comparison pane on the result page

### DIFF
--- a/apps/design-system.kalkulacka.one/stories/ComparisonList.stories.tsx
+++ b/apps/design-system.kalkulacka.one/stories/ComparisonList.stories.tsx
@@ -1,0 +1,95 @@
+// Ported from kalkulacka-2026/packages/ui/src/comparison-list/comparison-list.stories.tsx
+import { ComparisonList } from "@kalkulacka-one/design-system/client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { useState } from "react";
+
+const ROWS = [
+  {
+    id: "q1",
+    statement: "Město by mělo omezit vánoční výzdobu kvůli cenám energií.",
+    user: { tone: "agree" as const, label: "Ano" },
+    candidate: { tone: "agree" as const, label: "Ano" },
+    important: true,
+    comment: "Úspory dávají smysl, výzdobu ale zcela rušit nechceme.",
+  },
+  {
+    id: "q2",
+    statement: "Město má vybudovat nový plavecký areál.",
+    user: { tone: "disagree" as const, label: "Ne" },
+    candidate: { tone: "agree" as const, label: "Ano" },
+  },
+  {
+    id: "q3",
+    statement: "Parkování v centru má zdražit.",
+    user: { tone: "agree" as const, label: "Ano" },
+    candidate: { tone: "none" as const, label: "Bez odpovědi" },
+  },
+  {
+    id: "q4",
+    statement: "Město má zavést bezplatnou MHD pro seniory.",
+    user: { tone: "neutral" as const, label: "Nevím" },
+    candidate: { tone: "disagree" as const, label: "Ne" },
+    comment: "Radši bychom investovali do častějších spojů, které pomůžou všem.",
+  },
+];
+
+const meta: Meta<typeof ComparisonList> = {
+  title: "Components/ComparisonList",
+  component: ComparisonList,
+  tags: ["autodocs"],
+  parameters: { layout: "padded" },
+  args: {
+    rows: ROWS,
+    labels: { you: "Vy", candidate: "Piráti", important: "Pro mě důležité" },
+  },
+  argTypes: {
+    rows: { control: "object" },
+    labels: { control: "object" },
+    resetKey: { control: false },
+  },
+  /* The pane the list scrolls in: a translucent surface, so the sticky heading has something to sit over. */
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          maxWidth: "30rem",
+          maxHeight: "22rem",
+          overflowY: "auto",
+          borderRadius: "var(--ko-radius-control)",
+          background: "oklch(from var(--ko-color-surface) l c h / 0.86)",
+          boxShadow: "var(--ko-shadow-surface)",
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+type ComparisonListStory = StoryObj<typeof meta>;
+
+/** All three agreement states, including the one neither side can be blamed for. */
+export const Default: ComparisonListStory = {};
+
+/** An archive party name runs across the statement column rather than being clipped to the width of its mark. */
+export const LongCandidateName: ComparisonListStory = {
+  args: { labels: { you: "Vy", candidate: "SPOLEČNĚ PRO PARDUBICE (Piráti, Zelení a nezávislí)", important: "Pro mě důležité" } },
+};
+
+/** Switching the key replays the list's entrance — the way a filter change lands as a new result. */
+export const Replayed: ComparisonListStory = {
+  render: function ReplayedStory(args) {
+    const [key, setKey] = useState(0);
+    return (
+      <>
+        <button type="button" onClick={() => setKey((current) => current + 1)} style={{ margin: "1rem 1.5rem 0", font: "inherit" }}>
+          Přehrát znovu
+        </button>
+        <ComparisonList {...args} resetKey={key} />
+      </>
+    );
+  },
+};
+
+export default meta;

--- a/apps/www.volebnakalkulacka.sk/calculator/components/client/match-card.test.tsx
+++ b/apps/www.volebnakalkulacka.sk/calculator/components/client/match-card.test.tsx
@@ -11,6 +11,8 @@ describe("MatchCard", () => {
     id: "1",
     references: [],
     displayName: "Občanská demokratická strana",
+    name: "Občanská demokratická strana",
+    shortName: "ODS",
     number: 1,
   };
 

--- a/apps/www.volebnikalkulacka.cz/calculator/components/client/match-card.test.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/client/match-card.test.tsx
@@ -11,6 +11,8 @@ describe("MatchCard", () => {
     id: "1",
     references: [],
     displayName: "Občanská demokratická strana",
+    name: "Občanská demokratická strana",
+    shortName: "ODS",
     number: 1,
   };
 

--- a/packages/app/src/client/hooks/index.ts
+++ b/packages/app/src/client/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from "./use-drag-dismiss";
 export * from "./use-pointer-kind";

--- a/packages/app/src/client/hooks/use-drag-dismiss.ts
+++ b/packages/app/src/client/hooks/use-drag-dismiss.ts
@@ -1,0 +1,139 @@
+"use client";
+
+// Ported from kalkulacka-2026/apps/web/lib/use-drag-dismiss.ts
+import { type PointerEvent as ReactPointerEvent, type RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+/** How far down the sheet has to travel before letting go closes it. */
+export const DISMISS_DISTANCE = 110;
+/** …or how fast it has to be moving, in px/ms, so a quick flick also closes it. */
+export const DISMISS_VELOCITY = 0.45;
+/** Matches the exit transition in the CSS, so the state change lands as it finishes. */
+export const EXIT_MS = 200;
+
+/** Below this width the pane is a sheet; above it, it is a column and cannot be dragged. */
+export const SHEET_QUERY = "(max-width: 63.99rem)";
+
+export type DragDismiss = {
+  /** Put on the sheet element itself — this is what moves. */
+  sheetRef: RefObject<HTMLElement | null>;
+  /** Spread onto the grab handle (and anything else draggable, e.g. the header). */
+  handleProps: {
+    onPointerDown: (event: ReactPointerEvent) => void;
+    onPointerMove: (event: ReactPointerEvent) => void;
+    onPointerUp: (event: ReactPointerEvent) => void;
+    onPointerCancel: (event: ReactPointerEvent) => void;
+  };
+  /** True while a drag is in progress — the CSS uses it to drop the sheet's transition. */
+  dragging: boolean;
+};
+
+/**
+ * Drag a bottom sheet down to close it.
+ *
+ * Only the handle is draggable, not the sheet's body: the body scrolls 42
+ * comparison rows, and a gesture that means "scroll" in one place and "dismiss"
+ * in another — distinguished only by whether the list happens to be at its top —
+ * is the kind of ambiguity that makes a sheet feel like it is fighting you.
+ *
+ * The transform is written straight to the node rather than held in React state.
+ * A pointer move fires at the display's refresh rate and re-rendering the whole
+ * comparison on each one would drop frames on exactly the phones this is for.
+ */
+export function useDragDismiss({ open, onDismiss, query = SHEET_QUERY }: { open: boolean; onDismiss: () => void; query?: string }): DragDismiss {
+  const sheetRef = useRef<HTMLElement | null>(null);
+  const drag = useRef<{ startY: number; dy: number; startedAt: number } | null>(null);
+  const exitTimer = useRef<number | undefined>(undefined);
+
+  const [enabled, setEnabled] = useState(false);
+  const [dragging, setDragging] = useState(false);
+
+  useEffect(() => {
+    // No `matchMedia` (jsdom, for one) means no way to tell — and a column
+    // that cannot be dragged is the state that stays true when nothing can be
+    // asked.
+    if (typeof window.matchMedia !== "function") return;
+
+    const media = window.matchMedia(query);
+    const sync = () => setEnabled(media.matches);
+
+    sync();
+    media.addEventListener("change", sync);
+    return () => media.removeEventListener("change", sync);
+  }, [query]);
+
+  useEffect(() => {
+    // While it is open the transform belongs to the entry animation, or to a
+    // drag in progress. There is nothing to tidy up until it closes.
+    if (open) return;
+
+    const sheet = sheetRef.current;
+    if (!sheet) return;
+
+    // By the time `open` flips, the exit has already played out, so clearing is
+    // safe — and necessary: this same node becomes the in-flow dashboard pane
+    // once it is no longer a sheet, and a stray `translateY` would push that
+    // down the page.
+    sheet.style.transform = "";
+    drag.current = null;
+    setDragging(false);
+  }, [open]);
+
+  useEffect(() => () => window.clearTimeout(exitTimer.current), []);
+
+  const onPointerDown = useCallback(
+    (event: ReactPointerEvent) => {
+      if (!enabled || !sheetRef.current) return;
+
+      drag.current = { startY: event.clientY, dy: 0, startedAt: event.timeStamp };
+      setDragging(true);
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [enabled],
+  );
+
+  const onPointerMove = useCallback((event: ReactPointerEvent) => {
+    const current = drag.current;
+    const sheet = sheetRef.current;
+    if (!current || !sheet) return;
+
+    // Downward only. Letting it travel up would lift the sheet off the top of
+    // the screen, revealing the page behind it with no way to put it back.
+    current.dy = Math.max(0, event.clientY - current.startY);
+    sheet.style.transform = `translateY(${current.dy}px)`;
+  }, []);
+
+  const finish = useCallback(
+    (event: ReactPointerEvent) => {
+      const current = drag.current;
+      const sheet = sheetRef.current;
+
+      drag.current = null;
+      setDragging(false);
+      if (!current || !sheet) return;
+
+      const velocity = current.dy / Math.max(1, event.timeStamp - current.startedAt);
+
+      if (current.dy > DISMISS_DISTANCE || velocity > DISMISS_VELOCITY) {
+        // Let it finish leaving before the state change unmounts the contents,
+        // so the sheet is seen to go rather than blinking out under the finger.
+        sheet.style.transform = "translateY(100%)";
+        exitTimer.current = window.setTimeout(onDismiss, EXIT_MS);
+        return;
+      }
+
+      sheet.style.transform = "";
+    },
+    [onDismiss],
+  );
+
+  return {
+    sheetRef,
+    handleProps: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: finish,
+      onPointerCancel: finish,
+    },
+    dragging,
+  };
+}

--- a/packages/app/src/components/comparison-pane.test.tsx
+++ b/packages/app/src/components/comparison-pane.test.tsx
@@ -1,0 +1,416 @@
+import type { Answer, CandidatesAnswers } from "@kalkulacka-one/schema";
+
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { useState } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EXIT_MS, SHEET_QUERY } from "@/client/hooks";
+import { AnswersStoreContext, CalculatorStoreContext, createAnswersStore, createCalculatorStore } from "@/client/stores";
+import { useCalculatedMatches, useResult } from "@/client/view-models";
+import type { CalculatorData } from "@/data-fetching";
+import { csMessages } from "@/locales";
+
+import { CLOSE_MS, ComparisonPane } from "./comparison-pane";
+import { LocaleProvider } from "./providers";
+
+const questionIds = ["11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222", "33333333-3333-4333-8333-333333333333", "44444444-4444-4444-8444-444444444444"] as const;
+const [q1, q2, q3, q4] = questionIds;
+
+const ids = {
+  alfa: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  beta: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+  gama: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  delta: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+} as const;
+
+type CandidateAnswers = CandidatesAnswers[string];
+
+const answersFor = (entries: Partial<Record<(typeof questionIds)[number], { answer: boolean | null; comment?: string }>>): CandidateAnswers =>
+  Object.entries(entries).map(([questionId, { answer, comment }]) => ({ questionId, answer, ...(comment ? { comment } : {}) }));
+
+/*
+ * Against the reader's answers below (yes, no starred, skipped, "nevím"):
+ *
+ *   alfa   yes (with a comment), yes, no, yes → q1 match, q2 mismatch, q4 none
+ *   beta   nevím, no, –, nevím               → q1 none, q2 match, q4 none — no mismatch to filter by
+ *   gama   no, yes, –, –                      → q1 mismatch, q2 mismatch, q4 none — no match to filter by
+ *   delta  nevím on everything                → nothing to filter by at all
+ */
+const candidatesAnswers: CandidatesAnswers = {
+  [ids.alfa]: answersFor({ [q1]: { answer: true, comment: "Souhlasíme, i když s výhradami." }, [q2]: { answer: true }, [q3]: { answer: false }, [q4]: { answer: true } }),
+  [ids.beta]: answersFor({ [q1]: { answer: null }, [q2]: { answer: false }, [q4]: { answer: null } }),
+  [ids.gama]: answersFor({ [q1]: { answer: false }, [q2]: { answer: true } }),
+  [ids.delta]: answersFor({ [q1]: { answer: null }, [q2]: { answer: null }, [q4]: { answer: null } }),
+};
+
+const calculatorData: CalculatorData = {
+  data: {
+    calculator: { id: "00000000-0000-4000-8000-000000000000", createdAt: new Date(0).toISOString(), key: "kalkulacka", shortTitle: "Sněmovní 2025" },
+    questions: questionIds.map((id, index) => ({ id, title: `Otázka ${index + 1}`, statement: `Tvrzení ${index + 1}` })),
+    candidates: [
+      { id: ids.alfa, displayName: "Alfa", references: [] },
+      { id: ids.beta, displayName: "Beta", references: [] },
+      { id: ids.gama, displayName: "Gama", references: [] },
+      { id: ids.delta, displayName: "Delta", references: [] },
+    ],
+    candidatesAnswers,
+  },
+  baseUrl: "https://data.kalkulacka.one/kalkulacka",
+};
+
+const userAnswers: Answer[] = [{ questionId: q1, answer: true }, { questionId: q2, answer: false, isImportant: true }, { questionId: q3 }, { questionId: q4, answer: null }];
+
+/** The same answers with nothing starred — for the case where no filter would leave anything. */
+const unstarredAnswers: Answer[] = userAnswers.map((answer) => ({ ...answer, isImportant: undefined }));
+
+const percent = (value: number) => `${Math.round(value)} %`;
+
+/** Stands in for the result page: owns `selectedId`, and hands the pane the same ranked list the page does. */
+function Harness({ initialId }: { initialId?: string }) {
+  const [selectedId, setSelectedId] = useState<string | undefined>(initialId);
+  const { matches } = useResult(useCalculatedMatches());
+
+  return (
+    <>
+      {(["alfa", "beta", "gama", "delta"] as const).map((key) => (
+        <button key={key} type="button" onClick={() => setSelectedId(ids[key])}>
+          Otevřít {key}
+        </button>
+      ))}
+      <ComparisonPane matches={matches} selectedId={selectedId} onClose={() => setSelectedId(undefined)} formatPercent={percent}>
+        <p>Přehled</p>
+      </ComparisonPane>
+    </>
+  );
+}
+
+function renderPane({ answers = userAnswers, initialId }: { answers?: Answer[]; initialId?: string } = {}) {
+  const answersStore = createAnswersStore();
+  answersStore.getState().setAnswers(answers);
+
+  return render(
+    <LocaleProvider locale="cs" messages={csMessages}>
+      <CalculatorStoreContext.Provider value={createCalculatorStore(calculatorData)}>
+        <AnswersStoreContext.Provider value={answersStore}>
+          <Harness initialId={initialId} />
+        </AnswersStoreContext.Provider>
+      </CalculatorStoreContext.Provider>
+    </LocaleProvider>,
+  );
+}
+
+const opener = (key: "alfa" | "beta" | "gama" | "delta") => screen.getByRole("button", { name: `Otevřít ${key}` });
+const open = (key: "alfa" | "beta" | "gama" | "delta") => {
+  // A real click focuses the button first; the pane remembers that as the way back.
+  opener(key).focus();
+  fireEvent.click(opener(key));
+};
+const pane = () => document.querySelector("section") as HTMLElement;
+const heading = (name: string) => screen.getByRole("heading", { level: 2, name });
+const closeButton = () => screen.getByRole("button", { name: "Zavřít porovnání" });
+const chips = () => within(screen.getByRole("group", { name: "Filtrovat odpovědi" })).getAllByRole("button");
+const rows = () => within(screen.getByRole("list")).getAllByRole("listitem");
+const statements = () => rows().map((row) => within(row as HTMLElement).getByText(/^Tvrzení/).textContent);
+
+describe("ComparisonPane", () => {
+  describe("holding the dashboard", () => {
+    it("shows the children in an unnamed, unstyled box while nothing is selected", () => {
+      renderPane();
+      expect(screen.getByText("Přehled")).toBeInTheDocument();
+      expect(pane()).toHaveClass("ko-comparison-pane");
+      expect(pane()).not.toHaveAttribute("data-open");
+      expect(pane()).not.toHaveAttribute("aria-labelledby");
+      expect(screen.queryByRole("region")).toBeNull();
+    });
+  });
+
+  describe("opening", () => {
+    it("names the region after the candidate, lands focus on that name, and shows the percent", () => {
+      renderPane();
+      open("alfa");
+
+      const region = screen.getByRole("region", { name: "Alfa" });
+      expect(region).toBe(pane());
+      expect(region).toHaveAttribute("data-open");
+      expect(heading("Alfa")).toHaveFocus();
+      expect(heading("Alfa")).toHaveAttribute("tabindex", "-1");
+      expect(within(region).getByText(/^\d+ %$/)).toBeInTheDocument();
+      expect(screen.queryByText("Přehled")).toBeNull();
+    });
+
+    it("lists only the questions the reader answered, in question order, with both marks named", () => {
+      renderPane();
+      open("alfa");
+
+      // q3 was skipped — it says nothing about either side, so it is not a row.
+      // The starred one carries its off-screen marker in the same paragraph.
+      expect(statements()).toEqual(["Tvrzení 1", "Tvrzení 2 (Pro mě důležité)", "Tvrzení 4"]);
+
+      const [first, second, third] = rows() as HTMLElement[];
+      expect(within(first as HTMLElement).getByRole("img", { name: "Alfa: Ano" })).toBeInTheDocument();
+      expect(within(first as HTMLElement).getByRole("img", { name: "Vy: Ano" })).toBeInTheDocument();
+      expect(within(first as HTMLElement).getByText("Souhlasíme, i když s výhradami.")).toBeInTheDocument();
+      expect(within(second as HTMLElement).getByRole("img", { name: "Vy: Ne" })).toBeInTheDocument();
+      expect(within(second as HTMLElement).getByText("(Pro mě důležité)")).toBeInTheDocument();
+      // An explicit "nevím" is a real answer, drawn as one.
+      expect(within(third as HTMLElement).getByRole("img", { name: "Vy: Nevím" })).toHaveClass("ko:bg-neutral-ink");
+    });
+
+    it("moves focus to the new name when another candidate is picked while one is open", () => {
+      renderPane();
+      open("alfa");
+      fireEvent.click(opener("beta"));
+
+      expect(screen.getByRole("region", { name: "Beta" })).toBeInTheDocument();
+      expect(heading("Beta")).toHaveFocus();
+      expect(pane()).not.toHaveAttribute("data-closing");
+    });
+  });
+
+  describe("filters", () => {
+    it("counts every filter, and narrows the rows to the one picked", () => {
+      renderPane();
+      open("alfa");
+
+      expect(chips().map((chip) => chip.textContent)).toEqual(["Vše3", "Shody1", "Neshody1", "Důležité1"]);
+      expect(chips()[0]).toHaveAttribute("aria-pressed", "true");
+
+      fireEvent.click(screen.getByRole("button", { name: /Neshody/ }));
+      expect(statements()).toEqual(["Tvrzení 2 (Pro mě důležité)"]);
+
+      fireEvent.click(screen.getByRole("button", { name: /Shody/ }));
+      expect(statements()).toEqual(["Tvrzení 1"]);
+
+      fireEvent.click(screen.getByRole("button", { name: /Důležité/ }));
+      expect(statements()).toEqual(["Tvrzení 2 (Pro mě důležité)"]);
+    });
+
+    it("offers a filter only where it would leave something", () => {
+      renderPane();
+
+      // A "nevím" on either side is neither a match nor a mismatch.
+      open("beta");
+      expect(chips().map((chip) => chip.textContent)).toEqual(["Vše3", "Shody1", "Důležité1"]);
+
+      open("gama");
+      expect(chips().map((chip) => chip.textContent)).toEqual(["Vše3", "Neshody2", "Důležité1"]);
+    });
+
+    it("shows no filter row at all when nothing could be filtered", () => {
+      renderPane({ answers: unstarredAnswers });
+      open("delta");
+
+      expect(screen.queryByRole("group", { name: "Filtrovat odpovědi" })).toBeNull();
+      expect(statements()).toEqual(["Tvrzení 1", "Tvrzení 2", "Tvrzení 4"]);
+    });
+
+    it("starts over on the filter when a different candidate opens", () => {
+      renderPane();
+      open("alfa");
+      fireEvent.click(screen.getByRole("button", { name: /Neshody/ }));
+      expect(statements()).toEqual(["Tvrzení 2 (Pro mě důležité)"]);
+
+      fireEvent.click(opener("gama"));
+      expect(screen.getByRole("button", { name: /Vše/ })).toHaveAttribute("aria-pressed", "true");
+      expect(statements()).toEqual(["Tvrzení 1", "Tvrzení 2 (Pro mě důležité)", "Tvrzení 4"]);
+    });
+  });
+
+  describe("closing", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("keeps the comparison rendered for the exit beat after the close button, then hands the box back", () => {
+      renderPane();
+      open("alfa");
+      fireEvent.click(closeButton());
+
+      // Told to close, but still on screen — this is what the exit animation
+      // plays on. `data-open` stays too: the box still *holds* a comparison,
+      // and the CSS lets the later `data-closing` rule take the animation.
+      expect(pane()).toHaveAttribute("data-closing");
+      expect(pane()).toHaveAttribute("data-open");
+      expect(heading("Alfa")).toBeInTheDocument();
+      expect(screen.queryByText("Přehled")).toBeNull();
+
+      act(() => {
+        vi.advanceTimersByTime(CLOSE_MS - 1);
+      });
+      expect(heading("Alfa")).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(screen.queryByRole("heading", { level: 2 })).toBeNull();
+      expect(screen.getByText("Přehled")).toBeInTheDocument();
+      expect(pane()).not.toHaveAttribute("data-closing");
+      expect(pane()).not.toHaveAttribute("data-open");
+      expect(pane()).not.toHaveAttribute("aria-labelledby");
+    });
+
+    it("returns focus to whatever opened it", () => {
+      renderPane();
+      open("alfa");
+      expect(heading("Alfa")).toHaveFocus();
+
+      fireEvent.click(closeButton());
+      expect(opener("alfa")).toHaveFocus();
+    });
+
+    it("closes on Escape from anywhere on the page — but not while a dialog is up", () => {
+      renderPane();
+      open("alfa");
+
+      const dialog = document.createElement("dialog");
+      dialog.setAttribute("open", "");
+      document.body.append(dialog);
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(pane()).toHaveAttribute("data-open");
+      dialog.remove();
+
+      fireEvent.keyDown(window, { key: "Escape" });
+      expect(pane()).toHaveAttribute("data-closing");
+      expect(opener("alfa")).toHaveFocus();
+    });
+
+    it("remembers the way back only on the way in, so a switch mid-comparison does not reroute it", () => {
+      renderPane();
+      open("alfa");
+      fireEvent.click(opener("beta"));
+      expect(heading("Beta")).toHaveFocus();
+
+      fireEvent.click(closeButton());
+      expect(opener("alfa")).toHaveFocus();
+    });
+
+    it("cuts a running exit short when another candidate is picked", () => {
+      renderPane();
+      open("alfa");
+      fireEvent.click(closeButton());
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+      expect(pane()).toHaveAttribute("data-closing");
+
+      fireEvent.click(opener("beta"));
+      expect(pane()).toHaveAttribute("data-open");
+      expect(pane()).not.toHaveAttribute("data-closing");
+      expect(heading("Beta")).toBeInTheDocument();
+
+      // The old exit's timer landing changes nothing about the new comparison.
+      act(() => {
+        vi.advanceTimersByTime(CLOSE_MS);
+      });
+      expect(pane()).toHaveAttribute("data-open");
+      expect(heading("Beta")).toBeInTheDocument();
+    });
+  });
+
+  describe("as a bottom sheet", () => {
+    const grip = () => pane().querySelector(".ko-comparison-pane-grip") as HTMLElement;
+
+    /** jsdom has neither `matchMedia` nor pointer capture; the sheet needs both to be a sheet. */
+    function pretendPhone(matches: boolean) {
+      Object.defineProperty(window, "matchMedia", {
+        configurable: true,
+        writable: true,
+        value: vi.fn((query: string) => ({ matches: matches && query === SHEET_QUERY, addEventListener: vi.fn(), removeEventListener: vi.fn() })),
+      });
+      Object.defineProperty(Element.prototype, "setPointerCapture", { configurable: true, writable: true, value: vi.fn() });
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      Reflect.deleteProperty(window, "matchMedia");
+      Reflect.deleteProperty(Element.prototype, "setPointerCapture");
+    });
+
+    it("follows a finger down the grip, never up, and springs back from a short, slow drag", () => {
+      pretendPhone(true);
+      renderPane();
+      open("alfa");
+      expect(grip()).toHaveAttribute("aria-hidden", "true");
+
+      fireEvent.pointerDown(grip(), { clientY: 100, pointerId: 1 });
+      expect(pane()).toHaveAttribute("data-dragging");
+
+      fireEvent.pointerMove(grip(), { clientY: 160, pointerId: 1 });
+      expect(pane().style.transform).toBe("translateY(60px)");
+
+      fireEvent.pointerMove(grip(), { clientY: 40, pointerId: 1 });
+      expect(pane().style.transform).toBe("translateY(0px)");
+
+      // Slow: the clock moves on before the finger lifts, so this is no flick.
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+      fireEvent.pointerMove(grip(), { clientY: 160, pointerId: 1 });
+      fireEvent.pointerUp(grip(), { clientY: 160, pointerId: 1 });
+      expect(pane().style.transform).toBe("");
+      expect(pane()).not.toHaveAttribute("data-dragging");
+      expect(pane()).toHaveAttribute("data-open");
+    });
+
+    it("dismisses after a long drag, letting the sheet finish leaving before the state clears", () => {
+      pretendPhone(true);
+      renderPane();
+      open("alfa");
+
+      fireEvent.pointerDown(grip(), { clientY: 100, pointerId: 1 });
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      fireEvent.pointerMove(grip(), { clientY: 260, pointerId: 1 });
+      fireEvent.pointerUp(grip(), { clientY: 260, pointerId: 1 });
+
+      // Sent off the bottom, but still open: the contents stay until it has gone.
+      expect(pane().style.transform).toBe("translateY(100%)");
+      expect(pane()).toHaveAttribute("data-open");
+
+      act(() => {
+        vi.advanceTimersByTime(EXIT_MS);
+      });
+      // No `closingId` beat on this route — the drag already animated the exit.
+      expect(pane()).not.toHaveAttribute("data-open");
+      expect(pane()).not.toHaveAttribute("data-closing");
+      expect(screen.getByText("Přehled")).toBeInTheDocument();
+      expect(pane().style.transform).toBe("");
+    });
+
+    it("dismisses on a quick flick, however short", () => {
+      pretendPhone(true);
+      renderPane();
+      open("alfa");
+
+      fireEvent.pointerDown(grip(), { clientY: 100, pointerId: 1 });
+      fireEvent.pointerMove(grip(), { clientY: 140, pointerId: 1 });
+      fireEvent.pointerUp(grip(), { clientY: 140, pointerId: 1 });
+      expect(pane().style.transform).toBe("translateY(100%)");
+
+      act(() => {
+        vi.advanceTimersByTime(EXIT_MS);
+      });
+      expect(screen.getByText("Přehled")).toBeInTheDocument();
+    });
+
+    it("is not draggable as a desktop column", () => {
+      pretendPhone(false);
+      renderPane();
+      open("alfa");
+
+      fireEvent.pointerDown(grip(), { clientY: 100, pointerId: 1 });
+      fireEvent.pointerMove(grip(), { clientY: 300, pointerId: 1 });
+      expect(pane()).not.toHaveAttribute("data-dragging");
+      expect(pane().style.transform).toBe("");
+    });
+  });
+});

--- a/packages/app/src/components/comparison-pane.tsx
+++ b/packages/app/src/components/comparison-pane.tsx
@@ -1,0 +1,364 @@
+"use client";
+
+// Ported from kalkulacka-2026/apps/web/components/comparison-pane.tsx (+ comparison-pane.module.css — the box's
+// sheet/column presentations live in the design system's `styles.css` as `.ko-comparison-pane`).
+import { ComparisonList, type ComparisonRow, FilterChips, IconButton } from "@kalkulacka-one/design-system/client";
+import { icons } from "@kalkulacka-one/design-system/icons";
+
+import { useTranslations } from "next-intl";
+import { type ReactNode, useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
+
+import { answerTone } from "@/answers";
+import { useDragDismiss } from "@/client/hooks";
+import { useAnswersStore, useCalculatorStore } from "@/client/stores";
+import { useQuestions } from "@/client/view-models";
+import { type CandidateMatchViewModel, getCandidateAnswerComparison } from "@/view-models";
+
+/** Matches the closing animation's duration in the CSS (`--ko-duration-base`). */
+export const CLOSE_MS = 150;
+
+type ComparisonFilter = "all" | "match" | "mismatch" | "important";
+
+/** How the user's answer and the candidate's relate on one question. */
+type Agreement = "match" | "mismatch" | "none";
+
+export type ComparisonPane = {
+  /** The ranked list, so the pane can still find a candidate that is on its way out. */
+  matches: CandidateMatchViewModel[];
+  /** Whose comparison is open. `undefined` means the pane shows `children` instead. */
+  selectedId: string | undefined;
+  /** Asks the owner to clear `selectedId`. The exit animation is this pane's business. */
+  onClose: () => void;
+  /** "74 %", the way the active locale writes it — number formatting is locale work, so it happens above. */
+  formatPercent: (value: number) => string;
+  /** What the pane holds when nothing is selected — the insight dashboard. */
+  children: ReactNode;
+};
+
+/**
+ * Ported from `agreementOf` in kalkulacka-2026/packages/core/src/matching/results.ts.
+ *
+ * A neutral on either side is a real answer that simply carries no direction,
+ * so it is neither a match nor a mismatch — and neither is a question one side
+ * never answered.
+ */
+function agreementOf(user: boolean | null | undefined, candidate: boolean | null | undefined): Agreement {
+  if (user === undefined || candidate === undefined) return "none";
+  if (user === null || candidate === null) return "none";
+  return user === candidate ? "match" : "mismatch";
+}
+
+const headClasses = "koa:flex-none koa:flex koa:items-start koa:justify-between koa:gap-4 koa:px-6 koa:py-4";
+const headingClasses = "koa:min-w-0";
+
+/*
+ * Focus lands here when a comparison opens (see below), so the ring has to be
+ * spelled out both ways rather than left to the UA: silent for the mouse click
+ * that put it here — nothing on screen changes for someone who never left the
+ * pointer — and drawn for the keyboard press that did, which is the reader
+ * who needs to see where they were taken.
+ */
+const titleClasses = [
+  "koa:m-0 koa:font-(family-name:--ko-font-sans) koa:text-base koa:font-semibold koa:leading-[1.3] koa:tracking-[-0.01em] koa:text-(--ko-color-text-strong)",
+  "koa:focus:outline-none koa:focus-visible:outline-3 koa:focus-visible:outline-offset-2 koa:focus-visible:outline-(--ko-color-focus)/55",
+].join(" ");
+
+/*
+ * Not the accent: the bar on the row behind this pane already spends that
+ * colour on the same number, and repeating it here made the heading compete
+ * with the ranking rather than label it.
+ */
+const percentClasses = "koa:m-0 koa:mt-0.5 koa:font-(family-name:--ko-font-display) koa:text-2xl koa:font-bold koa:tracking-[-0.01em] koa:text-(--ko-color-text-strong) koa:tabular-nums";
+
+/* Matches `ComparisonList`'s own inset (1.5rem) so the chips line up with the
+   statements and marks scrolling beneath them. */
+const filtersClasses = "koa:flex-none koa:px-6 koa:pb-3";
+
+/*
+ * The grab handle. Phone only — on a desktop the pane is a column, not a sheet,
+ * and there is nothing to drag it away from. `touch-none` claims the vertical
+ * gesture from the browser so a drag doesn't also scroll.
+ */
+const gripClasses = [
+  "ko-comparison-pane-grip koa:flex-none koa:flex koa:items-center koa:justify-center koa:pt-3 koa:pb-2 koa:touch-none koa:cursor-grab koa:active:cursor-grabbing koa:lg:hidden",
+  "koa:before:content-[''] koa:before:w-10 koa:before:h-1 koa:before:rounded-full koa:before:bg-(--ko-color-border-strong)",
+].join(" ");
+
+/**
+ * One candidate's answers against the reader's own — and, when nothing is
+ * picked, whatever the caller puts in the same box.
+ *
+ * The pane owns its own exit: `selectedId` clearing is the *start* of closing,
+ * not the end of it, so the comparison has to keep rendering for a beat after
+ * the owner has already forgotten about it.
+ *
+ * The rows come from the platform's own `getCandidateAnswerComparison` — the
+ * same per-candidate reading the legacy comparison used — narrowed to the
+ * questions the reader actually answered: a question they skipped says nothing
+ * about either side, and listing it would pad the comparison with rows that
+ * carry no information.
+ */
+export function ComparisonPane({ matches, selectedId, onClose, formatPercent, children }: ComparisonPane) {
+  const t = useTranslations("koa.components.comparisonPane");
+
+  const answers = useAnswersStore((state) => state.answers);
+  const candidatesAnswers = useCalculatorStore((state) => state.data.candidatesAnswers);
+  const { questions } = useQuestions();
+
+  /**
+   * Set for the duration of the close animation only — the comparison for
+   * this id keeps rendering (and the pane keeps its sheet/popover styling)
+   * after `selectedId` clears, so there is something to animate out instead
+   * of the dashboard just appearing underneath it.
+   */
+  const [closingId, setClosingId] = useState<string | undefined>(undefined);
+  /** Which of a comparison's rows are shown — reset whenever a different candidate opens. */
+  const [comparisonFilter, setComparisonFilter] = useState<ComparisonFilter>("all");
+
+  /*
+   * The button/Escape route: play the pane's exit animation, then swap to the
+   * dashboard once it's finished. A drag dismissal skips this entirely — see
+   * `dismissDrag` below — because `useDragDismiss` has already animated the
+   * sheet away by the time it calls its own callback.
+   */
+  const closeComparison = useCallback(() => {
+    if (selectedId !== undefined) setClosingId(selectedId);
+    onClose();
+  }, [selectedId, onClose]);
+
+  const dismissDrag = useCallback(() => onClose(), [onClose]);
+
+  useEffect(() => {
+    if (closingId === undefined) return;
+    const timer = window.setTimeout(() => setClosingId(undefined), CLOSE_MS);
+    return () => window.clearTimeout(timer);
+  }, [closingId]);
+
+  /*
+   * Escape, the third route out — the close button covers the pointer, the
+   * grip covers a finger. Handled explicitly rather than left to anything
+   * native: this is a `<section>`, not a `<dialog>`, so there is no built-in
+   * dismissal to inherit, and `dialog.tsx` documents why even the real
+   * element's own Escape is not trusted in this codebase.
+   *
+   * On `window` rather than the section, because on a desktop the pane is a
+   * column beside the ranking and the reader may well still be in the list —
+   * but skipped while a modal is up. The share, help, restart and leave sheets
+   * all sit over this pane, and dismissing the comparison underneath one would
+   * be answering a key that was aimed somewhere else.
+   */
+  useEffect(() => {
+    if (selectedId === undefined) return;
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      if (document.querySelector("dialog[open]")) return;
+      event.preventDefault();
+      closeComparison();
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [selectedId, closeComparison]);
+
+  /**
+   * Where focus goes when the comparison closes — the row that opened it.
+   *
+   * Without this the close button is simply unmounted out from under the
+   * caret and focus falls to `<body>`, which on a ranking of nine candidates
+   * means tabbing back down from the top of the page to reach the next one.
+   */
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+  const headingRef = useRef<HTMLHeadingElement>(null);
+  const wasOpenRef = useRef(false);
+  const headingId = useId();
+
+  useEffect(() => {
+    const open = selectedId !== undefined;
+
+    if (open) {
+      // Only on the way in: picking a second candidate while the first is
+      // still open must not record the first's close button as the way back.
+      if (!wasOpenRef.current) {
+        const active = document.activeElement;
+        returnFocusRef.current = active instanceof HTMLElement ? active : null;
+      }
+      // The name of whose comparison this is, which is the one thing a reader
+      // needs told before the 42 rows underneath it.
+      headingRef.current?.focus();
+    } else if (wasOpenRef.current) {
+      returnFocusRef.current?.focus();
+      returnFocusRef.current = null;
+    }
+
+    wasOpenRef.current = open;
+  }, [selectedId]);
+
+  const { sheetRef, handleProps, dragging } = useDragDismiss({
+    open: selectedId !== undefined,
+    onDismiss: dismissDrag,
+  });
+
+  /** The comparison rendered in the pane — kept alive through `closingId` so it has something to animate out with. */
+  const shownId = selectedId ?? closingId;
+
+  /*
+   * Only *closing* while nothing is selected. Picking a row while another
+   * comparison is still on its way out cuts the exit short — the new one is
+   * what's on screen now, so there is nothing left to animate out. Derived
+   * rather than cleared by hand at the moment of selection, which keeps the
+   * rule in one place and out of the owner's select handler.
+   */
+  const closing = selectedId === undefined && closingId !== undefined;
+
+  const selected = useMemo(() => matches.find((entry) => entry.candidate.id === shownId), [matches, shownId]);
+
+  /**
+   * How an answer reads aloud — the accessible name behind a mark. The mark is
+   * a bare coloured circle, so this string *is* the answer as far as a screen
+   * reader is concerned; the tone that draws it is `answerTone`'s, and this is
+   * its counterpart for the words — the same four the recap rows use.
+   */
+  const answerLabel = useCallback(
+    (tone: ReturnType<typeof answerTone>) => {
+      if (tone === "agree") return t("yes");
+      if (tone === "disagree") return t("no");
+      if (tone === "neutral") return t("neutral");
+      return t("none");
+    },
+    [t],
+  );
+
+  const comparison = useMemo(() => {
+    if (!selected) return undefined;
+
+    return getCandidateAnswerComparison(selected.candidate.id, answers, candidatesAnswers, questions)
+      .filter((entry) => entry.userAnswer !== undefined)
+      .map((entry) => {
+        const userTone = answerTone({ questionId: entry.questionId, answer: entry.userAnswer });
+        const candidateTone = answerTone({ questionId: entry.questionId, answer: entry.candidateAnswer });
+
+        return {
+          row: {
+            id: entry.questionId,
+            statement: entry.questionText ?? "",
+            user: { tone: userTone, label: answerLabel(userTone) },
+            candidate: { tone: candidateTone, label: answerLabel(candidateTone) },
+            important: entry.isImportant === true,
+            ...(entry.candidateComment ? { comment: entry.candidateComment } : {}),
+          } satisfies ComparisonRow,
+          agreement: agreementOf(entry.userAnswer, entry.candidateAnswer),
+        };
+      });
+  }, [selected, answers, candidatesAnswers, questions, answerLabel]);
+
+  /*
+   * Starting over on the filter every time a different comparison opens, so a
+   * "Neshody" pick made on one candidate can't silently hide rows on the next.
+   *
+   * `shownId` is the effect's *trigger*, not an input it reads — which is why
+   * the exhaustive-deps rule reads it as surplus and offers to delete it. Taking
+   * that fix would leave an empty dependency array, resetting the filter once on
+   * mount and never again. The suppression below has to stay a single line and
+   * sit directly on the hook: Biome only parses the first line of a `//` run as
+   * the suppression, so a wrapped one silently detaches and stops working.
+   */
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the dep is the reset trigger, not an input.
+  useEffect(() => {
+    setComparisonFilter("all");
+  }, [shownId]);
+
+  const comparisonCounts = useMemo(() => {
+    const counts = { all: 0, match: 0, mismatch: 0, important: 0 };
+    for (const entry of comparison ?? []) {
+      counts.all += 1;
+      if (entry.agreement === "match") counts.match += 1;
+      else if (entry.agreement === "mismatch") counts.mismatch += 1;
+      if (entry.row.important) counts.important += 1;
+    }
+    return counts;
+  }, [comparison]);
+
+  // Only offered when they would leave something — same rule the recap's own
+  // filter chips follow for "Přeskočené" and "Důležité".
+  const comparisonFilterOptions = [
+    { id: "all" as const, label: t("filterAll"), count: comparisonCounts.all },
+    ...(comparisonCounts.match > 0 ? [{ id: "match" as const, label: t("filterMatches"), count: comparisonCounts.match }] : []),
+    ...(comparisonCounts.mismatch > 0 ? [{ id: "mismatch" as const, label: t("filterMismatches"), count: comparisonCounts.mismatch }] : []),
+    ...(comparisonCounts.important > 0 ? [{ id: "important" as const, label: t("filterImportant"), count: comparisonCounts.important }] : []),
+  ];
+
+  const visibleRows = useMemo(() => {
+    if (!comparison) return [];
+    if (comparisonFilter === "all") return comparison.map((entry) => entry.row);
+    if (comparisonFilter === "important") return comparison.filter((entry) => entry.row.important).map((entry) => entry.row);
+    return comparison.filter((entry) => entry.agreement === comparisonFilter).map((entry) => entry.row);
+  }, [comparison, comparisonFilter]);
+
+  return (
+    /*
+      One element, two presentations: the right-hand pane on a desktop, and
+      a bottom sheet over the list on a phone once something is open (see
+      `.ko-comparison-pane` in the design system's `styles.css`). Rendering it
+      twice — once per breakpoint — is how the scroll position and the filter's
+      state end up differing between the two.
+    */
+    <section
+      ref={sheetRef}
+      className="ko-comparison-pane"
+      /* A named region only while it holds a comparison — with the dashboard
+         in it there is no one heading that describes the box, and a landmark
+         called nothing in particular is one more stop to skip past. */
+      aria-labelledby={selected && comparison ? headingId : undefined}
+      data-open={selected ? "" : undefined}
+      data-closing={closing ? "" : undefined}
+      data-dragging={dragging ? "" : undefined}
+    >
+      {selected && comparison ? (
+        <>
+          {/*
+            Phone only (hidden from `lg`): drag it down to put the sheet away.
+            The close button beside it is the keyboard and assistive-tech
+            route; this is a pointer affordance layered on top.
+          */}
+          <div className={gripClasses} {...handleProps} aria-hidden="true" />
+          <div className={headClasses}>
+            <div className={headingClasses}>
+              {/* `tabIndex={-1}` is not a tab stop — it only makes the
+                  heading a legal target for the focus move above, so opening
+                  a comparison lands the reader on whose it is. The short name,
+                  as the column heading below: the row behind this sheet
+                  already carries the full one. */}
+              <h2 ref={headingRef} id={headingId} className={titleClasses} tabIndex={-1}>
+                {selected.candidate.name}
+              </h2>
+              {selected.match !== undefined ? <p className={percentClasses}>{formatPercent(selected.match)}</p> : null}
+            </div>
+
+            <IconButton icon={icons.close} label={t("close")} onClick={closeComparison} />
+          </div>
+
+          {comparisonCounts.match > 0 || comparisonCounts.mismatch > 0 || comparisonCounts.important > 0 ? (
+            <div className={filtersClasses}>
+              <FilterChips label={t("filterLabel")} options={comparisonFilterOptions} value={comparisonFilter} onChange={(id) => setComparisonFilter(id as ComparisonFilter)} />
+            </div>
+          ) : null}
+
+          <div className="ko-comparison-pane-body">
+            <ComparisonList
+              rows={visibleRows}
+              labels={{
+                you: t("you"),
+                candidate: selected.candidate.shortName,
+                important: t("important"),
+              }}
+              resetKey={comparisonFilter}
+            />
+          </div>
+        </>
+      ) : (
+        <div className="ko-comparison-pane-body">{children}</div>
+      )}
+    </section>
+  );
+}

--- a/packages/app/src/components/index.ts
+++ b/packages/app/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./comparison-pane";
 export * from "./comparison-question-card";
 export * from "./embed-attribution";
 export * from "./guide";

--- a/packages/app/src/components/result-page.test.tsx
+++ b/packages/app/src/components/result-page.test.tsx
@@ -8,6 +8,7 @@ import { AnswersStoreContext, CalculatorStoreContext, createAnswersStore, create
 import type { CalculatorData } from "@/data-fetching";
 import { csMessages } from "@/locales";
 
+import { CLOSE_MS } from "./comparison-pane";
 import { LocaleProvider } from "./providers";
 import { CALCULATING_MS, ResultPage, seenKey } from "./result-page";
 
@@ -30,6 +31,8 @@ const ids = {
   beta: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
   gama: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
   delta: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+  /** The party behind Delta: the row is headed by its full name, the pane by its short one. */
+  deltaParty: "d0d0d0d0-d0d0-4d0d-8d0d-d0d0d0d0d0d0",
   epsilon: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
   zeta: "ffffffff-ffff-4fff-8fff-ffffffffffff",
   ghost: "99999999-9999-4999-8999-999999999999",
@@ -78,12 +81,13 @@ const calculatorData: CalculatorData = {
       { id: ids.alfa, displayName: "Alfa", references: [] },
       { id: ids.beta, displayName: "Beta", references: [] },
       { id: ids.gama, displayName: "Gama", references: [] },
-      { id: ids.delta, displayName: "Delta", references: [] },
+      { id: ids.delta, references: [{ id: ids.deltaParty, type: "organization" }] },
       { id: ids.epsilon, displayName: "Epsilon", references: [] },
       { id: ids.zeta, displayName: "Zeta", references: [] },
       { id: ids.ghost, displayName: "Ghost", references: [] },
     ],
     candidatesAnswers,
+    organizations: [{ id: ids.deltaParty, name: "Demokratická strana", shortName: "Delta", abbreviation: "DS" }],
   },
   baseUrl: "https://data.kalkulacka.one/kalkulacka",
 };
@@ -242,7 +246,7 @@ describe("ResultPage", () => {
       renderPage();
       expect(rows()).toHaveLength(5);
       expect(rows().map(visibleText)).toEqual([
-        "Největší shoda1.Delta100\u00a0%",
+        "Největší shoda1.Demokratická strana100\u00a0%",
         "2.Alfa67\u00a0%",
         "3.Gama50\u00a0%",
         "4.Epsilon50\u00a0%",
@@ -294,11 +298,22 @@ describe("ResultPage", () => {
 
       await user.click(rowButton("Alfa"));
       expect(rowButton("Alfa")).toHaveAttribute("aria-pressed", "true");
-      expect(rowButton("Delta")).toHaveAttribute("aria-pressed", "false");
+      expect(rowButton("Demokratická strana")).toHaveAttribute("aria-pressed", "false");
 
-      await user.click(rowButton("Delta"));
-      expect(rowButton("Delta")).toHaveAttribute("aria-pressed", "true");
+      await user.click(rowButton("Demokratická strana"));
+      expect(rowButton("Demokratická strana")).toHaveAttribute("aria-pressed", "true");
       expect(rowButton("Alfa")).toHaveAttribute("aria-pressed", "false");
+    });
+
+    it("heads a party's row and the pane by its full name, and keeps the short one for the columns", async () => {
+      const user = userEvent.setup();
+      renderPage();
+
+      expect(rowButton("Demokratická strana")).toBeInTheDocument();
+      expect(within(ranking()).queryByRole("button", { name: /^1\. Delta/ })).toBeNull();
+
+      await user.click(rowButton("Demokratická strana"));
+      expect(screen.getByRole("region", { name: "Demokratická strana" })).toBeInTheDocument();
     });
 
     it("goes back, shares and compares through the app", async () => {
@@ -389,6 +404,78 @@ describe("ResultPage", () => {
       await user.click(screen.getByRole("button", { name: "Vyplnit vlastní kalkulačku" }));
       expect(onStartOwnClick).toHaveBeenCalledTimes(1);
       expect(onCompareClick).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the comparison pane", () => {
+    const region = (name: string) => screen.getByRole("region", { name });
+
+    it("takes the dashboard's place when a row is opened, headed by the candidate and focused there", async () => {
+      const user = userEvent.setup();
+      renderPage();
+      expect(screen.getByRole("heading", { level: 2, name: "Jak jste odpovídali" })).toBeInTheDocument();
+
+      await user.click(rowButton("Alfa"));
+      expect(screen.queryByRole("heading", { level: 2, name: "Jak jste odpovídali" })).toBeNull();
+      expect(screen.getByRole("heading", { level: 2, name: "Alfa" })).toHaveFocus();
+      // Written the Czech way, with a no-break space before the sign — the same formatter the rows use.
+      expect(within(region("Alfa")).getByText("67 %").textContent).toBe("67\u00a0%");
+      // Only the five answered questions, in order; the skipped fourth says nothing about either side.
+      expect(
+        within(region("Alfa"))
+          .getAllByRole("listitem")
+          .map((row) => within(row as HTMLElement).getByText(/^Tvrzení/).textContent),
+      ).toEqual(["Tvrzení 1", "Tvrzení 2", "Tvrzení 3 (Pro mě důležité)", "Tvrzení 5", "Tvrzení 6"]);
+      expect(within(region("Alfa")).getByRole("group", { name: "Filtrovat odpovědi" })).toHaveTextContent("Vše5Shody3Neshody2Důležité1");
+    });
+
+    it("closes on Escape after the exit beat, and puts focus back on the row that opened it", () => {
+      vi.useFakeTimers();
+      try {
+        renderPage();
+        const row = rowButton("Demokratická strana");
+        row.focus();
+        fireEvent.click(row);
+        expect(screen.getByRole("heading", { level: 2, name: "Demokratická strana" })).toHaveFocus();
+        // Delta answered exactly as the reader did: nothing to filter as a mismatch.
+        expect(within(region("Demokratická strana")).getByRole("group", { name: "Filtrovat odpovědi" })).toHaveTextContent("Vše5Shody5Důležité1");
+
+        fireEvent.keyDown(window, { key: "Escape" });
+        expect(row).toHaveAttribute("aria-pressed", "false");
+        expect(row).toHaveFocus();
+        // Still rendered while the pane animates out…
+        expect(region("Demokratická strana")).toHaveAttribute("data-closing");
+
+        act(() => {
+          vi.advanceTimersByTime(CLOSE_MS);
+        });
+        // …then the dashboard is back.
+        expect(screen.queryByRole("region")).toBeNull();
+        expect(screen.getByRole("heading", { level: 2, name: "Jak jste odpovídali" })).toBeInTheDocument();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("closes when the ranking switches to the people on the lists", async () => {
+      const user = userEvent.setup();
+      renderPage({
+        data: nestedCalculatorData,
+        answers: [
+          { questionId: q1, answer: true },
+          { questionId: q2, answer: false },
+        ],
+      });
+
+      await user.click(rowButton("Koalice"));
+      expect(region("Koalice")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Lidé" }));
+      expect(screen.queryByRole("region")).toBeNull();
+      expect(rowButton("Marie")).toHaveAttribute("aria-pressed", "false");
+
+      await user.click(rowButton("Marie"));
+      expect(region("Marie")).toBeInTheDocument();
     });
   });
 
@@ -503,7 +590,7 @@ describe("ResultPage", () => {
         </CalculatorStoreContext.Provider>
       </LocaleProvider>,
     );
-    expect(rows()[0]).toHaveTextContent("Delta");
+    expect(rows()[0]).toHaveTextContent("Demokratická strana");
 
     // Flip every answer: Zeta, who said no on the two questions now answered no, is the perfect match.
     act(() => {

--- a/packages/app/src/components/result-page.tsx
+++ b/packages/app/src/components/result-page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-// Ported from kalkulacka-2026/apps/web/components/results.tsx (+ results.module.css), with the right pane's closed
-// state from comparison-pane.module.css — the comparison itself arrives with the next PR.
+// Ported from kalkulacka-2026/apps/web/components/results.tsx (+ results.module.css)
 import { Button, Calculating, FilterChips, MatchRow } from "@kalkulacka-one/design-system/client";
 import { icons } from "@kalkulacka-one/design-system/icons";
 import { AppHeader, Screen, Shell, StickyBar } from "@kalkulacka-one/design-system/server";
@@ -15,6 +14,7 @@ import { useAnswersStore } from "@/client/stores";
 import { useAnswerDistribution, useCalculatedMatches, useCalculator, useQuestionConsensus, useQuestions, useResult, useTopicMatches } from "@/client/view-models";
 import { buildAiPrompt, selectAgainstTheGrain, selectImportant, topicSlug } from "@/insights";
 
+import { ComparisonPane } from "./comparison-pane";
 import { ResultsDashboard } from "./results-dashboard";
 
 export type ResultPage = {
@@ -186,7 +186,7 @@ const shareBoxClasses = "koa:[grid-area:share] koa:justify-self-end koa:flex koa
  * That is the width at which the ranking and a comparison can be read at
  * once; below it they take turns.
  */
-const panesClasses = "koa:grid koa:grid-cols-[minmax(0,1fr)] koa:gap-5 koa:items-start koa:lg:flex-1 koa:lg:min-h-0 koa:lg:grid-cols-[30rem_minmax(0,1fr)] koa:lg:gap-6 koa:lg:items-stretch";
+const panesClasses = "koa:grid koa:grid-cols-[minmax(0,1fr)] koa:gap-6 koa:items-start koa:lg:flex-1 koa:lg:min-h-0 koa:lg:grid-cols-[30rem_minmax(0,1fr)] koa:lg:gap-8 koa:lg:items-stretch";
 
 /* Holds the ranking and the actions under it, so the grid's left column stays
    one child and the actions can sit outside the list's own scroll region. */
@@ -215,15 +215,6 @@ const donateItemClasses = "koa:list-none";
 /* Centred on a phone, where the whole column is centred reading; the desktop
    left-aligns them under the list's own edge instead. */
 const listActionsClasses = "koa:flex koa:flex-wrap koa:justify-center koa:gap-3 koa:lg:justify-start";
-
-/*
- * The right pane, closed: the dashboard flowing under the list on a phone, and
- * from `lg` a column that scrolls on its own so the ranking never moves while
- * the cards are read — the comparison that will replace the cards (next PR)
- * takes the same box.
- */
-const detailClasses = "koa:flex koa:flex-col koa:min-w-0 koa:lg:min-h-0";
-const detailBodyClasses = "koa:flex-1 koa:min-h-0 koa:overflow-visible koa:lg:overflow-y-auto koa:lg:overscroll-contain koa:lg:pb-5";
 
 /**
  * The ranking, and what the answers say beyond it.
@@ -281,10 +272,12 @@ export function ResultPage({
 
   /**
    * The candidate whose comparison is open. Nothing is open on arrival — the
-   * dashboard holds the pane. The pane itself comes with the next PR; the
-   * rows already report their choice so it can pick it up.
+   * dashboard holds the pane. Clearing this *starts* the pane closing; the exit
+   * animation belongs to `ComparisonPane`, which keeps rendering the comparison
+   * for a beat after this has already forgotten about it.
    */
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+  const closeComparison = useCallback(() => setSelectedId(undefined), []);
   /*
    * The beat is skipped outright on a shared result: it exists to let someone
    * register that a ranking came out of the answers they just gave, and the
@@ -472,7 +465,13 @@ export function ResultPage({
                       { id: "people", label: t("viewPeople") },
                     ]}
                     value={showOnlyNested ? "people" : "lists"}
-                    onChange={(id) => setShowOnlyNested(id === "people")}
+                    /* The rows swap wholesale, and the one that was open is
+                       not among the new ones — so its comparison goes too,
+                       rather than lingering over a list it is not in. */
+                    onChange={(id) => {
+                      setShowOnlyNested(id === "people");
+                      setSelectedId(undefined);
+                    }}
                   />
                 </div>
               ) : null}
@@ -484,7 +483,9 @@ export function ResultPage({
                   <Fragment key={candidate.id}>
                     <MatchRow
                       rank={order}
-                      name={candidate.displayName ?? ""}
+                      /* The full name, as 2026 heads its rows: "Svoboda a přímá demokracie",
+                         with "SPD" kept for the comparison pane's tighter places. */
+                      name={candidate.name}
                       avatarImage={candidate.avatar?.urls}
                       matchPercentage={match}
                       percentLabel={match === undefined ? undefined : formatPercent(match)}
@@ -531,20 +532,24 @@ export function ResultPage({
               ) : null}
             </div>
 
-            <div className={detailClasses}>
-              <div className={detailBodyClasses}>
-                <ResultsDashboard
-                  distribution={distribution}
-                  topics={topics}
-                  important={important}
-                  againstTheGrain={againstTheGrain}
-                  prompt={prompt}
-                  formatPercent={formatPercent}
-                  onCompareTopicClick={shared ? undefined : (topic) => onCompareTopicClick(topicSlug(topic))}
-                  onCompareImportantClick={shared ? undefined : onCompareImportantClick}
-                />
-              </div>
-            </div>
+            {/*
+              The right pane: the dashboard flowing under the list on a phone
+              and a column of its own from `lg` — until a row is picked, when
+              the same box holds that candidate's comparison instead (a sheet
+              over the ranking on a phone, the column beside it on a desktop).
+            */}
+            <ComparisonPane matches={matches} selectedId={selectedId} onClose={closeComparison} formatPercent={formatPercent}>
+              <ResultsDashboard
+                distribution={distribution}
+                topics={topics}
+                important={important}
+                againstTheGrain={againstTheGrain}
+                prompt={prompt}
+                formatPercent={formatPercent}
+                onCompareTopicClick={shared ? undefined : (topic) => onCompareTopicClick(topicSlug(topic))}
+                onCompareImportantClick={shared ? undefined : onCompareImportantClick}
+              />
+            </ComparisonPane>
           </div>
         </div>
       </main>

--- a/packages/app/src/components/results-dashboard.test.tsx
+++ b/packages/app/src/components/results-dashboard.test.tsx
@@ -11,7 +11,7 @@ import type { CandidateViewModel } from "@/view-models";
 import { LocaleProvider } from "./providers";
 import { ResultsDashboard } from "./results-dashboard";
 
-const candidate = (id: string, displayName: string): CandidateViewModel => ({ id, displayName, references: [] });
+const candidate = (id: string, displayName: string): CandidateViewModel => ({ id, displayName, name: displayName, shortName: displayName, references: [] });
 const question = (id: string, title: string): Question => ({ id, title, statement: `${title}.` });
 
 const alfa = candidate("alfa", "Alfa");

--- a/packages/app/src/components/results-dashboard.tsx
+++ b/packages/app/src/components/results-dashboard.tsx
@@ -192,7 +192,7 @@ function ConsensusRow({ entry, show = "share" }: { entry: QuestionConsensus; sho
 
         {show === "agreeing" ? (
           <AvatarStack
-            items={entry.agreeing.map((candidate) => ({ id: candidate.id, name: candidate.displayName ?? "", src: avatarSrc(candidate) }))}
+            items={entry.agreeing.map((candidate) => ({ id: candidate.id, name: candidate.shortName, src: avatarSrc(candidate) }))}
             label={t("agreeingParties")}
             popover={{ closeLabel: t("close") }}
           />
@@ -295,8 +295,9 @@ export function ResultsDashboard({ distribution, topics, important, againstTheGr
                         </span>
 
                         <span className={topicBestClasses}>
-                          <Avatar name={topic.best.candidate.displayName} image={topic.best.candidate.avatar?.urls} size="small" />
-                          <span className={topicBestNameClasses}>{topic.best.candidate.displayName}</span>
+                          {/* The short name, as 2026 has it: "SPD" fits beside the percent where "Svoboda a přímá demokracie" would wrap the row. */}
+                          <Avatar name={topic.best.candidate.shortName} image={topic.best.candidate.avatar?.urls} size="small" />
+                          <span className={topicBestNameClasses}>{topic.best.candidate.shortName}</span>
                         </span>
                       </span>
 

--- a/packages/app/src/insights/ai-prompt.test.ts
+++ b/packages/app/src/insights/ai-prompt.test.ts
@@ -23,7 +23,7 @@ const labels: AiPromptLabels = {
   locale: "cs",
 };
 
-const candidate = (id: string, displayName: string): CandidateViewModel => ({ id, displayName, references: [] });
+const candidate = (id: string, displayName: string): CandidateViewModel => ({ id, displayName, name: displayName, shortName: displayName, references: [] });
 const question = (id: string, statement: string): Question => ({ id, title: statement, statement });
 
 const alfa = candidate("alfa", "Alfa");

--- a/packages/app/src/insights/insights.test.ts
+++ b/packages/app/src/insights/insights.test.ts
@@ -13,7 +13,7 @@ import { buildAnswerDistribution, buildAnswerGroups, buildQuestionConsensus, bui
 const question = (id: string, tags?: string[]): Question => (tags ? { id, title: id, statement: id, tags } : { id, title: id, statement: id });
 
 const candidate = (id: string, nestedCandidates?: CandidateViewModel[]): CandidateViewModel =>
-  nestedCandidates ? { id, displayName: id, references: [], nestedCandidates } : { id, displayName: id, references: [] };
+  nestedCandidates ? { id, displayName: id, name: id, shortName: id, references: [], nestedCandidates } : { id, displayName: id, name: id, shortName: id, references: [] };
 
 const answersFor = (entries: Record<string, boolean | null>): CandidateAnswer[] => Object.entries(entries).map(([questionId, answer]) => ({ questionId, answer }));
 

--- a/packages/app/src/locales/cs.json
+++ b/packages/app/src/locales/cs.json
@@ -1,6 +1,20 @@
 {
   "koa": {
     "components": {
+      "comparisonPane": {
+        "close": "Zavřít porovnání",
+        "filterLabel": "Filtrovat odpovědi",
+        "filterAll": "Vše",
+        "filterMatches": "Shody",
+        "filterMismatches": "Neshody",
+        "filterImportant": "Důležité",
+        "you": "Vy",
+        "important": "Pro mě důležité",
+        "yes": "Ano",
+        "no": "Ne",
+        "neutral": "Nevím",
+        "none": "Bez odpovědi"
+      },
       "embedAttribution": {
         "broughtBy": "Přináší"
       },

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1,6 +1,20 @@
 {
   "koa": {
     "components": {
+      "comparisonPane": {
+        "close": "Close comparison",
+        "filterLabel": "Filter answers",
+        "filterAll": "All",
+        "filterMatches": "Matches",
+        "filterMismatches": "Mismatches",
+        "filterImportant": "Important",
+        "you": "You",
+        "important": "Important to me",
+        "yes": "Yes",
+        "no": "No",
+        "neutral": "Don't know",
+        "none": "No answer"
+      },
       "embedAttribution": {
         "broughtBy": "Brought by"
       },

--- a/packages/app/src/locales/mk.json
+++ b/packages/app/src/locales/mk.json
@@ -1,6 +1,20 @@
 {
   "koa": {
     "components": {
+      "comparisonPane": {
+        "close": "Затвори ја споредбата",
+        "filterLabel": "Филтрирај одговори",
+        "filterAll": "Сите",
+        "filterMatches": "Совпаѓања",
+        "filterMismatches": "Несовпаѓања",
+        "filterImportant": "Важни",
+        "you": "Вие",
+        "important": "Важно за мене",
+        "yes": "Да",
+        "no": "Не",
+        "neutral": "Не знам",
+        "none": "Без одговор"
+      },
       "embedAttribution": {
         "broughtBy": "Обезбедено од"
       },

--- a/packages/app/src/locales/sk.json
+++ b/packages/app/src/locales/sk.json
@@ -1,6 +1,20 @@
 {
   "koa": {
     "components": {
+      "comparisonPane": {
+        "close": "Zavrieť porovnanie",
+        "filterLabel": "Filtrovať odpovede",
+        "filterAll": "Všetko",
+        "filterMatches": "Zhody",
+        "filterMismatches": "Nezhody",
+        "filterImportant": "Dôležité",
+        "you": "Vy",
+        "important": "Pre mňa dôležité",
+        "yes": "Áno",
+        "no": "Nie",
+        "neutral": "Neviem",
+        "none": "Bez odpovede"
+      },
       "embedAttribution": {
         "broughtBy": "Prináša"
       },

--- a/packages/app/src/view-models/candidate.test.ts
+++ b/packages/app/src/view-models/candidate.test.ts
@@ -1,0 +1,69 @@
+import type { Candidate } from "@kalkulacka-one/schema";
+
+import { describe, expect, it } from "vitest";
+
+import { candidateViewModel } from "./candidate";
+import { organizationViewModel } from "./organization";
+import { personViewModel } from "./person";
+
+const baseUrl = "https://data.kalkulacka.one/kalkulacka";
+
+const ids = {
+  spd: "94c3d32d-7915-4a07-bd99-d54cd1e53063",
+  mzh: "0d2e7c1a-6b47-4a3a-9c0e-1a2b3c4d5e6f",
+  babis: "5ce1deab-ca02-4768-bff9-59bff4a3bcce",
+} as const;
+
+const organizations = new Map([
+  [ids.spd, organizationViewModel({ id: ids.spd, name: "Svoboda a přímá demokracie", shortName: "SPD", abbreviation: "SPD" }, baseUrl)],
+  [ids.mzh, organizationViewModel({ id: ids.mzh, name: "Moravské zemské hnutí", abbreviation: "MZH" }, baseUrl)],
+]);
+const persons = new Map([[ids.babis, personViewModel({ id: ids.babis, givenName: "Andrej", familyName: "Babiš" }, baseUrl)]]);
+
+const candidate = (fields: Partial<Candidate>): Candidate => ({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", references: [], ...fields });
+
+describe("candidateViewModel", () => {
+  it("heads a party by its full name and labels it by its short one", () => {
+    const model = candidateViewModel(candidate({ references: [{ id: ids.spd, type: "organization" }] }), persons, organizations, baseUrl);
+    expect(model.name).toBe("Svoboda a přímá demokracie");
+    expect(model.shortName).toBe("SPD");
+    // The legacy screens' name is untouched: the short form, as before.
+    expect(model.displayName).toBe("SPD");
+  });
+
+  it("takes the abbreviation as the short name when the organization has no shortName", () => {
+    const model = candidateViewModel(candidate({ references: [{ id: ids.mzh, type: "organization" }] }), persons, organizations, baseUrl);
+    expect(model.name).toBe("Moravské zemské hnutí");
+    expect(model.shortName).toBe("MZH");
+  });
+
+  it("uses a person's display name for both", () => {
+    const model = candidateViewModel(candidate({ references: [{ id: ids.babis, type: "person" }] }), persons, organizations, baseUrl);
+    expect(model.name).toBe("Andrej Babiš");
+    expect(model.shortName).toBe("Andrej Babiš");
+  });
+
+  it("lets a coalition's own displayName stand for both, over whatever it references", () => {
+    const model = candidateViewModel(candidate({ displayName: "SPOLU", references: [{ id: ids.spd, type: "organization", relationship: "coalition-member" }] }), persons, organizations, baseUrl);
+    expect(model.name).toBe("SPOLU");
+    expect(model.shortName).toBe("SPOLU");
+  });
+
+  it("falls back to the id when nothing resolves, so a data gap shows rather than an empty row", () => {
+    const model = candidateViewModel(candidate({ references: [{ id: "ffffffff-ffff-4fff-8fff-ffffffffffff", type: "organization" }] }), persons, organizations, baseUrl);
+    expect(model.name).toBe("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+    expect(model.shortName).toBe("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa");
+    expect(model.displayName).toBeUndefined();
+  });
+
+  it("resolves nested candidates the same way", () => {
+    const model = candidateViewModel(
+      candidate({ displayName: "Koalice", nestedCandidates: [{ id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", references: [{ id: ids.spd, type: "organization" }] }] }),
+      persons,
+      organizations,
+      baseUrl,
+    );
+    expect(model.nestedCandidates?.[0]?.name).toBe("Svoboda a přímá demokracie");
+    expect(model.nestedCandidates?.[0]?.shortName).toBe("SPD");
+  });
+});

--- a/packages/app/src/view-models/candidate.ts
+++ b/packages/app/src/view-models/candidate.ts
@@ -6,7 +6,27 @@ import type { OrganizationViewModel } from "./organization";
 import type { PersonViewModel } from "./person";
 
 export type CandidateViewModel = Omit<Candidate, "nestedCandidates"> & {
+  /**
+   * The name as the legacy screens have always shown it — the short form for
+   * an organization. Unchanged so those screens stay untouched; the new
+   * screens read `name` and `shortName` instead.
+   */
   displayName: string | undefined;
+  /**
+   * The full preferred name — a ranking row's headline. A coalition's own
+   * `displayName` ("SPOLU"), else the referenced organization's `name` or the
+   * person's display name, else the id: a candidate always resolves to
+   * *something*, and a stray id on screen is a data bug made visible rather
+   * than an empty row. Mirrors 2026's platform adapter.
+   */
+  name: string;
+  /**
+   * The short form for tight places — the comparison pane's heading and column,
+   * an avatar's caption: the candidate's own `displayName`, else the
+   * organization's short name (a person has none, so their name serves), else
+   * `name`.
+   */
+  shortName: string;
   organization?: string | undefined;
   avatar?: {
     type: "avatar" | "logo" | "portrait";
@@ -31,6 +51,28 @@ function getCandidateDisplayName(candidate: Candidate, personsMap: Map<string, P
     }
   }
 
+  return undefined;
+}
+
+/**
+ * The full and the short name together, resolved once: the two must come from
+ * the same reference, or a coalition's own `displayName` would head the row
+ * while a member's short name labelled the column.
+ */
+function getCandidateNames(candidate: Candidate, personsMap: Map<string, PersonViewModel>, organizationsMap: Map<string, OrganizationViewModel>): { name: string; shortName: string } {
+  const referenced = getReferencedNames(candidate, personsMap, organizationsMap);
+  const name = candidate.displayName ?? referenced?.name ?? candidate.id;
+  return { name, shortName: candidate.displayName ?? referenced?.shortName ?? name };
+}
+
+/** What the first reference is called — an organization's two names, or a person's one name serving as both. */
+function getReferencedNames(candidate: Candidate, personsMap: Map<string, PersonViewModel>, organizationsMap: Map<string, OrganizationViewModel>): { name: string; shortName: string } | undefined {
+  const firstReference = candidate.references?.[0];
+  if (firstReference?.type === "organization") return organizationsMap.get(firstReference.id);
+  if (firstReference?.type === "person") {
+    const person = personsMap.get(firstReference.id);
+    return person ? { name: person.displayName, shortName: person.displayName } : undefined;
+  }
   return undefined;
 }
 
@@ -88,6 +130,7 @@ function getCandidateType(candidate: Candidate): "person" | "organization" | und
 
 export function candidateViewModel(candidate: Candidate, personsMap: Map<string, PersonViewModel>, organizationsMap: Map<string, OrganizationViewModel>, baseUrl: string): CandidateViewModel {
   const displayName = getCandidateDisplayName(candidate, personsMap, organizationsMap);
+  const { name, shortName } = getCandidateNames(candidate, personsMap, organizationsMap);
   const organization = getCandidateOrganization(candidate, personsMap, organizationsMap);
   const avatar = getCandidateAvatar(candidate, personsMap, organizationsMap, baseUrl);
   const type = getCandidateType(candidate);
@@ -96,6 +139,8 @@ export function candidateViewModel(candidate: Candidate, personsMap: Map<string,
   return {
     ...candidate,
     displayName,
+    name,
+    shortName,
     organization,
     avatar,
     type,

--- a/packages/app/src/view-models/organization.test.ts
+++ b/packages/app/src/view-models/organization.test.ts
@@ -1,0 +1,29 @@
+import type { Organization } from "@kalkulacka-one/schema";
+
+import { describe, expect, it } from "vitest";
+
+import { organizationViewModel } from "./organization";
+
+const baseUrl = "https://data.kalkulacka.one/kalkulacka";
+
+const organization = (fields: Partial<Organization>): Organization => ({ id: "94c3d32d-7915-4a07-bd99-d54cd1e53063", name: "Svoboda a přímá demokracie", ...fields });
+
+describe("organizationViewModel", () => {
+  it("keeps the full name and derives the short one from shortName first", () => {
+    const model = organizationViewModel(organization({ shortName: "SPD", abbreviation: "SPD" }), baseUrl);
+    expect(model.name).toBe("Svoboda a přímá demokracie");
+    expect(model.shortName).toBe("SPD");
+    // The legacy screens' name is untouched: still the short form.
+    expect(model.displayName).toBe("SPD");
+  });
+
+  it("falls back to the abbreviation, then to the full name", () => {
+    expect(organizationViewModel(organization({ abbreviation: "MZH" }), baseUrl).shortName).toBe("MZH");
+    expect(organizationViewModel(organization({}), baseUrl).shortName).toBe("Svoboda a přímá demokracie");
+  });
+
+  it("resolves the avatar against the calculator's base URL", () => {
+    const model = organizationViewModel(organization({ images: [{ type: "logo", urls: { original: "images/spd.png" } }] }), baseUrl);
+    expect(model.avatar).toEqual({ type: "logo", urls: { original: `${baseUrl}/images/spd.png` } });
+  });
+});

--- a/packages/app/src/view-models/organization.ts
+++ b/packages/app/src/view-models/organization.ts
@@ -3,7 +3,23 @@ import type { ImageUrls, Organization } from "@kalkulacka-one/schema";
 import { findImageByType, resolveImageUrls } from "@/data-fetching";
 
 export type OrganizationViewModel = Organization & {
+  /**
+   * The short form, kept as it always was — the legacy screens read it.
+   * The new screens pick `name` or `shortName` for the place a name sits in.
+   */
   displayName: string;
+  /**
+   * The preferred full name, e.g. "Svoboda a přímá demokracie" — what a
+   * ranking row is headed by. Always set: the schema requires it.
+   */
+  name: string;
+  /**
+   * The short form for tight places — a column heading over a mark, an avatar's
+   * caption: `shortName`, else the abbreviation, else the full name. The same
+   * resolution 2026's platform adapter used, so the two screens agree on what
+   * "SPD" is short for.
+   */
+  shortName: string;
   avatar?: {
     type: "avatar" | "logo";
     urls: ImageUrls;
@@ -12,6 +28,10 @@ export type OrganizationViewModel = Organization & {
 
 function getOrganizationDisplayName(organization: Organization): string {
   return organization.shortName || organization.abbreviation || organization.name;
+}
+
+function getOrganizationShortName(organization: Organization): string {
+  return organization.shortName ?? organization.abbreviation ?? organization.name;
 }
 
 function getOrganizationAvatar(organization: Organization, baseUrl: string): { type: "avatar" | "logo"; urls: ImageUrls } | undefined {
@@ -28,6 +48,8 @@ export function organizationViewModel(organization: Organization, baseUrl: strin
   return {
     ...organization,
     displayName: getOrganizationDisplayName(organization),
+    name: organization.name,
+    shortName: getOrganizationShortName(organization),
     avatar: getOrganizationAvatar(organization, baseUrl),
   };
 }

--- a/packages/design-system/src/components/client/comparisonList.test.tsx
+++ b/packages/design-system/src/components/client/comparisonList.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ComparisonList, type ComparisonRow } from "./comparisonList";
+
+const labels = { you: "Vy", candidate: "Piráti", important: "Pro mě důležité" };
+
+const rows: ComparisonRow[] = [
+  {
+    id: "q1",
+    statement: "Město by mělo omezit vánoční výzdobu kvůli cenám energií.",
+    user: { tone: "agree", label: "Ano" },
+    candidate: { tone: "agree", label: "Ano" },
+    important: true,
+    comment: "Úspory dávají smysl, výzdobu ale zcela rušit nechceme.",
+  },
+  {
+    id: "q2",
+    statement: "Město má vybudovat nový plavecký areál.",
+    user: { tone: "disagree", label: "Ne" },
+    candidate: { tone: "agree", label: "Ano" },
+  },
+  {
+    id: "q3",
+    statement: "Parkování v centru má zdražit.",
+    user: { tone: "agree", label: "Ano" },
+    candidate: { tone: "none", label: "Bez odpovědi" },
+  },
+];
+
+const items = () => screen.getAllByRole("listitem");
+
+describe("ComparisonList", () => {
+  it("lists every row in the order given, each with the candidate's mark before the reader's", () => {
+    render(<ComparisonList rows={rows} labels={labels} />);
+    expect(items()).toHaveLength(3);
+    expect(items().map((item) => within(item).getByText(/^(Město|Parkování)/).textContent)).toEqual([
+      "Město by mělo omezit vánoční výzdobu kvůli cenám energií. (Pro mě důležité)",
+      "Město má vybudovat nový plavecký areál.",
+      "Parkování v centru má zdražit.",
+    ]);
+
+    const marks = within(items()[1] as HTMLElement).getAllByRole("img");
+    expect(marks.map((mark) => mark.getAttribute("aria-label"))).toEqual(["Piráti: Ano", "Vy: Ne"]);
+  });
+
+  it("names the answers for a screen reader, including the one nobody gave", () => {
+    render(<ComparisonList rows={rows} labels={labels} />);
+    expect(screen.getByRole("img", { name: "Piráti: Bez odpovědi" })).toHaveClass("ko:border-dashed");
+    expect(screen.getAllByRole("img", { name: "Vy: Ano" })).toHaveLength(2);
+  });
+
+  it("heads the two mark columns with the reader and the candidate, hidden from assistive tech", () => {
+    const { container } = render(<ComparisonList rows={rows} labels={labels} />);
+    const head = container.querySelector('[aria-hidden="true"]');
+    expect(head).toHaveTextContent("PirátiVy");
+    expect(head).toHaveClass("ko:sticky", "ko:top-0");
+    // The candidate's label may run across the statement column; "Vy" stays in its own.
+    expect(head?.firstElementChild).toHaveClass("ko:col-start-1", "ko:col-end-3", "ko:text-right");
+    expect(head?.lastElementChild).toHaveClass("ko:col-start-3", "ko:text-center");
+  });
+
+  it("stars an important question with the design system's own mark and says so off-screen", () => {
+    render(<ComparisonList rows={rows} labels={labels} />);
+    const [starred, plain] = items() as HTMLElement[];
+    // Inside the statement — the marks beside it are SVGs of their own.
+    expect(starred?.querySelector("p svg")).toHaveAttribute("aria-hidden", "true");
+    expect(starred?.querySelector("p svg")).toHaveAttribute("fill", "currentColor");
+    expect(within(starred as HTMLElement).getByText("(Pro mě důležité)")).toHaveClass("ko:sr-only");
+    expect(plain?.querySelector("p svg")).toBeNull();
+    expect(within(plain as HTMLElement).queryByText("(Pro mě důležité)")).toBeNull();
+  });
+
+  it("quotes the candidate's own comment under the statement, and only where there is one", () => {
+    render(<ComparisonList rows={rows} labels={labels} />);
+    const comment = screen.getByText("Úspory dávají smysl, výzdobu ale zcela rušit nechceme.");
+    expect(comment.tagName).toBe("P");
+    expect(comment).toHaveClass("ko:col-span-full", "ko:xs:col-start-1");
+    expect(items()[1]?.querySelectorAll("p")).toHaveLength(1);
+  });
+
+  it("remounts the list when the reset key changes, so the entrance replays", () => {
+    const { rerender } = render(<ComparisonList rows={rows} labels={labels} resetKey="all" />);
+    const before = screen.getByRole("list");
+    expect(before).toHaveClass("ko:animate-recap-list-in", "ko:motion-reduce:animate-none");
+
+    rerender(<ComparisonList rows={rows} labels={labels} resetKey="all" />);
+    expect(screen.getByRole("list")).toBe(before);
+
+    rerender(<ComparisonList rows={rows} labels={labels} resetKey="match" />);
+    expect(screen.getByRole("list")).not.toBe(before);
+  });
+
+  it("renders an empty list without a row", () => {
+    render(<ComparisonList rows={[]} labels={labels} />);
+    expect(screen.getByRole("list")).toBeEmptyDOMElement();
+  });
+});

--- a/packages/design-system/src/components/client/comparisonList.tsx
+++ b/packages/design-system/src/components/client/comparisonList.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+// Ported from kalkulacka-2026/packages/ui/src/comparison-list/comparison-list.tsx and comparison-list.module.css
+import { icons } from "../icons";
+import { AnswerMark, type AnswerMarkTone } from "../server/answerMark";
+import { VisuallyHidden } from "../server/visuallyHidden";
+import { Icon } from "./icon";
+
+/** One recorded position — the tone that draws the mark, and the words a screen reader gets instead of it. */
+export type ComparisonAnswer = {
+  tone: AnswerMarkTone;
+  /** How the answer reads aloud, e.g. "Ano" — the mark is a bare coloured circle, so this string *is* the answer. */
+  label: string;
+};
+
+export type ComparisonRow = {
+  /** Stable across re-renders — the question's id. */
+  id: string;
+  statement: string;
+  /** The user's recorded position. */
+  user: ComparisonAnswer;
+  /** The candidate's. */
+  candidate: ComparisonAnswer;
+  /** The user marked this one "pro mě důležité". */
+  important?: boolean;
+  /** The candidate's own justification, where they left one. */
+  comment?: string;
+};
+
+export type ComparisonListProps = {
+  rows: ComparisonRow[];
+  labels: {
+    /** Column heading over the user's answers, e.g. "Vy". */
+    you: string;
+    /** Column heading over the candidate's — usually their short name. */
+    candidate: string;
+    /** Accessible marker for a starred question, e.g. "Pro mě důležité". */
+    important: string;
+  };
+  /**
+   * Changing this remounts the row list, replaying its entrance animation —
+   * the same `key={filter}` trick the recap uses so switching "Shody" to
+   * "Neshody" reads as a new result landing rather than a silent swap.
+   */
+  resetKey?: string | number;
+};
+
+/*
+ * The list owns its own inset rather than being padded by whatever contains it.
+ *
+ * That is what lets the column heading below be *sticky and full-bleed*: it
+ * cancels this padding with a negative margin so its background reaches both
+ * edges of the scroll container. Padded from outside instead, the heading could
+ * only ever be as wide as the text column, and rows slid past in the gap beside
+ * it — which is exactly how it looked before.
+ */
+const wrapClasses = "ko:px-6 ko:pb-6";
+
+/* The two fixed mark columns beside the statement, shared by the heading and every row so the circles line up. */
+const columnsClasses = "ko:grid ko:grid-cols-[minmax(0,1fr)_1.5rem_1.5rem] ko:gap-4";
+
+/*
+ * Nearly opaque, not merely tinted. The sheet this sits in is itself
+ * translucent, so a heading at 0.8 was glass over glass and the statements
+ * scrolling underneath read straight through the column labels. Enough alpha
+ * to stay a surface, with the blur doing the rest.
+ */
+const headClasses = `${columnsClasses} ko:sticky ko:top-0 ko:z-1 ko:-mx-6 ko:px-6 ko:pt-4 ko:pb-3 ko:bg-surface/95 ko:backdrop-blur-[12px] ko:backdrop-saturate-[1.4]`;
+
+const headLabelClasses = "ko:min-w-0 ko:font-sans ko:text-[0.6875rem] ko:font-semibold ko:tracking-[0.02em] ko:uppercase ko:text-text-muted";
+
+/* The shorter of the two, so it stays put in its own column rather than
+   needing the room the candidate's claims — the two now sit on one line
+   instead of the candidate's being pushed to a row of its own to avoid
+   overlapping it. */
+const headYouClasses = `${headLabelClasses} ko:col-start-3 ko:text-center`;
+
+/* Spans the statement column and the candidate's own mark column, so a long
+   party name extends leftward into the statement's empty space instead of
+   being clipped — and stops short of "Vy"'s column so the two share one line
+   rather than one wrapping under the other. Right-aligned so a short name
+   still sits next to the mark column it labels rather than drifting off
+   toward the statement side. */
+const headCandidateClasses = `${headLabelClasses} ko:col-start-1 ko:col-end-3 ko:text-right ko:overflow-hidden ko:text-ellipsis ko:whitespace-nowrap`;
+
+/*
+ * Replayed whenever the caller changes `resetKey` (the comparison pane does
+ * this on every filter switch) — the same small entrance the recap's own list
+ * plays on a filter change (`--ko-animate-recap-list-in`), so "Shody" swapping
+ * in over "Vše" reads as a new result landing rather than a silent content
+ * swap.
+ */
+const listClasses = "ko:flex ko:flex-col ko:m-0 ko:p-0 ko:list-none ko:animate-recap-list-in ko:motion-reduce:animate-none";
+
+const rowClasses = `${columnsClasses} ko:items-start ko:gap-y-3 ko:py-4 ko:border-b-[1.5px] ko:border-border ko:last:border-b-0`;
+
+/* `pt-0.5` optically centres the first line against its pair of marks. */
+const statementClasses = "ko:col-start-1 ko:m-0 ko:min-w-0 ko:pt-0.5 ko:font-sans ko:text-sm ko:leading-[1.45] ko:text-text";
+
+const starClasses = "ko:inline ko:size-[13px] ko:align-[-0.15em] ko:mr-1.5 ko:text-text-muted";
+
+/*
+ * The party's own words.
+ *
+ * Full width on a phone — the whole row, including the space under the marks —
+ * rather than indented into the statement's column. At that width the column is
+ * already narrow enough that a quotation set inside it wrapped every four or
+ * five words. Once there is width for it (`xs`, 34rem), the comment tucks
+ * under the statement it belongs to; the marks' columns stay clear, which
+ * keeps the two circles reading as one uninterrupted vertical pair down the
+ * whole list.
+ *
+ * Marked by a quotation mark set as a watermark rather than by a rule down the
+ * left. A border is the same device the statement's own column edge uses, so the
+ * two competed; a quote says "someone is speaking" on its own, which is exactly
+ * the distinction being drawn.
+ *
+ * The raised opening mark, not Czech's low one. Czech opens a quotation on the
+ * baseline, which is right when the marks actually bracket the text — but this
+ * is a watermark with no closing partner, and a baseline glyph at this size
+ * hung level with the paragraph's second line and read as debris in the
+ * margin. The raised shape sits where a drop cap would and is the one people
+ * parse as "quoted". Off the type scale on purpose (2.75rem): a watermark
+ * glyph, drawn at whatever size balances the block it sits behind. It is never
+ * read, so it is artwork that happens to be a character — decorative, and the
+ * statement above already establishes whose answer this is.
+ */
+const commentClasses = [
+  "ko:col-span-full ko:xs:col-span-1 ko:xs:col-start-1",
+  "ko:relative ko:m-0 ko:pl-8",
+  "ko:font-sans ko:text-[0.8125rem] ko:leading-[1.45] ko:text-text-muted ko:text-pretty",
+  "ko:before:content-['“'] ko:before:absolute ko:before:left-0 ko:before:-top-2 ko:before:font-display ko:before:text-[2.75rem] ko:before:leading-none ko:before:text-text-muted/30 ko:before:pointer-events-none",
+].join(" ");
+
+/**
+ * Answer-by-answer, the user against one candidate.
+ *
+ * The two positions lead the row as a pair of marks in fixed columns, so 42 rows
+ * can be read straight down — where the two circles differ is the whole point of
+ * the screen, and that pattern only emerges if they line up. They are the same
+ * marks the recap uses, at the smaller size.
+ *
+ * Rows keep their original question order rather than being sorted by agreement:
+ * this is a record of what was asked, and re-ordering it would make a candidate
+ * look better or worse depending on which end you read first.
+ */
+export function ComparisonList({ rows, labels, resetKey }: ComparisonListProps) {
+  return (
+    <div className={wrapClasses}>
+      {/*
+        The candidate's column heading is allowed to run across the statement
+        column rather than being truncated to the width of its circle: archive
+        party names reach 85 characters, and clipping one to "SPOLEČN…" in the
+        heading that identifies whose answers these are is worse than letting it
+        extend into empty space. "Vy" needs no such room — it stays put in the
+        one column it labels, which is what keeps this heading a single line
+        instead of the two the previous, fully-overlapping layout wrapped to.
+      */}
+      <div className={headClasses} aria-hidden="true">
+        <span className={headCandidateClasses}>{labels.candidate}</span>
+        <span className={headYouClasses}>{labels.you}</span>
+      </div>
+
+      <ul className={listClasses} key={resetKey}>
+        {rows.map((row) => (
+          <li key={row.id} className={rowClasses}>
+            <p className={statementClasses}>
+              {/* The design system's own star — the same heavy mark the question
+                  card and the recap wear for "pro mě důležité", not a text
+                  asterisk standing in for it. */}
+              {row.important ? <Icon icon={icons.star} size={null} filled decorative className={starClasses} /> : null}
+              {row.statement}
+              {row.important ? <VisuallyHidden> ({labels.important})</VisuallyHidden> : null}
+            </p>
+
+            <AnswerMark tone={row.candidate.tone} label={`${labels.candidate}: ${row.candidate.label}`} size="small" />
+            <AnswerMark tone={row.user.tone} label={`${labels.you}: ${row.user.label}`} size="small" />
+
+            {/*
+              A grid child in its own right rather than nested under the
+              statement: on a narrow screen it takes the full row, including the
+              space beneath the marks, instead of being squeezed into the same
+              column as the question it answers.
+            */}
+            {row.comment ? <p className={commentClasses}>{row.comment}</p> : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/design-system/src/components/client/index.ts
+++ b/packages/design-system/src/components/client/index.ts
@@ -4,6 +4,7 @@ export * from "./avatarStack";
 export * from "./button";
 export * from "./calculating";
 export * from "./clientTest";
+export * from "./comparisonList";
 export * from "./description";
 export * from "./dialog";
 export * from "./dragGuides";

--- a/packages/design-system/src/styles.css
+++ b/packages/design-system/src/styles.css
@@ -1495,6 +1495,220 @@
     }
   }
 
+  /* --- ComparisonPane --------------------------------------------------------
+   * Ported from kalkulacka-2026/apps/web/components/comparison-pane.module.css
+   * (`.detail`, `.detailBody`, `sheetIn`/`sheetOut`, `panelIn`/`panelOut`).
+   * The box the app's `ComparisonPane` renders into — the head, the grip and
+   * the filters inside it are `koa:` utilities in comparison-pane.tsx. It
+   * lives in this layer, like the recap header, because every rule keys on an
+   * attribute of the element (`data-open`, `data-closing`, `data-dragging`),
+   * switches wholesale under one media query, and carries keyframes — which
+   * a utility on each state would spell out several times and could drift on.
+   *
+   * One element, two presentations: the right-hand pane on a desktop, and a
+   * bottom sheet over the list on a phone once something is open. Rendering
+   * it twice — once per breakpoint — is how the scroll position and the
+   * filter's state end up differing between the two.
+   *
+   * `--ko-comparison-sheet-top` is how far the sheet stops short of the top
+   * edge. Named because the sheet's height is derived from it and the two
+   * must not drift.
+   */
+  .ko-comparison-pane {
+    --ko-comparison-sheet-top: max(4rem, env(safe-area-inset-top, 0px));
+
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  /*
+   * On a phone, an open comparison is a bottom sheet.
+   *
+   * The recap established that changing an answer means opening the real
+   * question rather than unfolding a drawer under a row, and the same
+   * reasoning holds here: 42 comparison rows expanded inside a list leave you
+   * scrolling to find your way back out. It stops short of the top edge so
+   * the ranking stays visible behind it — the sheet is a layer over this
+   * screen, not a different screen.
+   *
+   * Closed, this element is just the dashboard sitting under the ranking, so
+   * nothing is duplicated to get both behaviours.
+   *
+   * Anchored to the top with an explicit height, rather than pinned with
+   * `bottom: 0`. A fixed box's bottom edge resolves against the *visible*
+   * viewport, so `0` would stop the sheet in a hard line above Safari's
+   * address bar; measured downward in `lvh` it reaches the bottom of the
+   * screen instead, and the comparison carries on under the glass exactly
+   * like the ranking behind it. Same reasoning as `<body>` in @layer base.
+   * `z-index: 20` — above the shell's sticky bar (5) in the content's own
+   * stacking context.
+   */
+  .ko-comparison-pane[data-open],
+  .ko-comparison-pane[data-closing] {
+    position: fixed;
+    top: var(--ko-comparison-sheet-top);
+    right: 0;
+    left: 0;
+    height: calc(100lvh - var(--ko-comparison-sheet-top));
+    z-index: 20;
+
+    border-radius: 1.25rem 1.25rem 0 0;
+    background: oklch(from var(--ko-color-surface) l c h / 0.86);
+    backdrop-filter: var(--ko-plate-blur);
+    box-shadow: var(--ko-shadow-card-lifted);
+    overflow: hidden;
+
+    transition: transform var(--ko-duration-base) var(--ko-ease-spring);
+  }
+
+  .ko-comparison-pane[data-open] {
+    animation: ko-comparison-sheet-in var(--ko-duration-slow) var(--ko-ease-spring);
+  }
+
+  /*
+   * The tap-to-close route (the X, Escape): the drag dismissal already
+   * animates itself by writing the transform directly as a finger releases it
+   * (see `use-drag-dismiss.ts`), so this only plays when there was no drag —
+   * the sheet sliding back down instead of the dashboard just appearing under
+   * it the instant the state clears.
+   */
+  .ko-comparison-pane[data-closing] {
+    animation: ko-comparison-sheet-out var(--ko-duration-base) var(--ko-ease-exit) forwards;
+  }
+
+  @keyframes ko-comparison-sheet-in {
+    from {
+      transform: translateY(100%);
+    }
+  }
+
+  @keyframes ko-comparison-sheet-out {
+    to {
+      transform: translateY(100%);
+    }
+  }
+
+  /* While a finger is on the handle the sheet must track it exactly; a transition
+     here would make it lag behind and feel elastic in the wrong way. */
+  .ko-comparison-pane[data-dragging] {
+    transition: none;
+  }
+
+  /*
+   * No padding of its own: `ComparisonList` carries its own inset so that its
+   * column heading can stick to this box's real top edge and span it fully.
+   */
+  .ko-comparison-pane-body {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 0;
+  }
+
+  /*
+   * The sheet runs to the bottom of the layout viewport, a few pixels above the
+   * address bar rather than under it — a fixed box cannot reach past that on
+   * iOS, whatever height it is given. So this is ordinary breathing room under
+   * the last row, not clearance for a bar.
+   */
+  .ko-comparison-pane[data-open] .ko-comparison-pane-body,
+  .ko-comparison-pane[data-closing] .ko-comparison-pane-body {
+    padding-bottom: 1.5rem;
+  }
+
+  /*
+   * Closed, the pane is the dashboard flowing under the list — no surface of its
+   * own, because the cards inside it already have one.
+   */
+  .ko-comparison-pane:not([data-open]) .ko-comparison-pane-body {
+    overflow: visible;
+  }
+
+  /*
+   * Two panes. The width at which the ranking and a comparison can be read at
+   * once. Below it they take turns; above it the ranking never scrolls away
+   * while you read somebody's answers, which is the whole reason this screen
+   * has two panes. The ranking column's own half of this breakpoint lives in
+   * result-page.tsx (`lg`).
+   *
+   * Never a sheet at this width — the pane it would cover is the one thing
+   * the comparison is meant to be read against.
+   */
+  @media (min-width: 64rem) {
+    .ko-comparison-pane,
+    .ko-comparison-pane[data-open],
+    .ko-comparison-pane[data-closing] {
+      position: static;
+      inset: auto;
+      height: auto;
+      min-height: 0;
+      border-radius: var(--ko-radius-control);
+      transform: none;
+    }
+
+    .ko-comparison-pane[data-open],
+    .ko-comparison-pane[data-closing] {
+      background: oklch(from var(--ko-color-surface) l c h / 0.86);
+      backdrop-filter: var(--ko-plate-blur);
+      box-shadow: var(--ko-shadow-surface);
+    }
+
+    /*
+     * A popover rather than a sheet at this width: the comparison settles into
+     * place instead of sliding up from an edge, since there is no edge here for
+     * it to travel from.
+     */
+    .ko-comparison-pane[data-open] {
+      animation: ko-comparison-panel-in var(--ko-duration-slow) var(--ko-ease-spring);
+    }
+
+    .ko-comparison-pane[data-closing] {
+      animation: ko-comparison-panel-out var(--ko-duration-base) var(--ko-ease-exit) forwards;
+    }
+
+    @keyframes ko-comparison-panel-in {
+      from {
+        opacity: 0;
+        transform: translateY(8px) scale(0.98);
+      }
+    }
+
+    @keyframes ko-comparison-panel-out {
+      to {
+        opacity: 0;
+        transform: translateY(4px) scale(0.98);
+      }
+    }
+
+    .ko-comparison-pane:not([data-open]):not([data-closing]) {
+      background: none;
+      backdrop-filter: none;
+      box-shadow: none;
+      overflow: visible;
+    }
+
+    /* Closed, a column that scrolls on its own so the ranking never moves
+       while the dashboard's cards are read. */
+    .ko-comparison-pane:not([data-open]):not([data-closing]) .ko-comparison-pane-body {
+      overflow-y: auto;
+      padding-bottom: 1.5rem;
+    }
+  }
+
+  /*
+   * The durations are tokens and already collapse under reduced motion; said
+   * outright as well so a `forwards`-filled exit never holds the pane at
+   * `opacity: 0` for the beat `closingId` keeps it rendered.
+   */
+  @media (prefers-reduced-motion: reduce) {
+    .ko-comparison-pane[data-open],
+    .ko-comparison-pane[data-closing] {
+      animation: none;
+    }
+  }
+
   /* --- Calculating -----------------------------------------------------------
    * Ported from kalkulacka-2026/packages/ui/src/calculating/calculating.module.css.
    *


### PR DESCRIPTION
Part 16 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #529. **Checkpoint C7.**

Ported from `kalkulacka-2026/apps/web/components/comparison-pane.tsx`, `lib/use-drag-dismiss.ts` and `packages/ui/src/comparison-list`:

- **`ComparisonPane`**: tapping a party opens its answers next to yours, question by question, in the pane that also holds the dashboard: a bottom sheet on phones (slide up, drag the grip down to dismiss, with the source's velocity and distance thresholds) and a static right column on desktop. Filters Vše / Shody / Neshody / Důležité appear only when non-zero; the heading receives focus on open; Escape closes (ignored while a dialog is open) and focus returns to the row that opened it; the exit beat keeps the pane rendered for 150 ms and picking another party mid-exit cuts it short.
- **`ComparisonList`** (design system): you and the candidate in two fixed mark columns so 42 rows read straight down, never re-sorted by agreement, with the candidate's comment as a watermark quote.
- **Names**: the organization and candidate view models gain `name` (full) and `shortName`; the ranking and the pane heading use the full name, the pane's columns, avatar stacks and topic rows the short one, as the prototype does. `displayName` is untouched for the legacy screens.
- Also aligns the result page's pane gap with the prototype's spacing scale.

Verified against the 2026 app at 375 and 1280 px: open, filters, Escape and focus return, mid-exit switch, the phone sheet drag. 59 new tests.

**Checks:** typecheck, lint, tests (app 363, design-system 422, CZ 6, SK 6), Czech app build, Czech Playwright flow (30 passed).

**Stack:** based on #529 → next: `port/17-comparison-page` (checkpoint C8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
