### PR TITLE
Track calculator flow events in Plausible

### DIFF
--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/comparison.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/comparison.tsx
@@ -3,9 +3,11 @@ import { useCalculatedMatches, useCalculator } from "@kalkulacka-one/app/client"
 
 import { useRouter, useSearchParams } from "next/navigation";
 import { useLocale } from "next-intl";
+import { useCallback } from "react";
 
 import { CalculatorMenu, useEmbed } from "@/components/client";
 import { calculatorNames } from "@/config/calculator-names";
+import { trackEvent } from "@/lib/analytics";
 import { COMPARISON_FILTER_PARAM, comparisonFilterQuery, parseComparisonFilter, type RouteSegments, routes } from "@/lib/routing";
 
 export function ComparisonPageWithRouting({ segments }: { segments: RouteSegments }) {
@@ -39,6 +41,10 @@ export function ComparisonPageWithRouting({ segments }: { segments: RouteSegment
    */
   const initialFilter = parseComparisonFilter(searchParams.get(COMPARISON_FILTER_PARAM));
 
+  const handleViewed = useCallback(() => {
+    trackEvent("Comparison viewed", { calculator: calculator.id });
+  }, [calculator.id]);
+
   const handleBackClick = () => {
     router.push(routes.result(segments, locale));
   };
@@ -60,6 +66,7 @@ export function ComparisonPageWithRouting({ segments }: { segments: RouteSegment
       logoMonochrome={logoMonochrome}
       onBackClick={handleBackClick}
       onFilterChange={handleFilterChange}
+      onViewed={handleViewed}
     />
   );
 }

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
@@ -8,6 +8,7 @@ import { CalculatorMenu, useEmbed } from "@/components/client";
 import { calculatorNames } from "@/config/calculator-names";
 import { useAutoSave } from "@/hooks/auto-save";
 import { useCalculatorActions } from "@/hooks/calculator-actions";
+import { trackEvent } from "@/lib/analytics";
 import { type RouteSegments, routes } from "@/lib/routing";
 
 export function IntroductionPageWithRouting({ segments }: { segments: RouteSegments }) {
@@ -37,6 +38,10 @@ export function IntroductionPageWithRouting({ segments }: { segments: RouteSegme
   const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
 
   const handleContinueClick = () => {
+    // Fired on the click, not on arrival at the guide: a tap here is the
+    // decision to start, and the tutorial after it is still onboarding, not
+    // a second start worth counting separately.
+    trackEvent("Calculator started", { calculator: calculator.id });
     router.push(routes.guide(segments, locale));
   };
 

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/result.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/result.tsx
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { CalculatorMenu, DonateCard, useEmbed, useSessionStatus } from "@/components/client";
 import { calculatorNames } from "@/config/calculator-names";
 import { useAutoSave } from "@/hooks/auto-save";
+import { trackEvent } from "@/lib/analytics";
 import { saveSessionData, shareSession } from "@/lib/api";
 import { reportError } from "@/lib/monitoring";
 import { canonical, comparisonFilterQuery, type RouteSegments, routes, stripEmbed } from "@/lib/routing";
@@ -122,6 +123,16 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
     }
   }, [calculator.id, canonicalSegments, locale]);
 
+  /*
+   * "Completed" the moment the ranking is first on screen for its owner —
+   * the page gates it past the calculating beat and off a shared result, so
+   * it means the same thing as the ranking `saveSessionData` marks the
+   * session finished with.
+   */
+  const handleRankingShown = useCallback(() => {
+    trackEvent("Calculator completed", { calculator: calculator.id });
+  }, [calculator.id]);
+
   const share = useMemo<ResultPageShare>(
     () => ({
       url: shareUrl,
@@ -129,8 +140,10 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
       // The card's pictures go through the same-origin proxy: the canvas
       // export needs readable pixels, and the data CDN sends no CORS header.
       assetUrl: (url) => toProxiedAssetUrl(url, { assetBase: baseUrl, group: calculatorGroup, key: calculatorKey }) ?? url,
+      // Only a completed hand-off reaches here — the dialog reports nothing for a dismissed sheet or a failure.
+      onShared: (method) => trackEvent("Result shared", { calculator: calculator.id, method }),
     }),
-    [shareUrl, sessionStatus, requestShareLink, baseUrl, calculatorGroup, calculatorKey],
+    [shareUrl, sessionStatus, requestShareLink, baseUrl, calculatorGroup, calculatorKey, calculator.id],
   );
 
   const donateCardPosition = embed.isEmbed ? (embed.config?.donateCard ?? 1) : 5;
@@ -147,6 +160,7 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
       onCompareClick={handleCompareClick}
       onCompareTopicClick={handleCompareTopicClick}
       onCompareImportantClick={handleCompareImportantClick}
+      onRankingShown={handleRankingShown}
       share={share}
       donateCardPosition={donateCardPosition}
       donateCard={

--- a/apps/www.volebnikalkulacka.cz/lib/analytics/index.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/analytics/index.ts
@@ -1,1 +1,2 @@
 export * from "./plausible-event";
+export * from "./track-event";

--- a/apps/www.volebnikalkulacka.cz/lib/analytics/track-event.test.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/analytics/track-event.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { trackEvent } from "./track-event";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(window, "plausible");
+});
+
+describe("trackEvent", () => {
+  it("does nothing when the script never installed window.plausible", () => {
+    expect(window.plausible).toBeUndefined();
+    expect(() => trackEvent("Calculator started", { calculator: "abc" })).not.toThrow();
+  });
+
+  it("does nothing without a window at all — a server render calling it by mistake", () => {
+    vi.stubGlobal("window", undefined);
+    expect(() => trackEvent("Calculator started", { calculator: "abc" })).not.toThrow();
+  });
+
+  it("forwards the event with its props under the `props` key the script expects", () => {
+    const plausible = vi.fn();
+    window.plausible = plausible;
+
+    trackEvent("Calculator completed", { calculator: "abc" });
+    expect(plausible).toHaveBeenCalledWith("Calculator completed", { props: { calculator: "abc" } });
+
+    trackEvent("Result shared", { calculator: "abc", method: "link" });
+    expect(plausible).toHaveBeenLastCalledWith("Result shared", { props: { calculator: "abc", method: "link" } });
+  });
+});

--- a/apps/www.volebnikalkulacka.cz/lib/analytics/track-event.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/analytics/track-event.ts
@@ -1,0 +1,28 @@
+// The custom events the calculator flow reports, fired straight through `window.plausible` — installed by the script
+// variant loaded in `components/server/plausible.tsx`. The class-name route (`plausibleEvent`) stays for the donate card,
+// where the event is a click Plausible can read off the element itself; these fire on outcomes no element carries.
+
+/** The four events, with the props each carries: the calculator's id on every one, and which action completed on the share. */
+export type TrackedEvent = {
+  "Calculator started": { calculator: string };
+  "Calculator completed": { calculator: string };
+  "Comparison viewed": { calculator: string };
+  "Result shared": { calculator: string; method: "image" | "image-copy" | "image-download" | "link" };
+};
+
+declare global {
+  interface Window {
+    /** Installed by the Plausible script tag itself — absent whenever that script never loaded, which is the only signal this module needs. */
+    plausible?: (name: string, options?: { props?: Record<string, string | number | boolean> }) => void;
+  }
+}
+
+/**
+ * Fire a Plausible custom event. A no-op wherever `window.plausible` isn't there to answer — analytics off, the script
+ * blocked or still loading, or a server render calling this by mistake — so every call site can fire and forget without
+ * checking whether analytics is even on.
+ */
+export function trackEvent<Name extends keyof TrackedEvent>(name: Name, props: TrackedEvent[Name]): void {
+  if (typeof window === "undefined") return;
+  window.plausible?.(name, { props });
+}

--- a/packages/app/src/components/comparison-page.test.tsx
+++ b/packages/app/src/components/comparison-page.test.tsx
@@ -72,6 +72,7 @@ type RenderOptions = {
 function renderPage({ answers = userAnswers, props = {} }: RenderOptions = {}) {
   const onBackClick = vi.fn();
   const onFilterChange = vi.fn();
+  const onViewed = vi.fn();
   const answersStore = createAnswersStore();
   answersStore.getState().setAnswers(answers);
 
@@ -79,13 +80,21 @@ function renderPage({ answers = userAnswers, props = {} }: RenderOptions = {}) {
     <LocaleProvider locale="cs" messages={csMessages}>
       <CalculatorStoreContext.Provider value={createCalculatorStore(calculatorData)}>
         <AnswersStoreContext.Provider value={answersStore}>
-          <ComparisonPage appTitle="Volební kalkulačka" electionName="Sněmovní volby 2025" calculatorName="Volební kalkulačka" onBackClick={onBackClick} onFilterChange={onFilterChange} {...props} />
+          <ComparisonPage
+            appTitle="Volební kalkulačka"
+            electionName="Sněmovní volby 2025"
+            calculatorName="Volební kalkulačka"
+            onBackClick={onBackClick}
+            onFilterChange={onFilterChange}
+            onViewed={onViewed}
+            {...props}
+          />
         </AnswersStoreContext.Provider>
       </CalculatorStoreContext.Provider>
     </LocaleProvider>,
   );
 
-  return { ...result, onBackClick, onFilterChange };
+  return { ...result, onBackClick, onFilterChange, onViewed };
 }
 
 /* The app bar, found from its wordmark. */
@@ -146,6 +155,17 @@ describe("ComparisonPage", () => {
       for (const entry of rows()) {
         expect(toggle(entry)).toHaveAttribute("aria-expanded", "false");
       }
+    });
+  });
+
+  describe("reporting the visit", () => {
+    it("reports it once, on arrival, and not again for a filter change or an opened card", () => {
+      const { onViewed } = renderPage();
+      expect(onViewed).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(chip("Doprava"));
+      fireEvent.click(toggle(row("Tvrzení 1")));
+      expect(onViewed).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/app/src/components/comparison-page.tsx
+++ b/packages/app/src/components/comparison-page.tsx
@@ -8,7 +8,7 @@ import { icons } from "@kalkulacka-one/design-system/icons";
 import { AnswerMark, type AnswerMarkTone, AppHeader, Avatar, Shell, Tag, VisuallyHidden } from "@kalkulacka-one/design-system/server";
 
 import { useTranslations } from "next-intl";
-import { type ReactNode, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 
 import { answersByQuestion, answerTone } from "@/answers";
 import { useAnswersStore } from "@/client/stores";
@@ -56,6 +56,12 @@ export type ComparisonPage = {
    * would only re-fetch it.
    */
   onFilterChange?: (filter: ComparisonFilter | undefined) => void;
+  /**
+   * The screen is up — once per mount, on arrival. The app's "viewed" hook;
+   * a filter change or an opened card is the same visit and reports nothing
+   * more.
+   */
+  onViewed?: () => void;
 };
 
 /** How many faces a collapsed row's stack shows before the "+n" disc. */
@@ -401,7 +407,7 @@ function AnswerGroup({
  * A button rather than a link for the way back, like the other screens: the
  * app owns the routes, and the page only says where the reader wants to go.
  */
-export function ComparisonPage({ appTitle, electionName, calculatorName, initialFilter, headerActions, attributionHref, logoMonochrome, onBackClick, onFilterChange }: ComparisonPage) {
+export function ComparisonPage({ appTitle, electionName, calculatorName, initialFilter, headerActions, attributionHref, logoMonochrome, onBackClick, onFilterChange, onViewed }: ComparisonPage) {
   const t = useTranslations("koa.components.comparisonPage");
 
   const { questions } = useQuestions();
@@ -421,6 +427,14 @@ export function ComparisonPage({ appTitle, electionName, calculatorName, initial
   );
   /** Which questions are open, by id. Reset when the filter changes. */
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+
+  /* Once per mount: the ref, not the effect's deps, is what keeps a re-render — or a callback handed in with a fresh identity — from reporting a second visit. */
+  const viewed = useRef(false);
+  useEffect(() => {
+    if (viewed.current) return;
+    viewed.current = true;
+    onViewed?.();
+  }, [onViewed]);
 
   /*
    * The ranking decides the order of faces inside every group: the stacks are

--- a/packages/app/src/components/result-page.test.tsx
+++ b/packages/app/src/components/result-page.test.tsx
@@ -141,6 +141,7 @@ function renderPage({ answers = userAnswers, data = calculatorData, props = {}, 
     onCompareTopicClick: vi.fn(),
     onCompareImportantClick: vi.fn(),
     onShareClick: vi.fn(),
+    onRankingShown: vi.fn(),
     onStartOwnClick: vi.fn(),
   };
   const answersStore = createAnswersStore();
@@ -210,6 +211,47 @@ describe("ResultPage", () => {
       expect(screen.queryByRole("status")).toBeNull();
       expect(heading()).toHaveTextContent("Moje shoda");
       for (const row of rows()) expect((row as HTMLElement).style.animationDelay).toBe("-1s");
+    });
+  });
+
+  describe("reporting the ranking", () => {
+    it("reports it once the rows are on screen — after the beat, not during it — and only once", () => {
+      vi.useFakeTimers();
+      try {
+        const { onRankingShown, answersStore } = renderPage({ seen: false });
+        expect(onRankingShown).not.toHaveBeenCalled();
+
+        act(() => {
+          vi.advanceTimersByTime(CALCULATING_MS);
+        });
+        expect(onRankingShown).toHaveBeenCalledTimes(1);
+
+        // A re-render is the same showing — even one that changes what the guard reads.
+        fireEvent.click(rowButton("Alfa"));
+        fireEvent.click(screen.getByRole("button", { name: /Zobrazit další strany/ }));
+        act(() => {
+          answersStore.getState().setAnswers(userAnswers.slice(0, 3));
+        });
+        expect(onRankingShown).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("reports it straight away on a revisit, where there is no beat to wait out", () => {
+      const { onRankingShown } = renderPage();
+      expect(onRankingShown).toHaveBeenCalledTimes(1);
+    });
+
+    it("reports nothing with nothing answered", () => {
+      const { onRankingShown } = renderPage({ answers: [{ questionId: q1 }] });
+      expect(onRankingShown).not.toHaveBeenCalled();
+    });
+
+    it("reports nothing on a shared result", () => {
+      const { onRankingShown } = renderPage({ seen: false, props: { shared: true } });
+      expect(rows()).toHaveLength(5);
+      expect(onRankingShown).not.toHaveBeenCalled();
     });
   });
 
@@ -762,5 +804,23 @@ describe("sharing", () => {
     renderPage({ props: { share: { onRequestShareLink: vi.fn().mockResolvedValue(null) } } });
     await user.click(screen.getByRole("button", { name: "Sdílet" }));
     expect(within(screen.getByRole("dialog", { name: "Sdílet výsledek" })).getByRole("button", { name: "Kopírovat odkaz" })).toBeInTheDocument();
+  });
+
+  it("tells the app how the result was shared, through the share configuration", async () => {
+    const user = userEvent.setup();
+    // After `setup()`: user-event installs a clipboard stub of its own, and this one has to win.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    try {
+      const onShared = vi.fn();
+      renderPage({ props: { share: { onRequestShareLink: vi.fn().mockResolvedValue("https://example.test/volby/vysledek/abc"), onShared } } });
+
+      await user.click(screen.getByRole("button", { name: "Sdílet" }));
+      await user.click(within(screen.getByRole("dialog", { name: "Sdílet výsledek" })).getByRole("button", { name: "Kopírovat odkaz" }));
+      expect(writeText).toHaveBeenCalledWith("https://example.test/volby/vysledek/abc");
+      expect(onShared).toHaveBeenCalledWith("link");
+    } finally {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
   });
 });

--- a/packages/app/src/components/result-page.tsx
+++ b/packages/app/src/components/result-page.tsx
@@ -7,7 +7,7 @@ import { AppHeader, Screen, Shell, StickyBar } from "@kalkulacka-one/design-syst
 import { prefersReducedMotion } from "@kalkulacka-one/design-system/utilities";
 
 import { useFormatter, useLocale, useTranslations } from "next-intl";
-import { Fragment, type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { Fragment, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { countAnswered } from "@/answers";
 import { useAnswersStore } from "@/client/stores";
@@ -17,7 +17,7 @@ import type { calculateMatches } from "@/result-calculation";
 
 import { ComparisonPane } from "./comparison-pane";
 import { ResultsDashboard } from "./results-dashboard";
-import { ShareDialog } from "./share-dialog";
+import { ShareDialog, type ShareMethod } from "./share-dialog";
 
 /**
  * What the app hands the share dialog — the two things it alone knows: where
@@ -41,6 +41,12 @@ export type ResultPageShare = {
    * it; the rows on screen keep loading the CDN directly.
    */
   assetUrl?: (url: string) => string;
+  /**
+   * An action in the dialog completed — which ones count is `ShareDialog`'s
+   * `onShared` to say. The app's analytics hook; nothing for a dismissed
+   * sheet or a failure.
+   */
+  onShared?: (method: ShareMethod) => void;
 };
 
 export type ResultPage = {
@@ -92,6 +98,15 @@ export type ResultPage = {
    * this is the whole action — the app opens whatever it still shares with.
    */
   onShareClick?: () => void;
+  /**
+   * The owner's ranking is on screen — once per mount, the first time the
+   * rows render: after the calculating beat, never during it, never again
+   * on a re-render, and never on a shared result (the visitor of a public
+   * link completed nothing) or the empty screen (which ranks nothing). The
+   * app's "completed" hook, gated so it means the same thing as the ranking
+   * the app saves.
+   */
+  onRankingShown?: () => void;
   /** Opts the page into the share dialog; the apps that still have a share surface of their own leave it out. */
   share?: ResultPageShare;
   /** A shared result's "Vyplnit vlastní kalkulačku". */
@@ -294,6 +309,7 @@ export function ResultPage({
   onCompareTopicClick,
   onCompareImportantClick,
   onShareClick,
+  onRankingShown,
   share,
   onStartOwnClick,
   donateCard,
@@ -364,6 +380,20 @@ export function ResultPage({
     }, CALCULATING_MS);
     return () => window.clearTimeout(timer);
   }, [shared, calculator.id]);
+
+  /*
+   * Once per mount, the moment the ranking is first on screen for its own
+   * owner. `waited` is in the guard: without it the calculating beat would
+   * be counted, not the result. A ref rather than state, so that a re-render
+   * — a row opened, the tail unfolded, an answer changed under the page —
+   * cannot report it a second time.
+   */
+  const rankingShown = useRef(false);
+  useEffect(() => {
+    if (shared || !waited || answered === 0 || rankingShown.current) return;
+    rankingShown.current = true;
+    onRankingShown?.();
+  }, [shared, waited, answered, onRankingShown]);
 
   /**
    * Whether the ranking's tail (below the fifth row) has been unfolded.
@@ -675,7 +705,15 @@ export function ResultPage({
         session for this calculator, which they have no reason to have.
       */}
       {!shared && share && shareMounted ? (
-        <ShareDialog open={shareOpen} onClose={closeShare} content={shareContent} fileName={`shoda-${calculator.id}`} shareUrl={share.url} onRequestShareLink={share.onRequestShareLink} />
+        <ShareDialog
+          open={shareOpen}
+          onClose={closeShare}
+          content={shareContent}
+          fileName={`shoda-${calculator.id}`}
+          shareUrl={share.url}
+          onRequestShareLink={share.onRequestShareLink}
+          onShared={share.onShared}
+        />
       ) : null}
     </Shell>
   );

--- a/packages/app/src/components/share-dialog.test.tsx
+++ b/packages/app/src/components/share-dialog.test.tsx
@@ -254,6 +254,83 @@ describe("ShareDialog", () => {
     });
   });
 
+  describe("reporting what was shared", () => {
+    it("names the download, and says nothing of one that failed", async () => {
+      const user = userEvent.setup();
+      const onShared = vi.fn();
+      mocks.renderShareCard.mockResolvedValue(png);
+      mocks.downloadImage.mockReturnValue(true);
+      renderDialog({ onShared });
+
+      await user.click(screen.getByRole("button", { name: "Stáhnout" }));
+      expect(onShared).toHaveBeenCalledWith("image-download");
+
+      mocks.renderShareCard.mockResolvedValue(null);
+      await user.click(screen.getByRole("button", { name: "Stáhnout" }));
+      expect(onShared).toHaveBeenCalledTimes(1);
+    });
+
+    it("tells a copied image from the download it fell back to, and says nothing of a failure", async () => {
+      const user = userEvent.setup();
+      const onShared = vi.fn();
+      mocks.copyShareCardImage.mockResolvedValue("copied");
+      renderDialog({ onShared });
+
+      await user.click(screen.getByRole("button", { name: "Zkopírovat obrázek" }));
+      expect(onShared).toHaveBeenLastCalledWith("image-copy");
+
+      mocks.copyShareCardImage.mockResolvedValue("downloaded");
+      await user.click(screen.getByRole("button", { name: "Zkopírovat obrázek" }));
+      expect(onShared).toHaveBeenLastCalledWith("image");
+
+      mocks.copyShareCardImage.mockResolvedValue("failed");
+      await user.click(screen.getByRole("button", { name: "Zkopírovat obrázek" }));
+      expect(onShared).toHaveBeenCalledTimes(2);
+    });
+
+    it("counts the OS sheet, and the download that stood in for it, as the image — never a dismissed sheet or a failure", async () => {
+      const user = userEvent.setup();
+      const onShared = vi.fn();
+      pointer("touch");
+      mocks.canShareImages.mockReturnValue(true);
+      mocks.renderShareCard.mockResolvedValue(png);
+      renderDialog({ onShared });
+      const sheet = () => screen.getByRole("button", { name: "Sdílet obrázek" });
+
+      mocks.shareImage.mockResolvedValue("shared");
+      await user.click(sheet());
+      expect(onShared).toHaveBeenLastCalledWith("image");
+
+      mocks.shareImage.mockResolvedValue("downloaded");
+      await user.click(sheet());
+      expect(onShared).toHaveBeenLastCalledWith("image");
+      expect(onShared).toHaveBeenCalledTimes(2);
+
+      mocks.shareImage.mockResolvedValue("cancelled");
+      await user.click(sheet());
+      mocks.shareImage.mockResolvedValue("failed");
+      await user.click(sheet());
+      expect(onShared).toHaveBeenCalledTimes(2);
+    });
+
+    it("names the link once it is on the clipboard, and says nothing of a mint or a copy that failed", async () => {
+      const user = userEvent.setup();
+      const onShared = vi.fn();
+      const onRequestShareLink = vi.fn().mockResolvedValue("https://example.test/volby/vysledek/abc");
+      mocks.copyText.mockResolvedValue(true);
+      renderDialog({ onRequestShareLink, onShared });
+
+      await user.click(screen.getByRole("button", { name: "Kopírovat odkaz" }));
+      expect(onShared).toHaveBeenCalledWith("link");
+
+      mocks.copyText.mockResolvedValue(false);
+      await user.click(screen.getByRole("button", { name: "Kopírovat odkaz" }));
+      onRequestShareLink.mockResolvedValue(null);
+      await user.click(screen.getByRole("button", { name: "Kopírovat odkaz" }));
+      expect(onShared).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it("clears a message on its own, and sooner for good news than for bad", async () => {
     vi.useFakeTimers();
     mocks.renderShareCard.mockResolvedValue(png);

--- a/packages/app/src/components/share-dialog.tsx
+++ b/packages/app/src/components/share-dialog.tsx
@@ -24,6 +24,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { usePointerKind } from "@/client/hooks";
 import { chooseShareMode, copyText } from "@/utilities";
 
+/** Which of the dialog's actions completed — how the result left the app. */
+export type ShareMethod = "image" | "image-copy" | "image-download" | "link";
+
 export type ShareDialog = {
   open: boolean;
   onClose: () => void;
@@ -49,6 +52,15 @@ export type ShareDialog = {
    * with no dead button explaining what it cannot do.
    */
   onRequestShareLink?: () => Promise<string | null>;
+  /**
+   * An action completed: the OS sheet took the picture — or, where the sheet
+   * fell through, the download that stood in for it — (`image`), the picture
+   * landed on the clipboard (`image-copy`), the file was saved
+   * (`image-download`), or the public link was copied (`link`). Nothing for a
+   * dismissed sheet or a failure: the app's analytics hook counts hand-offs,
+   * not attempts.
+   */
+  onShared?: (method: ShareMethod) => void;
 };
 
 /**
@@ -148,7 +160,7 @@ const statusClasses = "koa:m-0 koa:min-h-5 koa:font-(family-name:--ko-font-sans)
  *    image to the clipboard, or download it — neither of which routes
  *    through that sheet.
  */
-export function ShareDialog({ open, onClose, content, fileName, shareUrl, onRequestShareLink }: ShareDialog) {
+export function ShareDialog({ open, onClose, content, fileName, shareUrl, onRequestShareLink, onShared }: ShareDialog) {
   const t = useTranslations("koa.components.shareDialog");
   const [theme, setTheme] = useState<CardTheme>("light");
   const [cardFormat, setCardFormat] = useState<CardFormat>("story");
@@ -231,10 +243,15 @@ export function ShareDialog({ open, onClose, content, fileName, shareUrl, onRequ
       // nothing to report, and nothing to undo.
       if (result === "cancelled" || result === "shared") setStatus("idle");
       else setStatus(result === "downloaded" ? "saved" : "failed");
+
+      // Both the OS share sheet and the direct-download fallback are a
+      // completed hand-off of the image — a cancelled sheet or a failed
+      // export is not.
+      if (result === "shared" || result === "downloaded") onShared?.("image");
     } catch {
       setStatus("failed");
     }
-  }, [content, theme, cardFormat, exportName, shareUrl]);
+  }, [content, theme, cardFormat, exportName, shareUrl, onShared]);
 
   /**
    * Copy the card straight onto the clipboard, as a PNG.
@@ -251,9 +268,14 @@ export function ShareDialog({ open, onClose, content, fileName, shareUrl, onRequ
         if (result === "copied") setStatus("copied");
         else if (result === "downloaded") setStatus("copyFailedSaved");
         else setStatus("failed");
+
+        // The download the copy fell back to is still the picture leaving
+        // the app: reported as the image, as 2026 does, not as a copy.
+        if (result === "copied") onShared?.("image-copy");
+        else if (result === "downloaded") onShared?.("image");
       })
       .catch(() => setStatus("failed"));
-  }, [content, theme, cardFormat, exportName]);
+  }, [content, theme, cardFormat, exportName, onShared]);
 
   const onDownload = useCallback(async () => {
     setStatus("working");
@@ -261,10 +283,11 @@ export function ShareDialog({ open, onClose, content, fileName, shareUrl, onRequ
       const blob = await renderShareCard({ content, theme, format: cardFormat });
       const ok = blob ? downloadImage(blob, exportName) : false;
       setStatus(ok ? "saved" : "failed");
+      if (ok) onShared?.("image-download");
     } catch {
       setStatus("failed");
     }
-  }, [content, theme, cardFormat, exportName]);
+  }, [content, theme, cardFormat, exportName, onShared]);
 
   /**
    * Turn the result into an address, and put it on the clipboard.
@@ -287,7 +310,8 @@ export function ShareDialog({ open, onClose, content, fileName, shareUrl, onRequ
 
     const copied = await copyText(publicUrl);
     setLinkStatus(copied ? "copied" : "failed");
-  }, [onRequestShareLink]);
+    if (copied) onShared?.("link");
+  }, [onRequestShareLink, onShared]);
 
   /*
    * One line for every action. They cannot be mid-flight and finished at the


### PR DESCRIPTION
Part 21 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #534.

The prototype's four Plausible events, ported from `kalkulacka-2026/apps/web/lib/analytics.ts` and its call sites, fired through `window.plausible` (a no-op when the script is absent):

| Event | Props | Fired |
|---|---|---|
| `Calculator started` | `{ calculator }` | on the intro's "Pokračovat" click, not on arrival at the guide |
| `Calculator completed` | `{ calculator }` | once per visit when the owner's ranking is first on screen (not for a shared result, not on the empty state) |
| `Comparison viewed` | `{ calculator }` | once on the comparison page |
| `Result shared` | `{ calculator, method }` | on each successful share: `image` (the OS sheet, or its download fallback), `image-copy`, `image-download`, `link`; nothing on cancel or failure |

The pages only report the moments (`onRankingShown`, `onViewed`, `share.onShared`); the Czech wrappers own the Plausible call in a typed `trackEvent` helper next to the existing tagged-events helper. Slovak and Macedonian apps are untouched.

**Checks:** typecheck, lint, tests (app, design-system, CZ 7, SK 2), Czech app build, Czech Playwright flow (37 passed).

**Stack:** based on #534 → next: `port/22-sk` (checkpoint C11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
