### PR TITLE
Add the answers comparison page

### DIFF
--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/comparison.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/comparison.tsx
@@ -1,29 +1,87 @@
-import { useAnswers, useCalculatedMatches, useCalculator, useQuestions, useResult } from "@kalkulacka-one/app/client";
+import { type ComparisonFilter, ComparisonPage } from "@kalkulacka-one/app";
+import { useAnswersStore, useCalculatedMatches, useCalculator } from "@kalkulacka-one/app/client";
+import { IconButton } from "@kalkulacka-one/design-system/client";
+import { icons } from "@kalkulacka-one/design-system/icons";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useLocale } from "next-intl";
 
-import { ComparisonPage } from "@/calculator";
-import { useEmbed } from "@/components/client";
-import { type RouteSegments, routes } from "@/lib/routing";
+import { HideOnEmbed, useEmbed } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
+import { saveSessionData } from "@/lib/api";
+import { reportError } from "@/lib/monitoring";
+import { COMPARISON_FILTER_PARAM, comparisonFilterQuery, parseComparisonFilter, type RouteSegments, routes } from "@/lib/routing";
 
 export function ComparisonPageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const calculator = useCalculator();
-  const algorithmMatches = useCalculatedMatches();
-  const result = useResult(algorithmMatches);
-  const answers = useAnswers();
-  const questions = useQuestions();
   const embed = useEmbed();
+  const answersStore = useAnswersStore((state) => state.answers);
+  const algorithmMatches = useCalculatedMatches();
   const locale = useLocale();
 
-  const handlePreviousClick = () => {
+  // A group calculator (`snemovni-2025/kalkulacka`) is named by its group and
+  // variant keys; a standalone one by its own key. Neither carries a display
+  // name in the data, hence the config.
+  const { electionName, calculatorName } = calculatorNames({
+    group: "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined,
+    key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    fallback: calculator.title || undefined,
+  });
+
+  // In an embed the wordmark doubles as the attribution — the one way out of a
+  // partner's iframe to the full site — unless the partner opted out of it.
+  const attributionHref = embed.isEmbed && embed.config?.attribution !== false ? (process.env.NEXT_PUBLIC_CANONICAL_URL ?? "/") : undefined;
+  const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
+
+  const comparisonRoute = routes.comparison(segments, locale);
+
+  /*
+   * `?filtr=dulezite` or `?filtr=<topic slug>`, as the results page's dashboard
+   * links write it. Read once, on arrival: the page keeps its own filter from
+   * there, and `handleFilterChange` keeps the address bar in step.
+   */
+  const initialFilter = parseComparisonFilter(searchParams.get(COMPARISON_FILTER_PARAM));
+
+  const handleBackClick = () => {
     router.push(routes.result(segments, locale));
   };
 
-  const handleCloseClick = () => {
+  const handleFilterChange = (filter: ComparisonFilter | undefined) => {
+    // The URL keeps up without a navigation: the screen already has the data
+    // for every filter, and a server round-trip would only re-fetch it.
+    window.history.replaceState(null, "", `${comparisonRoute}${comparisonFilterQuery(filter)}`);
+  };
+
+  const handleCloseClick = async () => {
+    try {
+      const hasValidMatches = algorithmMatches?.some((match) => match.match !== undefined);
+
+      if (answersStore.length > 0 && hasValidMatches) {
+        await saveSessionData(calculator.id, answersStore, algorithmMatches, calculator.version);
+      }
+    } catch (error) {
+      reportError(error);
+    }
     router.push("/");
   };
 
-  return <ComparisonPage embedContext={embed} calculator={calculator} result={result} answers={answers} questions={questions} onPreviousClick={handlePreviousClick} onCloseClick={handleCloseClick} />;
+  return (
+    <ComparisonPage
+      appTitle="Volební kalkulačka"
+      electionName={electionName}
+      calculatorName={calculatorName}
+      initialFilter={initialFilter}
+      headerActions={
+        <HideOnEmbed>
+          <IconButton icon={icons.close} label="Zavřít" variant="surface" onClick={handleCloseClick} />
+        </HideOnEmbed>
+      }
+      attributionHref={attributionHref}
+      logoMonochrome={logoMonochrome}
+      onBackClick={handleBackClick}
+      onFilterChange={handleFilterChange}
+    />
+  );
 }

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/result.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/result.tsx
@@ -13,15 +13,7 @@ import { calculatorNames } from "@/config/calculator-names";
 import { useAutoSave } from "@/hooks/auto-save";
 import { saveSessionData } from "@/lib/api";
 import { reportError } from "@/lib/monitoring";
-import { type RouteSegments, routes } from "@/lib/routing";
-
-/**
- * The comparison view's filter, as a query parameter — `?filtr=dulezite` for
- * the starred questions, `?filtr=<topic slug>` for one theme. A stand-in
- * until the comparison page itself is ported and defines the deep link.
- */
-const FILTER_PARAM = "filtr";
-const IMPORTANT_FILTER = "dulezite";
+import { comparisonFilterQuery, type RouteSegments, routes } from "@/lib/routing";
 
 export function ResultPageWithRouting({ segments }: { segments: RouteSegments }) {
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
@@ -72,12 +64,14 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
     router.push(comparisonRoute);
   };
 
+  // The dashboard's deep links into the comparison — the same `?filtr=` the
+  // comparison page reads on arrival (see `lib/routing/comparison-filter.ts`).
   const handleCompareTopicClick = (topicSlug: string) => {
-    router.push(`${comparisonRoute}?${FILTER_PARAM}=${encodeURIComponent(topicSlug)}`);
+    router.push(`${comparisonRoute}${comparisonFilterQuery({ topic: topicSlug })}`);
   };
 
   const handleCompareImportantClick = () => {
-    router.push(`${comparisonRoute}?${FILTER_PARAM}=${IMPORTANT_FILTER}`);
+    router.push(`${comparisonRoute}${comparisonFilterQuery("important")}`);
   };
 
   const handleCloseClick = async () => {

--- a/apps/www.volebnikalkulacka.cz/lib/routing/comparison-filter.test.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/routing/comparison-filter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { COMPARISON_FILTER_PARAM, comparisonFilterQuery, parseComparisonFilter } from "./comparison-filter";
+
+describe("comparisonFilterQuery", () => {
+  it("writes nothing for everything", () => {
+    expect(comparisonFilterQuery(undefined)).toBe("");
+  });
+
+  it("writes the starred questions and a topic slug on the one parameter", () => {
+    expect(comparisonFilterQuery("important")).toBe(`?${COMPARISON_FILTER_PARAM}=dulezite`);
+    expect(comparisonFilterQuery({ topic: "zivotni-prostredi" })).toBe(`?${COMPARISON_FILTER_PARAM}=zivotni-prostredi`);
+  });
+
+  it("escapes what a slug should never contain, rather than trusting it", () => {
+    expect(comparisonFilterQuery({ topic: "a b&c" })).toBe(`?${COMPARISON_FILTER_PARAM}=a%20b%26c`);
+  });
+});
+
+describe("parseComparisonFilter", () => {
+  it("reads a missing or empty parameter as everything", () => {
+    expect(parseComparisonFilter(null)).toBeUndefined();
+    expect(parseComparisonFilter(undefined)).toBeUndefined();
+    expect(parseComparisonFilter("")).toBeUndefined();
+  });
+
+  it("reads the starred questions and leaves any other value to the page as a topic slug", () => {
+    expect(parseComparisonFilter("dulezite")).toBe("important");
+    expect(parseComparisonFilter("doprava")).toEqual({ topic: "doprava" });
+  });
+
+  it("round-trips", () => {
+    for (const filter of [undefined, "important" as const, { topic: "skolstvi" }]) {
+      const query = comparisonFilterQuery(filter);
+      expect(parseComparisonFilter(new URLSearchParams(query).get(COMPARISON_FILTER_PARAM))).toEqual(filter);
+    }
+  });
+});

--- a/apps/www.volebnikalkulacka.cz/lib/routing/comparison-filter.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/routing/comparison-filter.ts
@@ -1,0 +1,36 @@
+import type { ComparisonFilter } from "@kalkulacka-one/app";
+
+/**
+ * The comparison view's filter, as a query parameter.
+ *
+ * The URL grammar of kalkulacka-2026/apps/web/lib/comparison-filters.ts, where
+ * the filter was a route segment (`/porovnani/dulezite`, `/porovnani/<topic>`).
+ * This app's routes have no such segment, so the same two forms ride on
+ * `?filtr=` instead: `dulezite` is the starred questions, a topic slug one
+ * theme, and no parameter at all is everything — which is what lets a
+ * dashboard card be a plain link and a filtered view survive being shared.
+ * The topic slug is the app package's `topicSlug`, so a link written by the
+ * results page and one typed by hand resolve the same way.
+ */
+export const COMPARISON_FILTER_PARAM = "filtr";
+
+const IMPORTANT_SLUG = "dulezite";
+
+/** `?filtr=…` for a filter, or the empty string for everything — ready to append to the comparison route. */
+export function comparisonFilterQuery(filter: ComparisonFilter | undefined): string {
+  if (filter === undefined) return "";
+
+  const value = filter === "important" ? IMPORTANT_SLUG : filter.topic;
+  return `?${COMPARISON_FILTER_PARAM}=${encodeURIComponent(value)}`;
+}
+
+/**
+ * The inverse, from the raw parameter. Whether a topic slug names a real topic
+ * is the page's call — it has the calculator's topics, this does not — and a
+ * slug that names none degrades to everything there rather than to a 404.
+ */
+export function parseComparisonFilter(value: string | null | undefined): ComparisonFilter | undefined {
+  if (!value) return undefined;
+  if (value === IMPORTANT_SLUG) return "important";
+  return { topic: value };
+}

--- a/apps/www.volebnikalkulacka.cz/lib/routing/index.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/routing/index.ts
@@ -1,3 +1,4 @@
+export * from "./comparison-filter";
 export * from "./params-mapper";
 export * from "./prefixes";
 export * from "./route-builders";

--- a/packages/app/src/components/comparison-page.test.tsx
+++ b/packages/app/src/components/comparison-page.test.tsx
@@ -1,0 +1,342 @@
+import type { Answer, CandidatesAnswers } from "@kalkulacka-one/schema";
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AnswersStoreContext, CalculatorStoreContext, createAnswersStore, createCalculatorStore } from "@/client/stores";
+import type { CalculatorData } from "@/data-fetching";
+import { csMessages } from "@/locales";
+
+import { ComparisonPage } from "./comparison-page";
+import { LocaleProvider } from "./providers";
+
+const questionIds = ["11111111-1111-4111-8111-111111111111", "22222222-2222-4222-8222-222222222222", "33333333-3333-4333-8333-333333333333", "44444444-4444-4444-8444-444444444444"] as const;
+const [q1, q2, q3, q4] = questionIds;
+const topics = ["Doprava", "Doprava", "Školství", "Školství"];
+
+const ids = {
+  alfa: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  beta: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+  gama: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  delta: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+} as const;
+
+type CandidateAnswers = CandidatesAnswers[string];
+
+const answersFor = (entries: Partial<Record<(typeof questionIds)[number], { answer: boolean | null; comment?: string }>>): CandidateAnswers =>
+  Object.entries(entries).map(([questionId, { answer, comment }]) => ({ questionId, answer, ...(comment ? { comment } : {}) }));
+
+/*
+ * Against the reader's answers below (yes, no starred, skipped, "nevím"):
+ *
+ *   beta   yes, no, –, –                        → +1 +2 = +3/3 → 100 %, the winner
+ *   alfa   yes (with a comment), yes, no, yes   → +1 −2 = −1/3 → 33 %
+ *   gama   no, yes, –, –                        → −1 −2 = −3/3 → 0 %
+ *   delta  "nevím" on q1, q2 and q4 (with a comment on q4), nothing on q3
+ *
+ * So the calculator's order (alfa, beta, gama, delta) is not the ranking's,
+ * which is what the face order inside a stack is checked against.
+ */
+const candidatesAnswers: CandidatesAnswers = {
+  [ids.alfa]: answersFor({ [q1]: { answer: true, comment: "Souhlasíme, i když s výhradami." }, [q2]: { answer: true }, [q3]: { answer: false }, [q4]: { answer: true } }),
+  [ids.beta]: answersFor({ [q1]: { answer: true }, [q2]: { answer: false } }),
+  [ids.gama]: answersFor({ [q1]: { answer: false }, [q2]: { answer: true } }),
+  [ids.delta]: answersFor({ [q1]: { answer: null }, [q2]: { answer: null }, [q4]: { answer: null, comment: "Záleží na okolnostech." } }),
+};
+
+const calculatorData: CalculatorData = {
+  data: {
+    calculator: { id: "00000000-0000-4000-8000-000000000000", createdAt: new Date(0).toISOString(), key: "kalkulacka", shortTitle: "Sněmovní 2025" },
+    questions: questionIds.map((id, index) => ({ id, title: `Otázka ${index + 1}`, statement: `Tvrzení ${index + 1}`, tags: [topics[index] ?? ""] })),
+    candidates: [
+      { id: ids.alfa, displayName: "Alfa", references: [] },
+      { id: ids.beta, displayName: "Beta", references: [] },
+      { id: ids.gama, displayName: "Gama", references: [] },
+      { id: ids.delta, displayName: "Delta", references: [] },
+    ],
+    candidatesAnswers,
+  },
+  baseUrl: "https://data.kalkulacka.one/kalkulacka",
+};
+
+const userAnswers: Answer[] = [{ questionId: q1, answer: true }, { questionId: q2, answer: false, isImportant: true }, { questionId: q3 }, { questionId: q4, answer: null }];
+
+/** The same answers with nothing starred — for the case where "Důležité" would leave nothing. */
+const unstarredAnswers: Answer[] = userAnswers.map((answer) => ({ ...answer, isImportant: undefined }));
+
+type RenderOptions = {
+  answers?: Answer[];
+  props?: Partial<ComparisonPage>;
+};
+
+function renderPage({ answers = userAnswers, props = {} }: RenderOptions = {}) {
+  const onBackClick = vi.fn();
+  const onFilterChange = vi.fn();
+  const answersStore = createAnswersStore();
+  answersStore.getState().setAnswers(answers);
+
+  const result = render(
+    <LocaleProvider locale="cs" messages={csMessages}>
+      <CalculatorStoreContext.Provider value={createCalculatorStore(calculatorData)}>
+        <AnswersStoreContext.Provider value={answersStore}>
+          <ComparisonPage appTitle="Volební kalkulačka" electionName="Sněmovní volby 2025" calculatorName="Volební kalkulačka" onBackClick={onBackClick} onFilterChange={onFilterChange} {...props} />
+        </AnswersStoreContext.Provider>
+      </CalculatorStoreContext.Provider>
+    </LocaleProvider>,
+  );
+
+  return { ...result, onBackClick, onFilterChange };
+}
+
+/* The app bar, found from its wordmark. */
+const appHeader = () => screen.getByText("Volební kalkulačka", { selector: "p" }).closest("header");
+
+/* The question list is the first list on the page; the groups inside an open card and a stack's popover are lists of their own. */
+const questionList = () => screen.getAllByRole("list")[0] as HTMLElement;
+const rows = () => Array.from(questionList().children) as HTMLElement[];
+const toggle = (row: HTMLElement) => within(row).getByRole("button", { name: /^Tvrzení/ });
+const statements = () => rows().map((row) => toggle(row).textContent);
+/* By accessible name, where the starred marker follows without the space `textContent` keeps. */
+const row = (statement: string) => screen.getByRole("button", { name: new RegExp(`^${statement}( ?\\(Pro mě důležité\\))?$`) }).closest("li") as HTMLElement;
+
+const chips = () => within(screen.getByRole("group", { name: "Filtrovat otázky" })).getAllByRole("button");
+const chip = (label: string) => screen.getByRole("button", { name: new RegExp(`^${label}\\d*$`) });
+
+/* A group inside an open card, found from its heading — "Ano2Vy" is the label, the count and the tag run together. */
+const group = (row: HTMLElement, heading: RegExp) => within(row).getByRole("heading", { level: 3, name: heading }).closest("section") as HTMLElement;
+const groupHeadings = (row: HTMLElement) =>
+  within(row)
+    .getAllByRole("heading", { level: 3 })
+    .map((heading) => heading.textContent);
+const partyNames = (section: HTMLElement) =>
+  within(section)
+    .getAllByRole("listitem")
+    .map((item) => within(item).getByText(/^(Alfa|Beta|Gama|Delta)$/).textContent);
+
+/* The popover a stack opens: its rows are avatar plus name, and the name is the last child. */
+const stackNames = (stack: HTMLElement) => {
+  const panel = document.getElementById(stack.getAttribute("aria-controls") ?? "") as HTMLElement;
+  return within(panel)
+    .getAllByRole("listitem")
+    .map((item) => item.lastElementChild?.textContent);
+};
+
+describe("ComparisonPage", () => {
+  describe("the screen", () => {
+    it("titles the screen, describes it, and offers the way back", () => {
+      const { onBackClick } = renderPage();
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Porovnání odpovědí");
+      expect(screen.getByText("Jak strany odpovídaly na jednotlivé otázky")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: "Zpět na výsledky" }));
+      expect(onBackClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("names the election and the calculator in the header, with the actions and the attribution link when given", () => {
+      renderPage({ props: { headerActions: <button type="button">Zavřít</button>, attributionHref: "https://www.volebnikalkulacka.cz" } });
+      expect(appHeader()).toHaveTextContent("Sněmovní volby Volební kalkulačka 2025");
+      expect(appHeader()).toContainElement(screen.getByRole("button", { name: "Zavřít" }));
+      expect(screen.getByRole("link")).toHaveAttribute("href", "https://www.volebnikalkulacka.cz");
+    });
+
+    it("lists every question in order, the skipped one included, all collapsed", () => {
+      renderPage();
+      // The starred one carries its off-screen marker inside the toggle's name.
+      expect(statements()).toEqual(["Tvrzení 1", "Tvrzení 2 (Pro mě důležité)", "Tvrzení 3", "Tvrzení 4"]);
+      for (const entry of rows()) {
+        expect(toggle(entry)).toHaveAttribute("aria-expanded", "false");
+      }
+    });
+  });
+
+  describe("a collapsed row", () => {
+    it("shows the reader's mark inside the stack that matches their answer", () => {
+      renderPage();
+
+      const first = row("Tvrzení 1");
+      const yourMark = within(first).getByRole("img", { name: "Vy: Ano" });
+      expect(yourMark).toHaveClass("ko:bg-agree");
+      // The "Vy" pill sits in the same pair as the mark, ahead of the faces.
+      expect(yourMark.parentElement).toHaveTextContent("Vy");
+      expect(within(first).getByRole("button", { name: "Odpověděly ano" })).toBeInTheDocument();
+      expect(within(first).getByRole("button", { name: "Odpověděly ne" })).toBeInTheDocument();
+      expect(within(first).queryByRole("img", { name: /^Vy: (Ne|Nevím|Bez odpovědi)$/ })).toBeNull();
+
+      const second = row("Tvrzení 2");
+      const yourNo = within(second).getByRole("img", { name: "Vy: Ne" });
+      expect(yourNo.parentElement).toHaveTextContent("Vy");
+      expect(within(second).getByRole("button", { name: "Odpověděly ne" })).toBeInTheDocument();
+    });
+
+    it("draws a pair of its own for a skipped or neutral answer, and no stack where nobody stands", () => {
+      renderPage();
+
+      // q3: nobody said yes and the reader took no side — so no "ano" pair at all, and the fallback pair carries "Vy".
+      const third = row("Tvrzení 3");
+      expect(within(third).getByRole("img", { name: "Vy: Bez odpovědi" })).toBeInTheDocument();
+      expect(within(third).queryByRole("button", { name: "Odpověděly ano" })).toBeNull();
+      expect(within(third).getByRole("button", { name: "Odpověděly ne" })).toBeInTheDocument();
+      expect(third.querySelector("[data-has-fallback]")).not.toBeNull();
+
+      // q4: an explicit "nevím" is a real answer, drawn as one.
+      const fourth = row("Tvrzení 4");
+      expect(within(fourth).getByRole("img", { name: "Vy: Nevím" })).toHaveClass("ko:bg-neutral-ink");
+      expect(within(fourth).queryByRole("button", { name: "Odpověděly ne" })).toBeNull();
+
+      expect(row("Tvrzení 1").querySelector("[data-has-fallback]")).toBeNull();
+    });
+
+    it("orders the faces in a stack by the reader's ranking, not the calculator's", () => {
+      renderPage();
+
+      // q1's "ano": alfa and beta in data order, beta first by ranking.
+      const yesStack = within(row("Tvrzení 1")).getByRole("button", { name: "Odpověděly ano" });
+      fireEvent.click(yesStack);
+      expect(stackNames(yesStack)).toEqual(["Beta", "Alfa"]);
+
+      // q2's "ano": alfa (33 %) ahead of gama (0 %).
+      const secondStack = within(row("Tvrzení 2")).getByRole("button", { name: "Odpověděly ano" });
+      fireEvent.click(secondStack);
+      expect(stackNames(secondStack)).toEqual(["Alfa", "Gama"]);
+    });
+  });
+
+  describe("expanding", () => {
+    it("opens the three groups with their counts and the reader's tag, and puts the summary line away", () => {
+      renderPage();
+      const first = row("Tvrzení 1");
+      fireEvent.click(toggle(first));
+
+      expect(toggle(first)).toHaveAttribute("aria-expanded", "true");
+      expect(first).toHaveAttribute("data-expanded");
+      expect(groupHeadings(first)).toEqual(["Ano2Vy", "Ne1", "Nevím / bez odpovědi1"]);
+      expect(within(first).queryByRole("button", { name: "Odpověděly ano" })).toBeNull();
+      expect(within(first).queryByRole("img", { name: "Vy: Ano" })).toBeNull();
+
+      // Faces by ranking inside the group too, each party's comment straight under its name.
+      const yes = group(first, /^Ano/);
+      expect(partyNames(yes)).toEqual(["Beta", "Alfa"]);
+      expect(within(yes).getByText("Souhlasíme, i když s výhradami.")).toBeInTheDocument();
+      expect(partyNames(group(first, /^Ne1/))).toEqual(["Gama"]);
+      expect(partyNames(group(first, /^Nevím/))).toEqual(["Delta"]);
+
+      // The other rows stay as they were.
+      expect(toggle(row("Tvrzení 2"))).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("collapses again on a second press", () => {
+      renderPage();
+      const first = row("Tvrzení 1");
+      fireEvent.click(toggle(first));
+      fireEvent.click(toggle(first));
+
+      expect(toggle(first)).toHaveAttribute("aria-expanded", "false");
+      expect(first).not.toHaveAttribute("data-expanded");
+      expect(within(first).queryByRole("heading", { level: 3 })).toBeNull();
+      expect(within(first).getByRole("button", { name: "Odpověděly ano" })).toBeInTheDocument();
+    });
+
+    it("tags the group holding the reader's own side, whichever it is", () => {
+      renderPage();
+
+      const second = row("Tvrzení 2");
+      fireEvent.click(toggle(second));
+      expect(groupHeadings(second)).toEqual(["Ano2", "Ne1Vy", "Nevím / bez odpovědi1"]);
+
+      const third = row("Tvrzení 3");
+      fireEvent.click(toggle(third));
+      expect(groupHeadings(third)).toEqual(["Ne1", "Nevím / bez odpovědi3Vy"]);
+    });
+
+    it("marks each party in the merged group, telling an explicit shrug from silence", () => {
+      renderPage();
+      const fourth = row("Tvrzení 4");
+      fireEvent.click(toggle(fourth));
+
+      const other = group(fourth, /^Nevím/);
+      // Neutrals first — delta's "nevím" with its comment — then the silent, in data order.
+      expect(partyNames(other)).toEqual(["Delta", "Beta", "Gama"]);
+      expect(
+        within(other)
+          .getAllByRole("img")
+          .map((mark) => mark.getAttribute("aria-label")),
+      ).toEqual(["Nevím", "Bez odpovědi", "Bez odpovědi"]);
+      expect(within(other).getByText("Záleží na okolnostech.")).toBeInTheDocument();
+      // The yes/no groups say it in the header instead.
+      expect(within(group(fourth, /^Ano/)).queryByRole("img")).toBeNull();
+    });
+  });
+
+  describe("filters", () => {
+    it("offers everything, the starred questions and every topic, counted", () => {
+      renderPage();
+      expect(chips().map((entry) => entry.textContent)).toEqual(["Vše4", "Důležité1", "Doprava2", "Školství2"]);
+      expect(chip("Vše")).toHaveAttribute("aria-pressed", "true");
+    });
+
+    it("narrows the list to the chip picked and tells the app which one, in route terms", () => {
+      const { onFilterChange } = renderPage();
+
+      fireEvent.click(chip("Důležité"));
+      expect(statements()).toEqual(["Tvrzení 2 (Pro mě důležité)"]);
+      expect(onFilterChange).toHaveBeenLastCalledWith("important");
+
+      fireEvent.click(chip("Školství"));
+      expect(statements()).toEqual(["Tvrzení 3", "Tvrzení 4"]);
+      expect(onFilterChange).toHaveBeenLastCalledWith({ topic: "skolstvi" });
+
+      fireEvent.click(chip("Vše"));
+      expect(statements()).toEqual(["Tvrzení 1", "Tvrzení 2 (Pro mě důležité)", "Tvrzení 3", "Tvrzení 4"]);
+      expect(onFilterChange).toHaveBeenLastCalledWith(undefined);
+      expect(onFilterChange).toHaveBeenCalledTimes(3);
+    });
+
+    it("collapses every open card when the filter changes", () => {
+      renderPage();
+      fireEvent.click(toggle(row("Tvrzení 1")));
+      expect(toggle(row("Tvrzení 1"))).toHaveAttribute("aria-expanded", "true");
+
+      fireEvent.click(chip("Doprava"));
+      expect(statements()).toEqual(["Tvrzení 1", "Tvrzení 2 (Pro mě důležité)"]);
+      expect(toggle(row("Tvrzení 1"))).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("offers the starred filter only when something is starred", () => {
+      renderPage({ answers: unstarredAnswers });
+      expect(chips().map((entry) => entry.textContent)).toEqual(["Vše4", "Doprava2", "Školství2"]);
+    });
+
+    it("says so when a filter leaves nothing, and offers the way out", () => {
+      const { onFilterChange } = renderPage({ answers: unstarredAnswers, props: { initialFilter: "important" } });
+      expect(screen.getByText("Tomuhle filtru neodpovídá žádná otázka.")).toBeInTheDocument();
+      expect(screen.queryAllByRole("list")).toHaveLength(0);
+
+      fireEvent.click(screen.getByRole("button", { name: "Zobrazit všechny" }));
+      expect(statements()).toHaveLength(4);
+      expect(chip("Vše")).toHaveAttribute("aria-pressed", "true");
+      expect(onFilterChange).toHaveBeenLastCalledWith(undefined);
+    });
+  });
+
+  describe("arriving with a filter", () => {
+    it("starts on the starred questions", () => {
+      renderPage({ props: { initialFilter: "important" } });
+      expect(chip("Důležité")).toHaveAttribute("aria-pressed", "true");
+      expect(statements()).toEqual(["Tvrzení 2 (Pro mě důležité)"]);
+    });
+
+    it("starts on a topic named by its slug", () => {
+      renderPage({ props: { initialFilter: { topic: "skolstvi" } } });
+      expect(chip("Školství")).toHaveAttribute("aria-pressed", "true");
+      expect(statements()).toEqual(["Tvrzení 3", "Tvrzení 4"]);
+    });
+
+    it("falls back to everything for a slug that names no topic", () => {
+      const { onFilterChange } = renderPage({ props: { initialFilter: { topic: "neznamy" } } });
+      expect(chip("Vše")).toHaveAttribute("aria-pressed", "true");
+      expect(statements()).toHaveLength(4);
+      // Arrival is not a change: the URL is the app's to keep, not to rewrite unasked.
+      expect(onFilterChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/app/src/components/comparison-page.tsx
+++ b/packages/app/src/components/comparison-page.tsx
@@ -1,0 +1,643 @@
+"use client";
+
+// Ported from kalkulacka-2026/apps/web/components/answers-comparison.tsx (+ answers-comparison.module.css). The
+// route half of its filter is `comparisonFilterToId` / `comparisonFilterFromId` in `@/recap`; the address bar itself
+// belongs to the app's wrapper, since this platform's routes carry the filter as a query rather than a segment.
+import { AvatarStack, type AvatarStackItem, Button, FilterChips, Icon } from "@kalkulacka-one/design-system/client";
+import { icons } from "@kalkulacka-one/design-system/icons";
+import { AnswerMark, type AnswerMarkTone, AppHeader, Avatar, Shell, Tag, VisuallyHidden } from "@kalkulacka-one/design-system/server";
+
+import { useTranslations } from "next-intl";
+import { type ReactNode, useMemo, useState } from "react";
+
+import { answersByQuestion, answerTone } from "@/answers";
+import { useAnswersStore } from "@/client/stores";
+import { useAnswerGroups, useCalculatedMatches, useQuestions, useRecapTotals, useResult } from "@/client/view-models";
+import type { CandidatePosition } from "@/insights";
+import {
+  type ComparisonFilter,
+  comparisonFilterFromId,
+  comparisonFilterToId,
+  countRecapTopics,
+  matchesRecapFilter,
+  RECAP_FILTER_ALL,
+  RECAP_FILTER_IMPORTANT,
+  type RecapFilterId,
+  type RecapFilterOption,
+  topicFilterId,
+} from "@/recap";
+import { avatarSrc } from "@/view-models";
+
+export type ComparisonPage = {
+  /** The header wordmark text, e.g. "Volební kalkulačka" — the product name, owned by the app. */
+  appTitle: string;
+  /** The election's display name, e.g. "Sněmovní volby 2025". */
+  electionName?: string;
+  /** The calculator's display name — the header's subtitle. */
+  calculatorName: string;
+  /**
+   * The filter the reader arrived with — from the URL, or a dashboard link.
+   * Absent = everything. Read once, on arrival: the page keeps its own filter
+   * from there and reports every change through `onFilterChange`.
+   */
+  initialFilter?: ComparisonFilter;
+  /** Right side of the header: today the app's close button, later the menu. */
+  headerActions?: ReactNode;
+  /** Embeds: makes the wordmark an outbound link to the full site. */
+  attributionHref?: string;
+  logoMonochrome?: boolean;
+  /** "Zpět na výsledky" — the app takes the reader back to the ranking. */
+  onBackClick: () => void;
+  /**
+   * A chip was picked: `undefined` for everything, else the filter in route
+   * terms. The app keeps the address bar in step so a filtered view survives a
+   * reload or being shared — with a `replaceState`, not a navigation: the
+   * screen already has the data for every filter, and a server round-trip
+   * would only re-fetch it.
+   */
+  onFilterChange?: (filter: ComparisonFilter | undefined) => void;
+};
+
+/** How many faces a collapsed row's stack shows before the "+n" disc. */
+const STACK_MAX = 5;
+
+/** The mark's tone and its accessible name, together: the mark is a bare coloured circle, so the name *is* the answer. */
+type Mark = { tone: AnswerMarkTone; label: string };
+
+/*
+ * A single reading column, unlike the results screen's two panes: this is a
+ * list to be scanned top to bottom, and a second pane would only be somewhere
+ * for the eye to lose its place. The document scrolls (see `scroll="document"`
+ * on the shell), so long comment threads behave like a page, not a widget.
+ *
+ * On a desktop the shell reverts to a fixed frame (the design system's
+ * `styles.css` caps `document` mode back to `overflow: hidden` at 64rem), so
+ * the screen scrolls internally: the header and the filter row stay put, the
+ * question list is what moves — the same division the recap makes.
+ */
+const screenClasses =
+  "koa:flex-1 koa:min-h-0 koa:flex koa:pl-[calc(var(--ko-spacing-fluid-gutter)+env(safe-area-inset-left,0px))] koa:pr-[calc(var(--ko-spacing-fluid-gutter)+env(safe-area-inset-right,0px))] koa:lg:overflow-hidden";
+
+/* Narrower than the results screen's 80rem: one column of statements reads
+   best at text width, and the stacks never need more. */
+const innerClasses = "koa:flex-1 koa:min-h-0 koa:flex koa:flex-col koa:gap-5 koa:w-full koa:max-w-[52rem] koa:mx-auto koa:pt-4 koa:lg:pt-8 koa:pb-(--ko-spacing-scroll-tail)";
+
+const headClasses = "koa:flex-none koa:flex koa:flex-col koa:items-start koa:gap-3";
+
+/* `Button` takes no `className`, so the alignment lives on a wrapper — the same one every screen's back link wears. */
+const backClasses = "koa:inline-flex koa:self-start koa:max-w-full";
+
+/* The results screen's title, to the letter — this screen opens from it. The
+   back link precedes it, hence the same clearance every screen gives a
+   headline under a control. */
+const titleClasses =
+  "koa:m-0 koa:mt-1 koa:font-(family-name:--ko-font-display) koa:text-(length:--ko-text-title) koa:font-bold koa:tracking-[-0.045em] koa:leading-[1.1] koa:text-(--ko-color-text) koa:text-balance";
+
+const descriptionClasses = "koa:m-0 koa:max-w-[32rem] koa:text-[0.9375rem] koa:leading-[1.45] koa:text-(--ko-color-text-muted) koa:text-pretty";
+
+const filtersClasses = "koa:flex-none koa:min-w-0";
+
+const emptyClasses = "koa:flex koa:flex-col koa:items-start koa:gap-4 koa:py-6";
+const emptyTextClasses = "koa:m-0 koa:text-[0.9375rem] koa:text-(--ko-color-text-muted)";
+
+/*
+ * The entrance (`--ko-animate-recap-list-in`) is replayed on every filter
+ * change via the `key={filter}` remount below — the same "new result landing"
+ * cue the recap and the comparison pane give.
+ *
+ * From `lg` the list is the screen's scroller. The padding/negative-margin
+ * pair is the recap's trick too: `overflow-y: auto` clips at the padding box,
+ * and without the extra room the rows' focus rings and hover growth would be
+ * sliced off at the edges.
+ */
+const listClasses = [
+  "koa:flex koa:flex-col koa:gap-3 koa:m-0 koa:p-0 koa:list-none",
+  "koa:animate-(--ko-animate-recap-list-in) koa:motion-reduce:animate-none",
+  "koa:lg:flex-1 koa:lg:min-h-0 koa:lg:overflow-y-auto koa:lg:px-2 koa:lg:pt-2 koa:lg:pb-6 koa:lg:-mx-2 koa:lg:-mt-2",
+].join(" ");
+
+/*
+ * One question. The same card the dashboard uses, so the view reads as the
+ * results screen unfolded rather than a different product.
+ *
+ * `relative` anchors the toggle's stretched overlay below — the whole
+ * collapsed card is clickable through it. Scale-not-lift on hover and the
+ * pressed-in active state are `MatchRow`'s own values, so reaching for a
+ * question feels like reaching for a party.
+ */
+const rowClasses = [
+  "koa:relative koa:flex koa:flex-col",
+  "koa:rounded-(--ko-radius-control) koa:bg-(--ko-color-surface) koa:shadow-[inset_0_0_0_1.5px_var(--ko-color-border)]",
+  "koa:[transition:box-shadow_var(--ko-duration-base)_ease,scale_var(--ko-duration-base)_var(--ko-ease-spring)]",
+].join(" ");
+
+/*
+ * Hover reads off the toggle, not the card: the stretched overlay makes the
+ * two the same surface everywhere *except* the avatar stacks, which sit above
+ * it — hovering a stack previews its popover and should not also promise the
+ * card is about to open. Only while collapsed: an expanded card is mostly
+ * reading surface, and a card that swells under a reader chasing a comment is
+ * noise.
+ */
+const rowCollapsedClasses = [
+  "koa:has-[[data-toggle]:hover]:scale-(--ko-pressable-scale-hover) koa:has-[[data-toggle]:hover]:shadow-[inset_0_0_0_1.5px_var(--ko-color-border),var(--ko-shadow-card-back)]",
+  "koa:has-[[data-toggle]:active]:scale-[0.99] koa:has-[[data-toggle]:active]:[transition-duration:var(--ko-duration-fast)]",
+].join(" ");
+
+/*
+ * The toggle is the statement line — and, while the card is collapsed, the
+ * stretched overlay (`toggleOverlayClasses`) extends its hit area over the
+ * whole card, meta line and whitespace included. The avatar stacks stay
+ * clickable because they come *after* the toggle in the DOM: both the overlay
+ * and a stack's root are positioned with no z-index, and positioned boxes
+ * paint in tree order, so the stack lands on top without a z-index of its own
+ * — which matters, because a z-index on a wrapper would cap the stack's open
+ * popover under the next card's faces. A nested-button structure is what this
+ * dodges: the stacks are buttons of their own and cannot live inside this one.
+ *
+ * Roomier inset from `lg` — and the chevron stops hugging the rounded corner
+ * for free.
+ */
+const toggleClasses = [
+  "koa:flex koa:items-start koa:gap-3 koa:w-full",
+  "koa:px-4 koa:pt-4 koa:pb-2 koa:lg:px-5 koa:lg:pt-5 koa:lg:pb-3",
+  "koa:border-0 koa:bg-transparent koa:text-inherit koa:text-left koa:cursor-pointer",
+  "koa:rounded-t-(--ko-radius-control)",
+  "koa:focus-visible:outline-3 koa:focus-visible:-outline-offset-2 koa:focus-visible:outline-(--ko-color-focus)/55",
+].join(" ");
+
+const toggleOverlayClasses = "koa:after:content-[''] koa:after:absolute koa:after:inset-0 koa:after:rounded-(--ko-radius-control)";
+
+const statementClasses = "koa:flex-1 koa:min-w-0 koa:font-(family-name:--ko-font-sans) koa:text-sm koa:leading-[1.45] koa:text-(--ko-color-text)";
+
+const starClasses = "koa:inline-block koa:h-[13px] koa:w-auto koa:align-[-0.15em] koa:mr-1.5 koa:text-(--ko-color-text-muted)";
+
+/* Optically level with the statement's first line. */
+const chevronClasses = "koa:flex-none koa:inline-flex koa:items-center koa:mt-0.5 koa:text-(--ko-color-text-muted)";
+const chevronIconClasses = "koa:size-[1.125rem]";
+
+/*
+ * The collapsed card's summary line. On a phone the pairs flow and wrap; from
+ * `lg` they sit in fixed columns instead, so the marks line up vertically card
+ * after card and the list can be read straight down a column of beads.
+ * `contents` on the stacks wrapper dissolves it into the grid; the explicit
+ * column on each pair keeps "ne" in its own column even on a question where
+ * nobody answered "ano".
+ *
+ * No reserved column for the skip/neutral fallback pair here — it used to
+ * always claim column 1, leaving it empty (and its width plus the gap beside
+ * it as dead indent) on every card that got an ordinary yes/no answer, which
+ * is nearly all of them. The agree pair now opens column 1 itself, flush with
+ * the statement text above it. `metaFallbackClasses` re-adds the reserved
+ * column only for the handful of cards that actually render the fallback
+ * pair, auto-sized to that pair's own content, at the cost of those specific
+ * cards' "ano" not lining up with everyone else's — an acceptable trade since
+ * cross-card bead alignment matters far less than the indent did.
+ *
+ * Column 1 ("ano") is sized for its fullest occupant — mark, "Vy" tag, a full
+ * face stack with overflow counter — so the tag never wraps the counter onto
+ * a second line.
+ */
+const metaBaseClasses = "koa:flex koa:flex-wrap koa:items-center koa:gap-x-5 koa:gap-y-3 koa:px-4 koa:pb-4 koa:lg:px-5 koa:lg:pb-5 koa:lg:grid koa:lg:items-center";
+const metaClasses = `${metaBaseClasses} koa:lg:grid-cols-[16rem_minmax(0,1fr)]`;
+const metaFallbackClasses = `${metaBaseClasses} koa:lg:grid-cols-[auto_16rem_minmax(0,1fr)]`;
+
+const stacksClasses = "koa:inline-flex koa:flex-wrap koa:items-center koa:gap-x-5 koa:gap-y-2 koa:lg:contents";
+
+/*
+ * One side's summary — the mark, an optional "Vy" tag, the face stack. No
+ * separate "your answer" row any more: the tag moves into whichever pair
+ * matches the reader's own answer instead (see the row for why), so this
+ * same pair has to hold three things some of the time and two the rest, hence
+ * the wrap-friendly `inline-flex` rather than a fixed slot count.
+ */
+const pairClasses = "koa:inline-flex koa:items-center koa:gap-2";
+
+/*
+ * The fallback pair for a skipped or explicit "nevím" answer, which matches
+ * neither face stack this summary shows (it only ever draws the yes/no groups
+ * — see the merged third group in the expanded card for where "nevím" gets
+ * its own row). Same mark-plus-tag shape as a matching pair.
+ *
+ * On the phone's wrapping flow the pair is narrow enough to share a line with
+ * a party stack, where it reads as part of that stack's answer. A full-row
+ * basis gives it the line to itself, and `order` moves it up to where the old
+ * "your answer" row sat — neither applies on desktop, where `contents`
+ * dissolves the flex context and the grid seats it in its own column.
+ */
+const fallbackPairClasses = "koa:whitespace-nowrap koa:basis-full koa:-order-1 koa:lg:col-start-1";
+
+/* Sits directly under the statement now that the open card drops its summary
+   line, so it carries the gap the summary line used to provide. */
+const bodyClasses = "koa:flex koa:flex-col koa:gap-5 koa:px-4 koa:pt-2 koa:pb-4 koa:lg:px-5 koa:lg:pb-5";
+
+/*
+ * The border between groups is the *only* horizontal rule inside the expanded
+ * card — individual party rows carry none — so it reads as the one place Ano
+ * hands off to Ne hands off to Nevím. It stays on the same hairline colour as
+ * every other border in the app: it is a boundary between sections, not
+ * something that should out-weigh the card's own edge.
+ *
+ * Your side is marked by the "Vy" tag in the group's header and nothing else
+ * — no tinted container, by explicit request. The tag rather than reordering
+ * is what keeps the party order best-match-first in every group.
+ */
+const groupClasses = "koa:border-t-[1.5px] koa:border-solid koa:border-(--ko-color-border) koa:pt-4 koa:first:border-t-0 koa:first:pt-0";
+
+/*
+ * A real heading, set as such: body size and bold, the same rung the party
+ * names below it read at. It had been small uppercase, which made the one word
+ * that names each group — Ano, Ne — look like a field label rather than the
+ * answer it is.
+ */
+const groupHeadClasses = "koa:flex koa:items-center koa:gap-2 koa:m-0 koa:mb-3 koa:font-(family-name:--ko-font-sans) koa:text-sm koa:font-bold koa:text-(--ko-color-text-strong)";
+
+/*
+ * A fixed-width column for every mark this card draws — every group header's
+ * mark — so the text beside them all starts at the same x regardless of
+ * whether the icon in that slot is a 1.5rem `AnswerMark` or a 2rem `Avatar`
+ * (which fills the slot exactly and needs no wrapper of its own). Without
+ * this a group's smaller mark left its label sitting to the left of where a
+ * party row's avatar leaves its name, and the whole card read as two
+ * uncoordinated columns rather than one.
+ */
+const groupIconClasses = "koa:flex-none koa:inline-flex koa:items-center koa:justify-center koa:w-8";
+const groupLabelClasses = "koa:min-w-0";
+const groupCountClasses = "koa:font-medium koa:text-(--ko-color-text-muted) koa:tabular-nums";
+const groupListClasses = "koa:flex koa:flex-col koa:gap-3 koa:m-0 koa:p-0 koa:list-none";
+
+/* No divider between rows on purpose — see `groupClasses` above. Vertical
+   rhythm alone is what separates one party from the next. */
+const partyClasses = "koa:flex koa:flex-col koa:gap-1";
+const partyLineClasses = "koa:flex koa:items-center koa:gap-3 koa:min-h-8";
+const partyNameClasses = "koa:flex-1 koa:min-w-0 koa:font-(family-name:--ko-font-sans) koa:text-[0.8125rem] koa:text-(--ko-color-text)";
+
+/*
+ * The party's own words — always shown, no disclosure — marked by the same
+ * raised-quote watermark the 1:1 comparison uses, so a comment reads as the
+ * same kind of thing in both places.
+ *
+ * A flex row rather than padding plus an absolutely-positioned glyph: the mark
+ * then *sits in* the same 2rem column the avatar above it occupies and the
+ * text starts at exactly the party name's x, with no offsets to keep in sync
+ * by hand. That is what the absolute version got wrong — it was placed
+ * against the paragraph's own box, so it drifted with every comment length.
+ */
+const commentClasses = "koa:flex koa:gap-3 koa:m-0 koa:font-(family-name:--ko-font-sans) koa:text-[0.8125rem] koa:leading-[1.45] koa:text-(--ko-color-text-muted) koa:text-pretty";
+
+/*
+ * U+201C is a *raised* mark: its ink sits high in the em box, nowhere near the
+ * baseline the box is positioned from. Left to the normal flow it therefore
+ * floats a good half-line above the text it opens, which is what made it read
+ * as debris in the margin.
+ *
+ * `leading-none` pins the glyph's box to its own em, and the nudge is
+ * measured, not guessed: at this size the ink's centre lands 7.4px below the
+ * box top, while the first line's cap band centres at 9.3px — so ~2px down
+ * puts the mark level with the words beside it. Recheck it if the display face
+ * ever changes; the number belongs to that face's outlines.
+ */
+const quoteClasses =
+  "koa:flex-none koa:w-8 koa:mt-0.5 koa:font-(family-name:--ko-font-display) koa:text-[1.75rem] koa:leading-none koa:text-center koa:text-(--ko-color-text-muted)/35 koa:pointer-events-none koa:select-none";
+
+/**
+ * One party's row inside an expanded question — face, name and, where the
+ * party left one, their own comment straight underneath. Not collapsible: a
+ * reader who opened the question already asked to see this level of detail,
+ * and a comment hidden behind a second click inside an already-open
+ * disclosure is one click too many.
+ *
+ * `mark` adds the party's own answer mark — wanted only in the merged
+ * "nevím / bez odpovědi" group, where the mark is what tells an explicit
+ * shrug from silence; in the yes/no groups the group header already says it.
+ */
+function PartyRow({ position, mark }: { position: CandidatePosition; mark?: Mark }) {
+  const { candidate, comment } = position;
+
+  return (
+    <li className={partyClasses}>
+      <div className={partyLineClasses}>
+        <Avatar name={candidate.name} src={avatarSrc(candidate)} size="small" />
+        <span className={partyNameClasses}>{candidate.name}</span>
+
+        {mark ? <AnswerMark tone={mark.tone} label={mark.label} size="small" /> : null}
+      </div>
+
+      {comment ? (
+        <p className={commentClasses}>
+          <span className={quoteClasses} aria-hidden="true">
+            “
+          </span>
+          {comment}
+        </p>
+      ) : null}
+    </li>
+  );
+}
+
+/**
+ * One side of a question — everyone who gave this answer.
+ *
+ * `you` marks the group holding the reader's own position with a plain "Vy"
+ * tag, neutral-toned rather than agree-toned: the tag says whose side this is,
+ * not that the side is good — a green pill under "Ne" would read as praise for
+ * having disagreed. No tinted container either, by request; the tag alone is
+ * what keeps the party order (best-match-first) undisturbed by any
+ * re-sorting.
+ *
+ * Shared by all three groups — including the merged "nevím / bez odpovědi"
+ * one, via `icon`/`markOf` — so a header never has to duplicate this
+ * structure by hand.
+ */
+function AnswerGroup({
+  icon,
+  label,
+  positions,
+  you,
+  youLabel,
+  markOf,
+}: {
+  icon: ReactNode;
+  label: string;
+  positions: CandidatePosition[];
+  you: boolean;
+  youLabel: string;
+  markOf?: (position: CandidatePosition) => Mark;
+}) {
+  if (positions.length === 0) return null;
+
+  return (
+    <section className={groupClasses} data-you={you || undefined}>
+      <h3 className={groupHeadClasses}>
+        <span className={groupIconClasses}>{icon}</span>
+        <span className={groupLabelClasses}>{label}</span>
+        <span className={groupCountClasses}>{positions.length}</span>
+        {you ? <Tag tone="neutral">{youLabel}</Tag> : null}
+      </h3>
+
+      <ul className={groupListClasses}>
+        {positions.map((position) => (
+          <PartyRow key={position.candidate.id} position={position} mark={markOf?.(position)} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+/**
+ * Every party's answer to every question, side by side with the reader's own.
+ *
+ * The question-centric counterpart of the per-candidate comparison pane: that
+ * one asks "how does this party line up with me overall", this one asks "who
+ * stands where on this question". Rows collapse to a scannable line — the
+ * statement, your mark, and two face stacks — because forty questions times
+ * nine parties in full would be a wall; the stacks' popover answers "whose
+ * faces are those" without opening anything.
+ *
+ * Unlike the pane this includes questions the reader skipped: the subject
+ * here is the parties' positions, and a question you didn't answer still has
+ * nine of those worth reading.
+ *
+ * A button rather than a link for the way back, like the other screens: the
+ * app owns the routes, and the page only says where the reader wants to go.
+ */
+export function ComparisonPage({ appTitle, electionName, calculatorName, initialFilter, headerActions, attributionHref, logoMonochrome, onBackClick, onFilterChange }: ComparisonPage) {
+  const t = useTranslations("koa.components.comparisonPage");
+
+  const { questions } = useQuestions();
+  const answers = useAnswersStore((state) => state.answers);
+  const lookup = useMemo(() => answersByQuestion(answers), [answers]);
+  const groups = useAnswerGroups();
+  const { matches } = useResult(useCalculatedMatches());
+  const { total, important } = useRecapTotals();
+
+  const topics = useMemo(() => countRecapTopics(questions), [questions]);
+
+  const [filter, setFilter] = useState<RecapFilterId>(() =>
+    comparisonFilterToId(
+      initialFilter,
+      topics.map(([topic]) => topic),
+    ),
+  );
+  /** Which questions are open, by id. Reset when the filter changes. */
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+
+  /*
+   * The ranking decides the order of faces inside every group: the stacks are
+   * a sample (the first five), and the sample should be the parties the reader
+   * has most reason to recognise — the ones at the top of their result.
+   */
+  const rankOf = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const entry of matches) {
+      map.set(entry.candidate.id, entry.order ?? Number.MAX_SAFE_INTEGER);
+    }
+    return map;
+  }, [matches]);
+
+  const ranked = useMemo(() => {
+    const byRank = (a: CandidatePosition, b: CandidatePosition) => (rankOf.get(a.candidate.id) ?? Number.MAX_SAFE_INTEGER) - (rankOf.get(b.candidate.id) ?? Number.MAX_SAFE_INTEGER);
+
+    // `other` keeps the builder's order — neutrals ahead of the silent — so
+    // an explicit "nevím" with a comment isn't buried under empty rows.
+    return groups.map((entry) => ({
+      ...entry,
+      yes: [...entry.yes].sort(byRank),
+      no: [...entry.no].sort(byRank),
+    }));
+  }, [groups, rankOf]);
+
+  const visible = useMemo(() => ranked.filter((entry) => matchesRecapFilter(entry.question, answers, filter)), [ranked, answers, filter]);
+
+  // "Důležité" only when it would leave something — the same rule the recap's
+  // own chips follow. Topics always follow, separated by a hairline because
+  // they answer a different question from the progress filter.
+  const filterOptions: RecapFilterOption[] = [
+    { id: RECAP_FILTER_ALL, label: t("filterAll"), count: total },
+    ...(important > 0 ? [{ id: RECAP_FILTER_IMPORTANT, label: t("filterImportant"), count: important } satisfies RecapFilterOption] : []),
+    ...topics.map(([topic, count], index) => ({
+      id: topicFilterId(topic),
+      label: topic,
+      count,
+      separatorBefore: index === 0,
+    })),
+  ];
+
+  /**
+   * How an answer reads aloud — the accessible name behind a mark. The mark is
+   * a bare coloured circle, so this string *is* the answer as far as a screen
+   * reader is concerned; the tone that draws it is `answerTone`'s, and this is
+   * its counterpart for the words — the same four the recap rows use.
+   */
+  const answerLabel = (tone: AnswerMarkTone) => {
+    if (tone === "agree") return t("yes");
+    if (tone === "disagree") return t("no");
+    if (tone === "neutral") return t("neutral");
+    return t("none");
+  };
+
+  const markOf = (questionId: string, answer: boolean | null | undefined): Mark => {
+    const tone = answerTone({ questionId, answer });
+    return { tone, label: answerLabel(tone) };
+  };
+
+  const changeFilter = (id: RecapFilterId) => {
+    setFilter(id);
+    setExpanded(new Set());
+    onFilterChange?.(comparisonFilterFromId(id));
+  };
+
+  const toggleQuestion = (id: string) => {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const faces = (positions: CandidatePosition[]): AvatarStackItem[] => positions.map(({ candidate }) => ({ id: candidate.id, name: candidate.shortName, src: avatarSrc(candidate) }));
+
+  const youTag = (
+    <Tag tone="neutral">
+      {/* The mark beside it already reads "Vy: Ano" aloud; the pill is for the eye. */}
+      <span aria-hidden="true">{t("you")}</span>
+    </Tag>
+  );
+
+  return (
+    <Shell
+      scroll="document"
+      header={<AppHeader title={appTitle} electionName={electionName} calculatorName={calculatorName} href={attributionHref} logoMonochrome={logoMonochrome} actions={headerActions} />}
+    >
+      <main className={screenClasses}>
+        <div className={innerClasses}>
+          <header className={headClasses}>
+            <span className={backClasses}>
+              <Button variant="plate" size="small" iconStart={icons.chevronLeftThin} onClick={onBackClick}>
+                {t("back")}
+              </Button>
+            </span>
+            <h1 className={titleClasses}>{t("title")}</h1>
+            <p className={descriptionClasses}>{t("description")}</p>
+          </header>
+
+          <div className={filtersClasses}>
+            <FilterChips label={t("filterLabel")} options={filterOptions} value={filter} onChange={(id) => changeFilter(id as RecapFilterId)} />
+          </div>
+
+          {visible.length === 0 ? (
+            <div className={emptyClasses}>
+              <p className={emptyTextClasses}>{t("emptyFilter")}</p>
+              <Button variant="surface" size="small" onClick={() => changeFilter(RECAP_FILTER_ALL)}>
+                {t("emptyFilterAction")}
+              </Button>
+            </div>
+          ) : (
+            /* Keyed on the filter so switching it replays the entrance
+               animation — the same "new result landing" cue the recap and the
+               comparison pane give. */
+            <ul className={listClasses} key={filter}>
+              {visible.map((entry) => {
+                const answer = lookup.get(entry.question.id);
+                const isExpanded = expanded.has(entry.question.id);
+                const isImportant = answer?.isImportant === true;
+                const userAnswer = answer?.answer;
+                // Only the skipped/neutral answer draws the fallback pair — see
+                // `fallbackPairClasses` — and only those cards need the desktop
+                // grid's reserved first column, so the row's own markup carries
+                // that fact rather than duplicating the condition in the CSS.
+                const hasFallbackPair = userAnswer !== true && userAnswer !== false;
+                const userMark = markOf(entry.question.id, userAnswer);
+
+                return (
+                  <li key={entry.question.id} className={isExpanded ? rowClasses : `${rowClasses} ${rowCollapsedClasses}`} data-expanded={isExpanded || undefined}>
+                    <button
+                      type="button"
+                      className={isExpanded ? toggleClasses : `${toggleClasses} ${toggleOverlayClasses}`}
+                      data-toggle=""
+                      aria-expanded={isExpanded}
+                      onClick={() => toggleQuestion(entry.question.id)}
+                    >
+                      <span className={statementClasses}>
+                        {isImportant ? <Icon icon={icons.star} size={null} filled decorative className={starClasses} /> : null}
+                        {entry.question.statement || entry.question.title}
+                        {isImportant ? <VisuallyHidden> ({t("important")})</VisuallyHidden> : null}
+                      </span>
+
+                      <span className={chevronClasses}>
+                        <Icon icon={isExpanded ? icons.chevronUpThin : icons.chevronDownThin} size={null} decorative className={chevronIconClasses} />
+                      </span>
+                    </button>
+
+                    {/*
+                      The summary line belongs to the collapsed card only. Open,
+                      the groups below say the same thing at full length — and
+                      which of them is the reader's own is carried by the "Vy"
+                      tag on that group's heading, so repeating their mark up
+                      here would be the answer stated twice.
+
+                      There is no separate "your answer" row any more: it used
+                      to sit above the two stacks wearing a text label where
+                      every other row wears a face, so the eye had to parse a
+                      column that only sometimes held avatars. Instead the "Vy"
+                      tag moves *into* whichever stack matches — same "Vy" pill
+                      the expanded groups already use, reused rather than
+                      reinvented, immediately before that row's faces. A
+                      skipped or neutral answer matches no stack (this summary
+                      never shows the merged "nevím" group), so it falls back
+                      to its own pair with the tag and no faces.
+                    */}
+                    {isExpanded ? null : (
+                      <div className={hasFallbackPair ? metaFallbackClasses : metaClasses} data-has-fallback={hasFallbackPair || undefined}>
+                        <span className={stacksClasses}>
+                          {entry.yes.length > 0 || userAnswer === true ? (
+                            <span className={`${pairClasses} ${hasFallbackPair ? "koa:lg:col-start-2" : "koa:lg:col-start-1"}`}>
+                              <AnswerMark tone="agree" size="small" label={userAnswer === true ? `${t("you")}: ${answerLabel("agree")}` : undefined} />
+                              {userAnswer === true ? youTag : null}
+                              {entry.yes.length > 0 ? <AvatarStack items={faces(entry.yes)} max={STACK_MAX} label={t("stackYes")} popover={{ closeLabel: t("close") }} /> : null}
+                            </span>
+                          ) : null}
+
+                          {entry.no.length > 0 || userAnswer === false ? (
+                            <span className={`${pairClasses} koa:lg:justify-self-start ${hasFallbackPair ? "koa:lg:col-start-3" : "koa:lg:col-start-2"}`}>
+                              <AnswerMark tone="disagree" size="small" label={userAnswer === false ? `${t("you")}: ${answerLabel("disagree")}` : undefined} />
+                              {userAnswer === false ? youTag : null}
+                              {entry.no.length > 0 ? <AvatarStack items={faces(entry.no)} max={STACK_MAX} label={t("stackNo")} popover={{ closeLabel: t("close") }} /> : null}
+                            </span>
+                          ) : null}
+
+                          {hasFallbackPair ? (
+                            <span className={`${pairClasses} ${fallbackPairClasses}`}>
+                              <AnswerMark tone={userMark.tone} label={`${t("you")}: ${userMark.label}`} size="small" />
+                              {youTag}
+                            </span>
+                          ) : null}
+                        </span>
+                      </div>
+                    )}
+
+                    {isExpanded ? (
+                      <div className={bodyClasses}>
+                        <AnswerGroup icon={<AnswerMark tone="agree" size="small" />} label={t("yes")} positions={entry.yes} you={userAnswer === true} youLabel={t("you")} />
+                        <AnswerGroup icon={<AnswerMark tone="disagree" size="small" />} label={t("no")} positions={entry.no} you={userAnswer === false} youLabel={t("you")} />
+                        <AnswerGroup
+                          icon={<AnswerMark tone="neutral" size="small" />}
+                          label={t("groupOther")}
+                          positions={entry.other}
+                          you={hasFallbackPair}
+                          youLabel={t("you")}
+                          markOf={(position) => markOf(entry.question.id, position.answer)}
+                        />
+                      </div>
+                    ) : null}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      </main>
+    </Shell>
+  );
+}

--- a/packages/app/src/components/index.ts
+++ b/packages/app/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "./comparison-page";
 export * from "./comparison-pane";
 export * from "./comparison-question-card";
 export * from "./embed-attribution";

--- a/packages/app/src/components/results-dashboard.tsx
+++ b/packages/app/src/components/results-dashboard.tsx
@@ -11,7 +11,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { answerTone } from "@/answers";
 import { type AnswerDistribution, MIN_TOPIC_ANSWERS, type QuestionConsensus, type TopicMatch, topicIcon } from "@/insights";
 import { copyText } from "@/utilities";
-import type { CandidateViewModel } from "@/view-models";
+import { avatarSrc } from "@/view-models";
 
 export type ResultsDashboard = {
   distribution: AnswerDistribution;
@@ -157,13 +157,6 @@ const promptClasses = [
 
 const promptActionsClasses = "koa:flex koa:items-center koa:gap-3 koa:flex-wrap";
 const promptNoteClasses = `${noteClasses} koa:flex-1 koa:min-w-48`;
-
-/** The smallest picture the data layer serves — a stack of faces needs no more. */
-function avatarSrc(candidate: CandidateViewModel): string | undefined {
-  const urls = candidate.avatar?.urls;
-  if (!urls) return undefined;
-  return urls.xs ?? urls.sm ?? urls.md ?? urls.original;
-}
 
 /**
  * A question with how much company you had on it — shared by two of the cards.

--- a/packages/app/src/locales/cs.json
+++ b/packages/app/src/locales/cs.json
@@ -1,6 +1,26 @@
 {
   "koa": {
     "components": {
+      "comparisonPage": {
+        "title": "Porovnání odpovědí",
+        "description": "Jak strany odpovídaly na jednotlivé otázky",
+        "back": "Zpět na výsledky",
+        "filterLabel": "Filtrovat otázky",
+        "filterAll": "Vše",
+        "filterImportant": "Důležité",
+        "you": "Vy",
+        "groupOther": "Nevím / bez odpovědi",
+        "stackYes": "Odpověděly ano",
+        "stackNo": "Odpověděly ne",
+        "close": "Zavřít",
+        "emptyFilter": "Tomuhle filtru neodpovídá žádná otázka.",
+        "emptyFilterAction": "Zobrazit všechny",
+        "important": "Pro mě důležité",
+        "yes": "Ano",
+        "no": "Ne",
+        "neutral": "Nevím",
+        "none": "Bez odpovědi"
+      },
       "comparisonPane": {
         "close": "Zavřít porovnání",
         "filterLabel": "Filtrovat odpovědi",

--- a/packages/app/src/locales/en.json
+++ b/packages/app/src/locales/en.json
@@ -1,6 +1,26 @@
 {
   "koa": {
     "components": {
+      "comparisonPage": {
+        "title": "Answer comparison",
+        "description": "How the parties answered each question",
+        "back": "Back to results",
+        "filterLabel": "Filter questions",
+        "filterAll": "All",
+        "filterImportant": "Important",
+        "you": "You",
+        "groupOther": "Don't know / no answer",
+        "stackYes": "Answered yes",
+        "stackNo": "Answered no",
+        "close": "Close",
+        "emptyFilter": "No question matches this filter.",
+        "emptyFilterAction": "Show all",
+        "important": "Important to me",
+        "yes": "Yes",
+        "no": "No",
+        "neutral": "Don't know",
+        "none": "No answer"
+      },
       "comparisonPane": {
         "close": "Close comparison",
         "filterLabel": "Filter answers",

--- a/packages/app/src/locales/mk.json
+++ b/packages/app/src/locales/mk.json
@@ -1,6 +1,26 @@
 {
   "koa": {
     "components": {
+      "comparisonPage": {
+        "title": "Споредба на одговорите",
+        "description": "Како партиите одговараа на одделните прашања",
+        "back": "Назад кон резултатите",
+        "filterLabel": "Филтрирај прашања",
+        "filterAll": "Сите",
+        "filterImportant": "Важни",
+        "you": "Вие",
+        "groupOther": "Не знам / без одговор",
+        "stackYes": "Одговорија да",
+        "stackNo": "Одговорија не",
+        "close": "Затвори",
+        "emptyFilter": "Ниедно прашање не одговара на овој филтер.",
+        "emptyFilterAction": "Прикажи ги сите",
+        "important": "Важно за мене",
+        "yes": "Да",
+        "no": "Не",
+        "neutral": "Не знам",
+        "none": "Без одговор"
+      },
       "comparisonPane": {
         "close": "Затвори ја споредбата",
         "filterLabel": "Филтрирај одговори",

--- a/packages/app/src/locales/sk.json
+++ b/packages/app/src/locales/sk.json
@@ -1,6 +1,26 @@
 {
   "koa": {
     "components": {
+      "comparisonPage": {
+        "title": "Porovnanie odpovedí",
+        "description": "Ako strany odpovedali na jednotlivé otázky",
+        "back": "Späť na výsledky",
+        "filterLabel": "Filtrovať otázky",
+        "filterAll": "Všetko",
+        "filterImportant": "Dôležité",
+        "you": "Vy",
+        "groupOther": "Neviem / bez odpovede",
+        "stackYes": "Odpovedali áno",
+        "stackNo": "Odpovedali nie",
+        "close": "Zavrieť",
+        "emptyFilter": "Tomuto filtru nezodpovedá žiadna otázka.",
+        "emptyFilterAction": "Zobraziť všetky",
+        "important": "Pre mňa dôležité",
+        "yes": "Áno",
+        "no": "Nie",
+        "neutral": "Neviem",
+        "none": "Bez odpovede"
+      },
       "comparisonPane": {
         "close": "Zavrieť porovnanie",
         "filterLabel": "Filtrovať odpovede",

--- a/packages/app/src/recap/comparison-filter.test.ts
+++ b/packages/app/src/recap/comparison-filter.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { comparisonFilterFromId, comparisonFilterToId } from "./comparison-filter";
+
+const topics = ["Doprava", "Životní prostředí"];
+
+describe("comparisonFilterToId", () => {
+  it("reads no filter as everything", () => {
+    expect(comparisonFilterToId(undefined, topics)).toBe("all");
+  });
+
+  it("reads the starred questions", () => {
+    expect(comparisonFilterToId("important", topics)).toBe("important");
+  });
+
+  it("resolves a topic slug against the calculator's topics", () => {
+    expect(comparisonFilterToId({ topic: "zivotni-prostredi" }, topics)).toBe("topic:Životní prostředí");
+    expect(comparisonFilterToId({ topic: "doprava" }, topics)).toBe("topic:Doprava");
+  });
+
+  it("degrades a slug that matches nothing to everything rather than failing", () => {
+    expect(comparisonFilterToId({ topic: "neznamy" }, topics)).toBe("all");
+    expect(comparisonFilterToId({ topic: "" }, topics)).toBe("all");
+  });
+});
+
+describe("comparisonFilterFromId", () => {
+  it("says nothing for everything", () => {
+    expect(comparisonFilterFromId("all")).toBeUndefined();
+  });
+
+  it("names the starred questions", () => {
+    expect(comparisonFilterFromId("important")).toBe("important");
+  });
+
+  it("names a topic by its slug", () => {
+    expect(comparisonFilterFromId("topic:Životní prostředí")).toEqual({ topic: "zivotni-prostredi" });
+  });
+
+  it("offers no filter for a topic the URL cannot spell", () => {
+    expect(comparisonFilterFromId("topic:Економија")).toBeUndefined();
+  });
+
+  it("never hands the routes the recap's own progress filter", () => {
+    expect(comparisonFilterFromId("unanswered")).toBeUndefined();
+  });
+
+  it("round-trips through the calculator's topics", () => {
+    for (const topic of topics) {
+      const filter = comparisonFilterFromId(`topic:${topic}`);
+      expect(comparisonFilterToId(filter, topics)).toBe(`topic:${topic}`);
+    }
+  });
+});

--- a/packages/app/src/recap/comparison-filter.ts
+++ b/packages/app/src/recap/comparison-filter.ts
@@ -1,0 +1,47 @@
+// Ported from kalkulacka-2026/apps/web/lib/comparison-filters.ts — the half that turns a route's filter into the
+// recap's filter id and back. The slug half (`slugifyDistrict` there) is `topicSlug` in `@/insights`.
+import { topicFromSlug, topicSlug } from "@/insights";
+
+import { RECAP_FILTER_ALL, RECAP_FILTER_IMPORTANT, RECAP_TOPIC_PREFIX, type RecapFilterId, topicFilterId } from "./recap";
+
+/**
+ * The comparison page's filter as the app's routes see it: the starred
+ * questions, or one topic named by its slug (`topicSlug`) — the form a URL
+ * carries and a dashboard link hands over. `undefined` is everything.
+ *
+ * 2026 wrote this into the route itself (`/porovnani/dulezite`,
+ * `/porovnani/<topic>`), which is what lets a dashboard card be a plain link
+ * and a filtered view survive being shared. This platform's routes have no
+ * such segment, so the app decides where the value goes (the Czech app puts it
+ * in a query); the page only speaks in these terms.
+ */
+export type ComparisonFilter = "important" | { topic: string };
+
+/**
+ * A route's filter as the recap's filter id, resolved against the calculator's
+ * actual topics. Anything that matches nothing — a stale link, a typo —
+ * degrades to "all" rather than an error: the reader still lands on the view
+ * they were promised, just unfiltered.
+ */
+export function comparisonFilterToId(filter: ComparisonFilter | undefined, topics: readonly string[]): RecapFilterId {
+  if (filter === undefined) return RECAP_FILTER_ALL;
+  if (filter === "important") return RECAP_FILTER_IMPORTANT;
+
+  const topic = topicFromSlug(filter.topic, topics);
+  return topic ? topicFilterId(topic) : RECAP_FILTER_ALL;
+}
+
+/**
+ * The inverse — what the page tells the app when a chip is picked. "All" is no
+ * filter at all, and so is a topic whose slug comes out empty (a name with no
+ * Latin letters or digits in it): a filter the URL cannot spell is not offered
+ * to it. The recap's "unanswered" is never a comparison filter; it reads as
+ * "all" too rather than as a value the routes have no word for.
+ */
+export function comparisonFilterFromId(id: RecapFilterId): ComparisonFilter | undefined {
+  if (id === RECAP_FILTER_IMPORTANT) return "important";
+  if (!id.startsWith(RECAP_TOPIC_PREFIX)) return undefined;
+
+  const slug = topicSlug(id.slice(RECAP_TOPIC_PREFIX.length));
+  return slug ? { topic: slug } : undefined;
+}

--- a/packages/app/src/recap/index.ts
+++ b/packages/app/src/recap/index.ts
@@ -1,1 +1,2 @@
+export * from "./comparison-filter";
 export * from "./recap";

--- a/packages/app/src/view-models/candidate.ts
+++ b/packages/app/src/view-models/candidate.ts
@@ -148,6 +148,16 @@ export function candidateViewModel(candidate: Candidate, personsMap: Map<string,
   };
 }
 
+/**
+ * The smallest picture the data layer serves — a stack of faces, or the small
+ * avatar on a party's row, needs no more.
+ */
+export function avatarSrc(candidate: Pick<CandidateViewModel, "avatar">): string | undefined {
+  const urls = candidate.avatar?.urls;
+  if (!urls) return undefined;
+  return urls.xs ?? urls.sm ?? urls.md ?? urls.original;
+}
+
 export type AnswerComparison = {
   questionId: string;
   questionText?: string;


### PR DESCRIPTION
Part 17 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #530. **Checkpoint C8.**

Ported from `kalkulacka-2026/apps/web/components/answers-comparison.tsx` and `lib/comparison-filters.ts`:

- **`ComparisonPage`** ("Porovnání odpovědí"): every question, including skipped ones, as a collapsible card. Collapsed: the agree and disagree marks with stacks of the parties who said Ano and Ne, faces ordered by the reader's own ranking, and a "Vy" tag in whichever group matches (or a fallback pair when you skipped). Expanded: the three groups Ano / Ne / "Nevím / bez odpovědi" with counts and each party's comment as a watermark quote. Filters Vše / Důležité / topics; changing one rewrites the URL without a navigation and collapses everything; an empty filter offers "Zobrazit všechny". On desktop the header and chips stay put and the list scrolls, with the marks aligned in a column.
- **Deep links**: this repository has no route parameter for the filter, so it is a `?filtr=dulezite` / `?filtr=<topic-slug>` query, defined once in the Czech app's routing helpers; the result page's dashboard links use it and the comparison wrapper reads it.
- The shared `avatarSrc` helper moves to the candidate view model.

Verified against the 2026 app at 375 and 1280 px with the same answers: identical chips and counts, identical expanded groups, the important and topic filters, the internal scroll on desktop. 18 page tests plus filter helper tests.

Known limitation, pre-existing: the topic slug strips non-Latin letters, so a Cyrillic topic (Macedonian) gets no deep link; a Unicode-aware slug is a separate change.

**Checks:** typecheck, lint, tests (app 391, design-system 422, CZ 12, SK 6), Czech app build, Czech Playwright flow (30 passed).

**Stack:** based on #530 → next: `port/18-menu` (checkpoint C9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
