### PR TITLE
Switch the Macedonian app to the shared calculator pages

### DIFF
--- a/apps/www.izborenkalkulator.mk/app/[locale]/(embed)/embed/[embed]/layout.tsx
+++ b/apps/www.izborenkalkulator.mk/app/[locale]/(embed)/embed/[embed]/layout.tsx
@@ -1,4 +1,6 @@
-import type { Metadata } from "next";
+import { bootstrapColorMode } from "@kalkulacka-one/app";
+
+import type { Metadata, Viewport } from "next";
 import { notFound } from "next/navigation";
 
 import "@/app/globals.css";
@@ -16,6 +18,16 @@ export const metadata: Metadata = {
   },
 };
 
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  // One un-gated tag, corrected before first paint by `bootstrapColorMode`
+  // below — see the site layout for why not a `prefers-color-scheme` pair.
+  // A partner theme resolves its own page colour; this is only the served
+  // guess, the default theme's light page.
+  themeColor: "#f8fafc",
+};
+
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
 }
@@ -27,11 +39,27 @@ export default async function RootLayout({ children, params }: { children: React
   const embed: EmbedName = embedParam;
 
   return (
-    <html lang={locale}>
+    // `suppressHydrationWarning`: the inline script below adds `data-mode`
+    // before hydration, out of step with the server markup on purpose.
+    <html lang={locale} suppressHydrationWarning>
       <head>
         <PlausibleScript />
       </head>
       <body>
+        {/*
+          The same pre-paint colour-mode bootstrap as the site layout. A
+          single-mode partner theme pins `color-scheme: light` in its own
+          stylesheet, which outranks the `data-mode` this writes — so a dark
+          override stored on the main site cannot leak into the partner's
+          palette, while the theme-colour it corrects is still the partner's.
+        */}
+        <script
+          id="color-mode-bootstrap"
+          suppressHydrationWarning
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: `bootstrapColorMode` is a fixed, module-scope string with no user input, not markup built from a request.
+          dangerouslySetInnerHTML={{ __html: bootstrapColorMode }}
+        />
+
         <I18nProvider locale={locale}>
           <EmbedProvider name={embed}>{children}</EmbedProvider>
         </I18nProvider>

--- a/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(app)/(public)/(one-segment)/[first]/result/[publicId]/page.tsx
+++ b/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(app)/(public)/(one-segment)/[first]/result/[publicId]/page.tsx
@@ -1,4 +1,4 @@
-import type { calculateMatches } from "@kalkulacka-one/app";
+import { type calculateMatches, hasAnswer } from "@kalkulacka-one/app";
 import { prisma } from "@kalkulacka-one/database";
 import type { Answer } from "@kalkulacka-one/schema";
 
@@ -44,6 +44,12 @@ export default async function Page({ params }: { params: Promise<{ first: string
 
   const answers = session.data.answers as Answer[];
   const result = session.data.result as ReturnType<typeof calculateMatches>;
+
+  // A session with no answers is not a result: it would render an empty
+  // ranking under a headline claiming somebody's match.
+  if (!answers.some((answer) => hasAnswer(answer))) {
+    notFound();
+  }
 
   return <PublicResultPageWithData algorithmMatches={result} answers={answers} segments={segments} />;
 }

--- a/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(app)/(public)/(three-segments)/[first]/[second]/[third]/result/[publicId]/page.tsx
+++ b/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(app)/(public)/(three-segments)/[first]/[second]/[third]/result/[publicId]/page.tsx
@@ -1,4 +1,4 @@
-import type { calculateMatches } from "@kalkulacka-one/app";
+import { type calculateMatches, hasAnswer } from "@kalkulacka-one/app";
 import { prisma } from "@kalkulacka-one/database";
 import type { Answer } from "@kalkulacka-one/schema";
 
@@ -46,6 +46,12 @@ export default async function Page({ params }: { params: Promise<{ first: string
 
   const answers = session.data.answers as Answer[];
   const result = session.data.result as ReturnType<typeof calculateMatches>;
+
+  // A session with no answers is not a result: it would render an empty
+  // ranking under a headline claiming somebody's match.
+  if (!answers.some((answer) => hasAnswer(answer))) {
+    notFound();
+  }
 
   return <PublicResultPageWithData algorithmMatches={result} answers={answers} segments={segments} />;
 }

--- a/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(app)/(public)/(two-segments)/[first]/[second]/result/[publicId]/page.tsx
+++ b/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(app)/(public)/(two-segments)/[first]/[second]/result/[publicId]/page.tsx
@@ -1,4 +1,4 @@
-import type { calculateMatches } from "@kalkulacka-one/app";
+import { type calculateMatches, hasAnswer } from "@kalkulacka-one/app";
 import { prisma } from "@kalkulacka-one/database";
 import type { Answer } from "@kalkulacka-one/schema";
 
@@ -46,6 +46,12 @@ export default async function Page({ params }: { params: Promise<{ first: string
 
   const answers = session.data.answers as Answer[];
   const result = session.data.result as ReturnType<typeof calculateMatches>;
+
+  // A session with no answers is not a result: it would render an empty
+  // ranking under a headline claiming somebody's match.
+  if (!answers.some((answer) => hasAnswer(answer))) {
+    notFound();
+  }
 
   return <PublicResultPageWithData algorithmMatches={result} answers={answers} segments={segments} />;
 }

--- a/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(content)/layout.tsx
+++ b/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(content)/layout.tsx
@@ -3,7 +3,10 @@ import { Footer } from "@/components/server";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="grid grid-cols-1">
+    // `scheme-light`: these screens are built in fixed light colours, so they
+    // opt out of the dark mode the calculator screens follow — see the
+    // matching root rule in `globals.css`.
+    <div className="grid grid-cols-1 scheme-light">
       <Header />
       {children}
       <Footer />

--- a/apps/www.izborenkalkulator.mk/app/[locale]/(web)/layout.tsx
+++ b/apps/www.izborenkalkulator.mk/app/[locale]/(web)/layout.tsx
@@ -1,5 +1,7 @@
 // TODO [TENANT-001]: Extract site metadata to appConfig
 
+import { bootstrapColorMode } from "@kalkulacka-one/app";
+
 import type { Metadata, Viewport } from "next";
 
 import type { I18nParams } from "@/i18n/params";
@@ -60,6 +62,20 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  /*
+   * One tag, no `prefers-color-scheme` pair.
+   *
+   * A media-gated pair follows the *OS*, which stops being the right answer
+   * the moment someone picks a mode in the app's menu — and a browser applies
+   * the first tag whose media matches, so the OS's answer would keep winning
+   * over anything written later. A single unconditional tag is the one the
+   * colour-mode code can own: `bootstrapColorMode` below corrects it before
+   * first paint and the toggle rewrites it on every switch. This value is
+   * only what a browser sees in the served HTML — the light page colour of
+   * the theme this site borrows (`--ko-palette-page-light` in the design
+   * system's `www.volebnikalkulacka.cz/default.css`, see `themes/default-theme.tsx`).
+   */
+  themeColor: "#f8fafc",
 };
 
 export function generateStaticParams() {
@@ -71,11 +87,36 @@ export default async function RootLayout({ children, params }: { children: React
   const defaultTheme = appConfig.theme.defaultTheme as ThemeName;
 
   return (
-    <html lang={locale}>
+    <html
+      lang={locale}
+      // The inline script below adds `data-mode` itself, before hydration —
+      // deliberately out of step with the server-rendered markup, which
+      // knows nothing about a client-only localStorage value. That mismatch
+      // is the point, not a bug for React to flag.
+      suppressHydrationWarning
+    >
       <head>
         <PlausibleScript />
       </head>
       <body className="min-h-dvh bg-slate-50">
+        {/*
+          Light/dark mode defaults to the OS preference (`color-scheme: light
+          dark` in the design system); this only has work to do once someone
+          picks an explicit override. A plain `<script>` — not `next/script` —
+          because it has to run synchronously while the server-rendered HTML
+          is still being parsed, before the browser paints anything: that's
+          what stops a stored override from flashing the system mode first.
+        */}
+        <script
+          id="color-mode-bootstrap"
+          suppressHydrationWarning
+          // A child string triggers React's "script tag while rendering"
+          // dev warning, since a `<script>` child is normally page text, not
+          // code — `dangerouslySetInnerHTML` is the same output without it.
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: `bootstrapColorMode` is a fixed, module-scope string with no user input, not markup built from a request.
+          dangerouslySetInnerHTML={{ __html: bootstrapColorMode }}
+        />
+
         <I18nProvider locale={locale}>
           <EmbedContextProvider isEmbed={false}>
             <ThemeProvider name={defaultTheme}>{children}</ThemeProvider>

--- a/apps/www.izborenkalkulator.mk/app/api/assets/[...path]/route.test.ts
+++ b/apps/www.izborenkalkulator.mk/app/api/assets/[...path]/route.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment node
+// Ported from kalkulacka-2026/apps/web/app/api/assets/[...path]/route.test.ts
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "./route";
+
+const fetchMock = vi.fn();
+
+function routeParams(path: string[]) {
+  return { params: Promise.resolve({ path }) };
+}
+
+const request = new Request("http://localhost/api/assets/kompas-2025/images/avatar.png");
+const assetPath = ["kompas-2025", "images", "avatar.png"];
+
+function upstreamImage(bytes: Uint8Array<ArrayBuffer>, headers: Record<string, string>) {
+  fetchMock.mockResolvedValue(new Response(bytes, { status: 200, headers }));
+}
+
+beforeEach(() => {
+  vi.stubEnv("DATA_ENDPOINT", "https://cdn.example/site");
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("GET /api/assets", () => {
+  it("mirrors an image with its type, nosniff and caching headers, fetched from under the data endpoint", async () => {
+    const pixels = new Uint8Array([1, 2, 3, 4]);
+    upstreamImage(pixels, { "content-type": "image/png" });
+
+    const response = await GET(request, routeParams(assetPath));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/png");
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(response.headers.get("cache-control")).toContain("immutable");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(pixels);
+    expect(fetchMock.mock.calls[0]?.[0]).toBeInstanceOf(URL);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toBe("https://cdn.example/site/kompas-2025/images/avatar.png");
+  });
+
+  it("normalises content-type parameters away", async () => {
+    upstreamImage(new Uint8Array([1]), { "content-type": "image/webp; charset=utf-8" });
+    const response = await GET(request, routeParams(assetPath));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/webp");
+  });
+
+  it("refuses to mirror a non-image type onto this origin", async () => {
+    // If the CDN ever serves HTML at an asset path, echoing its type would be
+    // stored XSS on this origin, cached for a day.
+    upstreamImage(new TextEncoder().encode("<script>alert(1)</script>"), { "content-type": "text/html" });
+
+    const response = await GET(request, routeParams(assetPath));
+    expect(response.status).toBe(502);
+  });
+
+  it("refuses svg — active content, and the platform never serves it", async () => {
+    upstreamImage(new TextEncoder().encode("<svg/>"), { "content-type": "image/svg+xml" });
+    const response = await GET(request, routeParams(assetPath));
+    expect(response.status).toBe(502);
+  });
+
+  it("refuses a declared oversized body without reading it", async () => {
+    upstreamImage(new Uint8Array([1]), { "content-type": "image/png", "content-length": String(6 * 1024 * 1024) });
+
+    const response = await GET(request, routeParams(assetPath));
+    expect(response.status).toBe(502);
+  });
+
+  it("caps the body even when Content-Length is absent or lying", async () => {
+    upstreamImage(new Uint8Array(5 * 1024 * 1024 + 1), { "content-type": "image/png" });
+    const response = await GET(request, routeParams(assetPath));
+    expect(response.status).toBe(502);
+  });
+
+  it("answers 504 when the CDN does not answer in time", async () => {
+    fetchMock.mockRejectedValue(new DOMException("timed out", "TimeoutError"));
+    const response = await GET(request, routeParams(assetPath));
+    expect(response.status).toBe(504);
+  });
+
+  it("rejects traversal-shaped segments without fetching", async () => {
+    for (const path of [["..", "secrets"], ["a/b"], ["https://evil.example"], []]) {
+      const response = await GET(request, routeParams(path));
+      expect(response.status).toBe(404);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 with no data endpoint configured", async () => {
+    vi.stubEnv("DATA_ENDPOINT", "");
+    const response = await GET(request, routeParams(assetPath));
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/www.izborenkalkulator.mk/app/api/assets/[...path]/route.ts
+++ b/apps/www.izborenkalkulator.mk/app/api/assets/[...path]/route.ts
@@ -1,0 +1,157 @@
+// Ported from kalkulacka-2026/apps/web/app/api/assets/[...path]/route.ts
+import { BadGatewayError, GatewayTimeoutError, HttpError, NotFoundError } from "@kalkulacka-one/app";
+
+/**
+ * A same-origin mirror of one asset on the data CDN.
+ *
+ * Exists only for the share-card export: `html-to-image` rasterises the card
+ * by re-fetching every `<img>`'s pixels itself, and the CDN sends no
+ * `Access-Control-Allow-Origin` (checked: none on the JSON, none on an image,
+ * a preflight answers 403) — so that fetch is blocked even though the `<img>`
+ * displays fine. Routing the same bytes through this origin sidesteps CORS
+ * without asking the CDN for anything. Nothing else in the app should point
+ * here: every other avatar keeps loading the CDN directly, which is strictly
+ * less latency for a picture that was never going onto a canvas.
+ */
+
+const UPSTREAM_TIMEOUT_MS = 10_000;
+
+/**
+ * The proxy mirrors avatar images and nothing else. The CDN is a separately
+ * operated service; re-serving whatever `Content-Type` it sends would let any
+ * non-image it ever hosts (compromise, misconfiguration, a future upload
+ * feature) render as a document on *this* origin — stored XSS, cached for a
+ * day. Everything the platform serves today is png/jpg/webp; svg is
+ * deliberately absent from the list because it is active content.
+ */
+const ALLOWED_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/avif", "image/gif"]);
+
+/** Avatars are tens of KB; this is generous headroom, not a target. */
+const MAX_ASSET_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Resolve `path` against the configured data endpoint, or refuse.
+ *
+ * The segments Next hands us are already URL-decoded, so an encoded slash or
+ * an encoded `..` does not arrive as its own segment — it arrives as a literal
+ * `/` or `.` *inside* one, which is exactly how `/api/assets/https%3A%2F%2Fevil.example`
+ * tries to smuggle a whole foreign URL in as "one path segment". Rejecting any
+ * segment that carries a slash, a backslash, or is bare `.`/`..` closes that.
+ * Resolving what's left with `URL` against the endpoint and then checking the
+ * resolved origin and pathname prefix closes the rest — including anything
+ * `URL` itself would collapse upward, and an endpoint typo that resolves
+ * outside itself.
+ */
+function resolveAssetUrl(endpoint: string, segments: string[]): URL | null {
+  if (segments.length === 0) return null;
+
+  for (const segment of segments) {
+    if (!segment) return null;
+    if (segment.includes("/") || segment.includes("\\")) return null;
+    if (segment === "." || segment === "..") return null;
+  }
+
+  let base: URL;
+  let target: URL;
+  try {
+    base = new URL(`${endpoint.replace(/\/$/, "")}/`);
+    target = new URL(segments.join("/"), base);
+  } catch {
+    return null;
+  }
+
+  if (target.origin !== base.origin) return null;
+  if (!target.pathname.startsWith(base.pathname)) return null;
+
+  return target;
+}
+
+export async function GET(_request: Request, { params }: { params: Promise<{ path: string[] }> }) {
+  try {
+    const endpoint = process.env.DATA_ENDPOINT;
+    if (!endpoint) {
+      return new NotFoundError("No data endpoint configured").toResponse();
+    }
+
+    const { path } = await params;
+    const target = resolveAssetUrl(endpoint, path ?? []);
+    if (!target) {
+      return new NotFoundError("Not found").toResponse();
+    }
+
+    let upstream: Response;
+    try {
+      upstream = await fetch(target, { signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS) });
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "TimeoutError") {
+        return new GatewayTimeoutError().toResponse();
+      }
+      return new BadGatewayError().toResponse();
+    }
+
+    if (!upstream.ok || !upstream.body) {
+      return new BadGatewayError(`Upstream returned ${upstream.status}`).toResponse();
+    }
+
+    const rawType = upstream.headers.get("content-type") ?? "";
+    const contentType = (rawType.split(";")[0] ?? "").trim().toLowerCase();
+    if (!ALLOWED_TYPES.has(contentType)) {
+      return new BadGatewayError("Upstream served a non-image type").toResponse();
+    }
+
+    const declaredLength = Number(upstream.headers.get("content-length"));
+    if (Number.isFinite(declaredLength) && declaredLength > MAX_ASSET_BYTES) {
+      return new BadGatewayError("Upstream asset too large").toResponse();
+    }
+
+    // Buffered rather than streamed: the size cap has to be enforceable after
+    // a missing/lying Content-Length, and aborting a stream mid-200 would hand
+    // the client (and the day-long cache) a truncated image instead of an
+    // error. The fetch's timeout signal still covers this read.
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    const reader = upstream.body.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        received += value.byteLength;
+        if (received > MAX_ASSET_BYTES) {
+          reader.cancel().catch(() => {});
+          return new BadGatewayError("Upstream asset too large").toResponse();
+        }
+        chunks.push(value);
+      }
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "TimeoutError") {
+        return new GatewayTimeoutError().toResponse();
+      }
+      return new BadGatewayError().toResponse();
+    }
+
+    const body = new Uint8Array(received);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": contentType,
+        // The guarantee travels with the route rather than with the
+        // deployment config: never sniffed into something else.
+        "X-Content-Type-Options": "nosniff",
+        // Versioned static assets — the CDN path changes when the image does.
+        "Cache-Control": "public, max-age=86400, immutable",
+      },
+    });
+  } catch (error) {
+    if (error instanceof HttpError) {
+      return error.toResponse();
+    }
+
+    throw error;
+  }
+}

--- a/apps/www.izborenkalkulator.mk/app/globals.css
+++ b/apps/www.izborenkalkulator.mk/app/globals.css
@@ -3,7 +3,22 @@
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
-:root {
+/*
+ * Light and dark follow the design system: `color-scheme: light dark` on the
+ * root, an explicit `data-mode` override written by the shell menu (applied
+ * before first paint by `bootstrapColorMode` in the layouts), and a partner
+ * theme's own single-mode pin. The legacy content screens — the homepage and
+ * the editorial pages — are built in fixed light colours (slate utilities, a
+ * light body), so they pin the scheme light instead: on their own wrapper
+ * (`scheme-light` in the content layout), which keeps every design-system
+ * component on them light everywhere, and — where `:has()` is understood —
+ * on the root as well, so the browser's own chrome and the theme-colour sync
+ * see the same light page. The second selector outranks the design system's
+ * `:root[data-mode="dark"]`, so a dark override stored while using a
+ * calculator does not follow the visitor onto these screens.
+ */
+html:has(.scheme-light),
+html[data-mode]:has(.scheme-light) {
   color-scheme: light;
 }
 

--- a/apps/www.izborenkalkulator.mk/components/client/calculator-menu.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/calculator-menu.tsx
@@ -1,0 +1,50 @@
+import { AppMenu, type calculateMatches } from "@kalkulacka-one/app";
+
+import { isSingleModeTheme } from "@/config/themes";
+import { useCalculatorActions } from "@/hooks/calculator-actions";
+import type { RouteSegments } from "@/lib/routing";
+
+import { useEmbed } from "./embed-context-provider";
+
+export type CalculatorMenu = {
+  segments: RouteSegments;
+  /** The ranking, on the screens that have one — saved along with the answers on the way out. */
+  matches?: ReturnType<typeof calculateMatches>;
+  /**
+   * A screen that only *shows* a calculator rather than being inside one —
+   * the public shared result. The menu keeps help and the mode switch and
+   * drops "Почни одново" and "Напушти го калкулаторот", which act on the
+   * viewer's own answers and progress; that page is somebody else's result.
+   */
+  readOnly?: boolean;
+};
+
+/*
+ * What the two actions become on a read-only screen. The menu offers neither
+ * item there, so neither could be reached anyway — but the hook behind them
+ * reads whichever answers store is nearest, which on the public result holds
+ * the *shared* answers, and a leave that saved those over the viewer's own
+ * session is not a path worth leaving open by accident. Cut off here rather
+ * than trusted to stay unreachable.
+ */
+const noop = () => {};
+
+/**
+ * The shell menu, wired to this app: it goes into every calculator screen's
+ * `headerActions` slot, where the close button used to be.
+ *
+ * What the menu offers is decided here rather than in the screens, because it
+ * is this app that knows two things the menu does not: whether it is inside
+ * a partner iframe (no "Напушти го калкулаторот" there — navigating the
+ * iframe to our homepage is not leaving, it is getting lost), and whether
+ * that partner's theme is single-mode (no light/dark toggle then; it would
+ * visibly do nothing).
+ */
+export function CalculatorMenu({ segments, matches, readOnly = false }: CalculatorMenu) {
+  const embed = useEmbed();
+  const { leave, restart } = useCalculatorActions({ segments, matches });
+
+  const singleModeTheme = embed.isEmbed && embed.config?.theme !== undefined && isSingleModeTheme(embed.config.theme);
+
+  return <AppMenu readOnly={readOnly} embed={embed.isEmbed} colorModeToggle={!singleModeTheme} onRestart={readOnly ? noop : restart} onLeave={readOnly ? noop : leave} />;
+}

--- a/apps/www.izborenkalkulator.mk/components/client/index.ts
+++ b/apps/www.izborenkalkulator.mk/components/client/index.ts
@@ -1,5 +1,6 @@
 "use client";
 
+export * from "./calculator-menu";
 export * from "./embed-context-provider";
 export * from "./embed-only";
 export * from "./embed-provider";
@@ -10,5 +11,6 @@ export * from "./pages";
 export * from "./provider-layout";
 export * from "./session-initializer";
 export * from "./session-provider-layout";
+export * from "./session-status";
 export * from "./subscribe-form";
 export * from "./theme-provider";

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/comparison.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/comparison.tsx
@@ -1,29 +1,71 @@
-import { useAnswers, useCalculatedMatches, useCalculator, useQuestions, useResult } from "@kalkulacka-one/app/client";
+import { type ComparisonFilter, ComparisonPage } from "@kalkulacka-one/app";
+import { useCalculatedMatches, useCalculator } from "@kalkulacka-one/app/client";
 
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useLocale } from "next-intl";
+import { useCallback } from "react";
 
-import { ComparisonPage } from "@/calculator";
-import { useEmbed } from "@/components/client";
-import { type RouteSegments, routes } from "@/lib/routing";
+import { CalculatorMenu, useEmbed } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
+import { trackEvent } from "@/lib/analytics";
+import { COMPARISON_FILTER_PARAM, comparisonFilterQuery, parseComparisonFilter, type RouteSegments, routes } from "@/lib/routing";
 
 export function ComparisonPageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const calculator = useCalculator();
-  const algorithmMatches = useCalculatedMatches();
-  const result = useResult(algorithmMatches);
-  const answers = useAnswers();
-  const questions = useQuestions();
   const embed = useEmbed();
+  const algorithmMatches = useCalculatedMatches();
   const locale = useLocale();
 
-  const handlePreviousClick = () => {
+  // A standalone calculator is named by its own data; there is no election
+  // group to name it after — see `config/calculator-names.ts`.
+  const { electionName, calculatorName } = calculatorNames({
+    key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    title: calculator.title || undefined,
+    shortTitle: calculator.shortTitle,
+  });
+
+  // In an embed the wordmark doubles as the attribution — the one way out of a
+  // partner's iframe to the full site — unless the partner opted out of it.
+  const attributionHref = embed.isEmbed && embed.config?.attribution !== false ? (process.env.NEXT_PUBLIC_CANONICAL_URL ?? "/") : undefined;
+  const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
+
+  const comparisonRoute = routes.comparison(segments, locale);
+
+  /*
+   * `?filter=vazni` or `?filter=<topic slug>`, as the results page's dashboard
+   * links write it. Read once, on arrival: the page keeps its own filter from
+   * there, and `handleFilterChange` keeps the address bar in step.
+   */
+  const initialFilter = parseComparisonFilter(searchParams.get(COMPARISON_FILTER_PARAM));
+
+  const handleViewed = useCallback(() => {
+    trackEvent("Comparison viewed", { calculator: calculator.id });
+  }, [calculator.id]);
+
+  const handleBackClick = () => {
     router.push(routes.result(segments, locale));
   };
 
-  const handleCloseClick = () => {
-    router.push("/");
+  const handleFilterChange = (filter: ComparisonFilter | undefined) => {
+    // The URL keeps up without a navigation: the screen already has the data
+    // for every filter, and a server round-trip would only re-fetch it.
+    window.history.replaceState(null, "", `${comparisonRoute}${comparisonFilterQuery(filter)}`);
   };
 
-  return <ComparisonPage embedContext={embed} calculator={calculator} result={result} answers={answers} questions={questions} onPreviousClick={handlePreviousClick} onCloseClick={handleCloseClick} />;
+  return (
+    <ComparisonPage
+      appTitle="Изборен калкулатор"
+      electionName={electionName}
+      calculatorName={calculatorName}
+      initialFilter={initialFilter}
+      headerActions={<CalculatorMenu segments={segments} matches={algorithmMatches} />}
+      attributionHref={attributionHref}
+      logoMonochrome={logoMonochrome}
+      onBackClick={handleBackClick}
+      onFilterChange={handleFilterChange}
+      onViewed={handleViewed}
+    />
+  );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/guide.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/guide.tsx
@@ -1,25 +1,36 @@
-import { useAnswersStore, useCalculator } from "@kalkulacka-one/app/client";
+import { GuidePage } from "@kalkulacka-one/app";
+import { useCalculator } from "@kalkulacka-one/app/client";
 
 import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
 
-import { GuidePage as AppGuidePage } from "@/calculator";
-import { useEmbed } from "@/components/client";
+import { CalculatorMenu, useEmbed } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
 import { useAutoSave } from "@/hooks/auto-save";
-import { saveSessionData } from "@/lib/api";
-import { reportError } from "@/lib/monitoring";
 import { type RouteSegments, routes } from "@/lib/routing";
 
 export function GuidePageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
   const embed = useEmbed();
-  const answersStore = useAnswersStore((state) => state.answers);
   const locale = useLocale();
 
   useAutoSave();
 
-  const handleNavigationNextClick = () => {
+  // A standalone calculator is named by its own data; there is no election
+  // group to name it after — see `config/calculator-names.ts`.
+  const { electionName, calculatorName } = calculatorNames({
+    key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    title: calculator.title || undefined,
+    shortTitle: calculator.shortTitle,
+  });
+
+  // In an embed the wordmark doubles as the attribution — the one way out of a
+  // partner's iframe to the full site — unless the partner opted out of it.
+  const attributionHref = embed.isEmbed && embed.config?.attribution !== false ? (process.env.NEXT_PUBLIC_CANONICAL_URL ?? "/") : undefined;
+  const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
+
+  const handleStartClick = () => {
     router.push(routes.question(segments, 1, locale));
   };
 
@@ -27,16 +38,16 @@ export function GuidePageWithRouting({ segments }: { segments: RouteSegments }) 
     router.push(routes.introduction(segments, locale));
   };
 
-  const handleCloseClick = async () => {
-    try {
-      if (answersStore.length > 0) {
-        await saveSessionData(calculator.id, answersStore, undefined, calculator.version);
-      }
-    } catch (error) {
-      reportError(error);
-    }
-    router.push("/");
-  };
-
-  return <AppGuidePage embedContext={embed} calculator={calculator} onNextClick={handleNavigationNextClick} onBackClick={handleBackClick} onCloseClick={handleCloseClick} />;
+  return (
+    <GuidePage
+      appTitle="Изборен калкулатор"
+      electionName={electionName}
+      calculatorName={calculatorName}
+      headerActions={<CalculatorMenu segments={segments} />}
+      attributionHref={attributionHref}
+      logoMonochrome={logoMonochrome}
+      onBackClick={handleBackClick}
+      onStartClick={handleStartClick}
+    />
+  );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/introduction.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/introduction.tsx
@@ -1,38 +1,65 @@
-import { useAnswersStore, useCalculator } from "@kalkulacka-one/app/client";
+import { IntroductionPage, type IntroductionResumeTarget } from "@kalkulacka-one/app";
+import { useCalculator, useCandidates } from "@kalkulacka-one/app/client";
 
 import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
 
-import { IntroductionPage } from "@/calculator";
-import { useEmbed } from "@/components/client";
+import { CalculatorMenu, useEmbed } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
 import { useAutoSave } from "@/hooks/auto-save";
-import { saveSessionData } from "@/lib/api";
-import { reportError } from "@/lib/monitoring";
+import { useCalculatorActions } from "@/hooks/calculator-actions";
+import { trackEvent } from "@/lib/analytics";
 import { type RouteSegments, routes } from "@/lib/routing";
 
 export function IntroductionPageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
+  const candidates = useCandidates();
   const embed = useEmbed();
-  const answersStore = useAnswersStore((state) => state.answers);
   const locale = useLocale();
+  // The same restart the shell menu offers — the intro's own "Почни одново"
+  // must land in the same place, so the two share one handler.
+  const { restart } = useCalculatorActions({ segments });
 
   useAutoSave();
 
-  const handleNavigationNextClick = () => {
+  // A standalone calculator is named by its own data; there is no election
+  // group to name it after — see `config/calculator-names.ts`.
+  const { electionName, calculatorName } = calculatorNames({
+    key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    title: calculator.title || undefined,
+    shortTitle: calculator.shortTitle,
+  });
+
+  // In an embed the wordmark doubles as the attribution — the one way out of a
+  // partner's iframe to the full site — unless the partner opted out of it.
+  const attributionHref = embed.isEmbed && embed.config?.attribution !== false ? (process.env.NEXT_PUBLIC_CANONICAL_URL ?? "/") : undefined;
+  const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
+
+  const handleContinueClick = () => {
+    // Fired on the click, not on arrival at the guide: a tap here is the
+    // decision to start, and the tutorial after it is still onboarding, not
+    // a second start worth counting separately.
+    trackEvent("Calculator started", { calculator: calculator.id });
     router.push(routes.guide(segments, locale));
   };
 
-  const handleCloseClick = async () => {
-    try {
-      if (answersStore.length > 0) {
-        await saveSessionData(calculator.id, answersStore, undefined, calculator.version);
-      }
-    } catch (error) {
-      reportError(error);
-    }
-    router.push("/");
+  const handleResumeClick = (target: IntroductionResumeTarget) => {
+    router.push("review" in target ? routes.review(segments, locale) : routes.question(segments, target.question, locale));
   };
 
-  return <IntroductionPage embedContext={embed} calculator={calculator} onNextClick={handleNavigationNextClick} onCloseClick={handleCloseClick} />;
+  return (
+    <IntroductionPage
+      appTitle="Изборен калкулатор"
+      electionName={electionName}
+      calculatorName={calculatorName}
+      candidateCount={candidates.length}
+      headerActions={<CalculatorMenu segments={segments} />}
+      attributionHref={attributionHref}
+      logoMonochrome={logoMonochrome}
+      onContinueClick={handleContinueClick}
+      onResumeClick={handleResumeClick}
+      onRestartClick={restart}
+    />
+  );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/public-result.test.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/public-result.test.tsx
@@ -1,0 +1,142 @@
+import { type CalculatorData, type calculateMatches, ResultPage } from "@kalkulacka-one/app";
+import { AnswersStoreContext, CalculatorStoreContext, createAnswersStore, createCalculatorStore } from "@kalkulacka-one/app/client";
+import type { Answer } from "@kalkulacka-one/schema";
+
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CalculatorMenu } from "@/components/client";
+
+import { PublicResultPageWithData } from "./public-result";
+
+const { push } = vi.hoisted(() => ({ push: vi.fn() }));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "mk",
+  hasLocale: (locales: readonly string[], locale: string) => locales.includes(locale),
+}));
+
+vi.mock("@/components/client", () => ({
+  CalculatorMenu: vi.fn(() => null),
+}));
+
+/*
+ * The page itself is the app package's business. What matters here is what
+ * it is handed — and which answers store it finds nearest, so the mock reads
+ * that store the way the real page does and writes it out.
+ */
+vi.mock("@kalkulacka-one/app", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@kalkulacka-one/app")>();
+  const { useAnswersStore } = await import("@kalkulacka-one/app/client");
+  return {
+    ...actual,
+    ResultPage: vi.fn(() => {
+      const answers = useAnswersStore((state) => state.answers);
+      return <output data-testid="answers">{JSON.stringify(answers)}</output>;
+    }),
+  };
+});
+
+const calculatorData: CalculatorData = {
+  data: {
+    calculator: {
+      id: "00000000-0000-4000-8000-000000000000",
+      createdAt: new Date(0).toISOString(),
+      // A standalone calculator, named by its own data rather than by a config.
+      key: "kompas-2025",
+      title: "Изборен компас 2025",
+      shortTitle: "Изборен компас",
+    },
+    questions: [],
+    candidates: [],
+    candidatesAnswers: {},
+  },
+  baseUrl: "https://data.kalkulacka.one/www.izborenkalkulator.mk/kompas-2025",
+};
+
+const segments = { first: "kompas-2025" };
+
+const answers: Answer[] = [
+  { questionId: "22222222-2222-4222-8222-222222222222", answer: true },
+  { questionId: "33333333-3333-4333-8333-333333333333", answer: false, isImportant: true },
+];
+
+const algorithmMatches: ReturnType<typeof calculateMatches> = [
+  { id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", match: 80 },
+  { id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", match: 20 },
+];
+
+function renderPage() {
+  // The route's own store, the one every other screen reads — empty, as it is on a public route with no session.
+  const routeStore = createAnswersStore();
+
+  render(
+    <CalculatorStoreContext.Provider value={createCalculatorStore(calculatorData)}>
+      <AnswersStoreContext.Provider value={routeStore}>
+        <PublicResultPageWithData algorithmMatches={algorithmMatches} answers={answers} segments={segments} />
+      </AnswersStoreContext.Provider>
+    </CalculatorStoreContext.Provider>,
+  );
+
+  const props = vi.mocked(ResultPage).mock.lastCall?.[0];
+  if (!props) throw new Error("ResultPage was not rendered");
+  return { props, routeStore };
+}
+
+describe("PublicResultPageWithData", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the results screen read-only, replaying the stored ranking under the data's own name", () => {
+    const { props } = renderPage();
+
+    expect(props).toEqual(
+      expect.objectContaining({
+        appTitle: "Изборен калкулатор",
+        calculatorName: "Изборен компас 2025",
+        shared: true,
+        algorithmMatches,
+      }),
+    );
+    // A standalone calculator belongs to no election.
+    expect(props.electionName).toBeUndefined();
+    // Nothing that would act on the viewer's own result.
+    expect(props.share).toBeUndefined();
+    expect(props.onShareClick).toBeUndefined();
+    expect(props.onCompareClick).toBeUndefined();
+    expect(props.onCompareTopicClick).toBeUndefined();
+    expect(props.onCompareImportantClick).toBeUndefined();
+    expect(props.donateCard).toBeUndefined();
+  });
+
+  it("puts the read-only menu in the header", () => {
+    const { props } = renderPage();
+    const menu = props.headerActions;
+
+    if (!menu || typeof menu !== "object" || !("type" in menu)) throw new Error("No element in the header");
+    expect(menu.type).toBe(CalculatorMenu);
+    expect(menu.props).toEqual({ segments, readOnly: true });
+  });
+
+  it("hands the page a store of its own, seeded with the shared answers, and leaves the route's store alone", () => {
+    const { routeStore } = renderPage();
+
+    expect(JSON.parse(screen.getByTestId("answers").textContent ?? "")).toEqual(answers);
+    expect(routeStore.getState().answers).toEqual([]);
+  });
+
+  it("sends the visitor to the calculator's intro for their own calculator, and from the empty state's exit too", () => {
+    const { props } = renderPage();
+
+    props.onStartOwnClick?.();
+    props.onBackClick();
+    expect(push).toHaveBeenCalledTimes(2);
+    expect(push).toHaveBeenNthCalledWith(1, "/kompas-2025/voved");
+    expect(push).toHaveBeenNthCalledWith(2, "/kompas-2025/voved");
+  });
+});

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/public-result.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/public-result.tsx
@@ -1,29 +1,93 @@
-import type { calculateMatches } from "@kalkulacka-one/app";
-import { useAnswersStore, useCalculator, useResult } from "@kalkulacka-one/app/client";
+import { type calculateMatches, ResultPage } from "@kalkulacka-one/app";
+import { AnswersStoreContext, createAnswersStore, useCalculator } from "@kalkulacka-one/app/client";
 import type { Answer } from "@kalkulacka-one/schema";
 
 import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
 import { useEffect, useState } from "react";
 
-import { PublicResultPage as AppPublicResultPage } from "@/calculator";
+import { CalculatorMenu } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
 import { type RouteSegments, routes } from "@/lib/routing";
 
-export function PublicResultPageWithData({ algorithmMatches, answers, segments }: { algorithmMatches: ReturnType<typeof calculateMatches>; answers: Answer[]; segments: RouteSegments }) {
-  const [showOnlyNested, setShowOnlyNested] = useState(false);
+export type PublicResultPageWithData = {
+  /** The ranking stored with the shared session — replayed as it stood, not recomputed. */
+  algorithmMatches: ReturnType<typeof calculateMatches>;
+  /** The answers behind it, for the dashboard and the per-party comparison. */
+  answers: Answer[];
+  segments: RouteSegments;
+};
+
+/**
+ * Somebody else's result, opened from a public link.
+ *
+ * The results screen rendered read-only: the note above the title says whose
+ * numbers these are, the beat and the ways out of your own result are gone,
+ * and the one thing it asks for is the visitor's own calculator. The ranking
+ * is the one the session saved, replayed through the same view model the
+ * results page uses — a later change to the data or the algorithm must not
+ * quietly alter a result somebody already posted.
+ *
+ * Nothing here touches the viewer's own state. The public routes mount no
+ * session (see their layouts), and the shared answers go into a store of
+ * this page's own rather than the route's — see below.
+ */
+export function PublicResultPageWithData({ algorithmMatches, answers, segments }: PublicResultPageWithData) {
   const router = useRouter();
   const calculator = useCalculator();
-  const result = useResult(algorithmMatches, { showOnlyNested });
-  const setAnswers = useAnswersStore((state) => state.setAnswers);
   const locale = useLocale();
 
-  useEffect(() => {
-    setAnswers(answers);
-  }, [answers, setAnswers]);
+  /*
+   * A store seeded before the first render, not the route's store filled in
+   * an effect: the page counts the answers on its first pass, and an empty
+   * store there would render — and serve — "Засега нема што да се пресмета"
+   * for a beat before the ranking replaced it. Nested inside the route's
+   * providers, so the store every other screen reads is never written.
+   */
+  const [answersStore] = useState(() => {
+    const store = createAnswersStore();
+    store.getState().setAnswers(answers);
+    return store;
+  });
 
-  const handleStartCalculator = () => {
+  // Client-side navigation from one shared result to another of the same
+  // calculator re-renders this page with new answers rather than remounting it.
+  useEffect(() => {
+    if (answersStore.getState().answers !== answers) {
+      answersStore.getState().setAnswers(answers);
+    }
+  }, [answersStore, answers]);
+
+  // A standalone calculator is named by its own data; there is no election
+  // group to name it after — see `config/calculator-names.ts`.
+  const { electionName, calculatorName } = calculatorNames({
+    key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    title: calculator.title || undefined,
+    shortTitle: calculator.shortTitle,
+  });
+
+  /*
+   * "Пополни сопствен калкулатор" — the intro, where the visitor's own
+   * calculator starts. The empty state's exit leads there too: the route
+   * refuses a result with no answers, so it is never shown, but a visitor
+   * with nowhere to go "back" to has no other sensible destination.
+   */
+  const handleStartOwnClick = () => {
     router.push(routes.introduction(segments, locale));
   };
 
-  return <AppPublicResultPage calculator={calculator} result={result} showOnlyNested={showOnlyNested} onFilterChange={setShowOnlyNested} onStartCalculator={handleStartCalculator} />;
+  return (
+    <AnswersStoreContext.Provider value={answersStore}>
+      <ResultPage
+        appTitle="Изборен калкулатор"
+        electionName={electionName}
+        calculatorName={calculatorName}
+        headerActions={<CalculatorMenu segments={segments} readOnly />}
+        shared
+        algorithmMatches={algorithmMatches}
+        onStartOwnClick={handleStartOwnClick}
+        onBackClick={handleStartOwnClick}
+      />
+    </AnswersStoreContext.Provider>
+  );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/question.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/question.tsx
@@ -1,24 +1,30 @@
-import { useAnswer, useAnswersStore, useCalculator, useQuestions } from "@kalkulacka-one/app/client";
+import { QuestionPage } from "@kalkulacka-one/app";
+import { useCalculator, useQuestions } from "@kalkulacka-one/app/client";
 
 import { notFound, usePathname, useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
-import { useEffect, useReducer } from "react";
+import { useCallback, useEffect, useReducer } from "react";
 
-import { QuestionPage as AppQuestionPage } from "@/calculator";
-import { useEmbed } from "@/components/client";
+import { CalculatorMenu, useEmbed } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
 import { useAutoSave } from "@/hooks/auto-save";
-import { saveSessionData } from "@/lib/api";
-import { reportError } from "@/lib/monitoring";
 import { parsedParams, type RouteSegments, routes } from "@/lib/routing";
 
 export function QuestionPageWithRouting({ current, segments }: { current: number; segments: RouteSegments }) {
   const router = useRouter();
   const pathname = usePathname();
   const calculator = useCalculator();
-  const { questions, total } = useQuestions();
+  const { questions } = useQuestions();
   const [, forceRender] = useReducer((x) => x + 1, 0);
   const locale = useLocale();
+  const embed = useEmbed();
 
+  useAutoSave();
+
+  // The position the URL says — `current` from the route on the first render,
+  // the path itself afterwards: the page keeps it in step through
+  // `replaceState`, and `usePathname` follows that. Only the guard below and
+  // the page's initial position read it; the page owns the position from then on.
   const currentQuestion = (() => {
     try {
       return parsedParams.questionNumber(pathname);
@@ -26,18 +32,6 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
       return current;
     }
   })();
-  const question = questions[currentQuestion - 1];
-  const embed = useEmbed();
-  const answersStore = useAnswersStore((state) => state.answers);
-  const setAnswer = useAnswersStore((state) => state.setAnswer);
-
-  useAutoSave();
-
-  useEffect(() => {
-    if (question) {
-      setAnswer({ questionId: question.id });
-    }
-  }, [question, setAnswer]);
 
   useEffect(() => {
     const handlePopState = () => {
@@ -48,56 +42,60 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
     return () => window.removeEventListener("popstate", handlePopState);
   }, []);
 
-  if (!question) {
+  if (!questions[currentQuestion - 1]) {
     notFound();
   }
 
-  const handleNextClick = () => {
-    if (currentQuestion < total) {
-      const nextUrl = routes.question(segments, currentQuestion + 1, locale);
-      window.history.pushState(null, "", nextUrl);
-      forceRender();
-    } else {
-      router.push(routes.review(segments, locale));
-    }
+  // A standalone calculator is named by its own data; there is no election
+  // group to name it after — see `config/calculator-names.ts`.
+  const { electionName, calculatorName } = calculatorNames({
+    key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    title: calculator.title || undefined,
+    shortTitle: calculator.shortTitle,
+  });
+
+  // In an embed the wordmark doubles as the attribution — the one way out of a
+  // partner's iframe to the full site — unless the partner opted out of it.
+  const attributionHref = embed.isEmbed && embed.config?.attribution !== false ? (process.env.NEXT_PUBLIC_CANONICAL_URL ?? "/") : undefined;
+  const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
+
+  /*
+   * The URL tracks the question so a refresh or a shared link lands in the
+   * right place — but via `replaceState` rather than a router push (or the
+   * `pushState` the previous page used). Routing on every answer would put a
+   * navigation between the swipe and the next card, which is exactly the
+   * latency this interaction cannot afford; and a history entry per question
+   * made the back button walk through every answered card before it left the
+   * flow. Next's router follows `replaceState`, so `usePathname` above stays
+   * in step.
+   */
+  const handlePositionChange = useCallback(
+    (position: number) => {
+      window.history.replaceState(null, "", routes.question(segments, position, locale));
+    },
+    [segments, locale],
+  );
+
+  const handleFinish = () => {
+    router.push(routes.review(segments, locale));
   };
 
-  const handlePreviousClick = () => {
-    if (currentQuestion === 1) {
-      router.push(routes.guide(segments, locale));
-    } else {
-      const prevUrl = routes.question(segments, currentQuestion - 1, locale);
-      window.history.pushState(null, "", prevUrl);
-      forceRender();
-    }
+  const handleBackToGuide = () => {
+    router.push(routes.guide(segments, locale));
   };
-
-  const handleCloseClick = async () => {
-    try {
-      if (answersStore.length > 0) {
-        await saveSessionData(calculator.id, answersStore, undefined, calculator.version);
-      }
-    } catch (error) {
-      reportError(error);
-    }
-    router.push("/");
-  };
-
-  const answer = useAnswer(question.id);
 
   return (
-    <div>
-      <AppQuestionPage
-        embedContext={embed}
-        calculator={calculator}
-        question={question}
-        number={currentQuestion}
-        total={total}
-        onPreviousClick={handlePreviousClick}
-        onNextClick={handleNextClick}
-        onCloseClick={handleCloseClick}
-        answer={answer}
-      />
-    </div>
+    <QuestionPage
+      appTitle="Изборен калкулатор"
+      electionName={electionName}
+      calculatorName={calculatorName}
+      initialPosition={currentQuestion}
+      headerActions={<CalculatorMenu segments={segments} />}
+      attributionHref={attributionHref}
+      logoMonochrome={logoMonochrome}
+      onPositionChange={handlePositionChange}
+      onFinish={handleFinish}
+      onBackToGuide={handleBackToGuide}
+    />
   );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/result.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/result.tsx
@@ -1,27 +1,42 @@
-import { useAnswersStore, useCalculatedMatches, useCalculator, useResult } from "@kalkulacka-one/app/client";
+import { ResultPage, type ResultPageShare } from "@kalkulacka-one/app";
+import { useAnswersStore, useCalculatedMatches, useCalculator, useCalculatorStore } from "@kalkulacka-one/app/client";
 
 import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { ShareModal } from "@/calculator/components/client";
-import { ResultPage as AppResultPage } from "@/calculator/components/server";
-import { useEmbed } from "@/components/client";
-import { saveSessionData } from "@/lib/api";
+import { CalculatorMenu, useEmbed, useSessionStatus } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
+import { useAutoSave } from "@/hooks/auto-save";
+import { trackEvent } from "@/lib/analytics";
+import { saveSessionData, shareSession } from "@/lib/api";
 import { reportError } from "@/lib/monitoring";
-import { type RouteSegments, routes } from "@/lib/routing";
+import { canonical, comparisonFilterQuery, type RouteSegments, routes, stripEmbed } from "@/lib/routing";
+import { toProxiedAssetUrl } from "@/lib/share-asset-url";
 
 export function ResultPageWithRouting({ segments }: { segments: RouteSegments }) {
-  const [showOnlyNested, setShowOnlyNested] = useState(false);
-  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const router = useRouter();
   const calculator = useCalculator();
+  const baseUrl = useCalculatorStore((state) => state.baseUrl);
   const embed = useEmbed();
   const answersStore = useAnswersStore((state) => state.answers);
   const locale = useLocale();
+  /*
+   * Whether there is a backend to mint a public link on: the sessions
+   * endpoint has answered this visit (see `SessionStatusProvider`). Without
+   * one — a local checkout, a fork that configured none — the share dialog is
+   * image-only rather than offering a "Копирај линк" that could only fail.
+   */
+  const sessionStatus = useSessionStatus();
 
   const algorithmMatches = useCalculatedMatches();
-  const result = useResult(algorithmMatches, { showOnlyNested });
+
+  /*
+   * The ranking is what marks the session finished server-side and what a
+   * shared result is drawn from: saved eagerly the moment there is one, and
+   * again with the ranking whenever the tab is hidden or left.
+   */
+  useAutoSave({ matches: algorithmMatches });
 
   useEffect(() => {
     const hasValidMatches = algorithmMatches?.some((match) => match.match !== undefined);
@@ -31,48 +46,132 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
     }
   }, [algorithmMatches, answersStore, calculator.id, calculator.version]);
 
-  const handlePreviousClick = () => {
+  // A standalone calculator is named by its own data; there is no election
+  // group to name it after — see `config/calculator-names.ts`. The same two
+  // keys are what the asset proxy needs to find the calculator's pictures
+  // under the data endpoint.
+  const calculatorGroup = "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined;
+  const calculatorKey = ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key;
+  const { electionName, calculatorName } = calculatorNames({
+    key: calculatorKey,
+    title: calculator.title || undefined,
+    shortTitle: calculator.shortTitle,
+  });
+
+  // In an embed the wordmark doubles as the attribution — the one way out of a
+  // partner's iframe to the full site — unless the partner opted out of it.
+  const attributionHref = embed.isEmbed && embed.config?.attribution !== false ? (process.env.NEXT_PUBLIC_CANONICAL_URL ?? "/") : undefined;
+  const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
+
+  const comparisonRoute = routes.comparison(segments, locale);
+
+  const handleBackClick = () => {
     router.push(routes.review(segments, locale));
   };
 
-  const handleNextClick = () => {
-    router.push(routes.comparison(segments, locale));
+  const handleCompareClick = () => {
+    router.push(comparisonRoute);
   };
 
-  const handleCloseClick = async () => {
-    try {
-      const hasValidMatches = algorithmMatches?.some((match) => match.match !== undefined);
+  /*
+   * The dashboard's deep links into the comparison — the same `?filter=` the
+   * comparison page reads on arrival (see `lib/routing/comparison-filter.ts`).
+   * The topic link is wired the way the other apps wire it, but this site's
+   * topics are Cyrillic and the app package's `topicSlug` is Latin-only, so
+   * the dashboard shows every topic row as plain text and never calls this
+   * today; it starts working the day the slug learns the script.
+   */
+  const handleCompareTopicClick = (topicSlug: string) => {
+    router.push(`${comparisonRoute}${comparisonFilterQuery({ topic: topicSlug })}`);
+  };
 
-      if (answersStore.length > 0 && hasValidMatches) {
-        await saveSessionData(calculator.id, answersStore, algorithmMatches, calculator.version);
-      }
+  const handleCompareImportantClick = () => {
+    router.push(`${comparisonRoute}${comparisonFilterQuery("important")}`);
+  };
+
+  /*
+   * Everything that leaves the app — the address handed to the OS share sheet
+   * and the public link — is addressed outside any embed (`stripEmbed`): a
+   * link shared out of a partner's iframe should open the full site, not a
+   * chrome-stripped embed orphaned from the page it was designed to sit in.
+   */
+  const canonicalSegments = useMemo(() => stripEmbed(segments), [segments]);
+
+  /*
+   * The sheet's address is the calculator's *intro*, never this results page
+   * — a recipient who opened this page's own URL would see the sender's
+   * ranking, not a blank calculator waiting for their own answers. The origin
+   * comes from the page rather than from configuration: it has to be the
+   * site the reader is actually on (staging, a preview deployment), and there
+   * is no `window` to read it from during the server render, hence the
+   * effect.
+   */
+  const [shareUrl, setShareUrl] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    setShareUrl(new URL(routes.introduction(canonicalSegments, locale), window.location.origin).toString());
+  }, [canonicalSegments, locale]);
+
+  /*
+   * "Копирај линк": the existing `sessions:share` endpoint mints the
+   * session's public id (idempotently — a session that already has one gets
+   * the same one back, so pressing twice cannot mint two links to one
+   * result), and the link is the canonical public-result address the retired
+   * share modal copied. A mint that fails is reported and answered with
+   * `null`, which the dialog turns into its own message.
+   */
+  const requestShareLink = useCallback(async () => {
+    try {
+      const { publicId } = await shareSession(calculator.id);
+      return canonical.publicResult(canonicalSegments, publicId, locale);
     } catch (error) {
       reportError(error);
+      return null;
     }
-    router.push("/");
-  };
+  }, [calculator.id, canonicalSegments, locale]);
 
-  const handleShareClick = () => {
-    setIsShareModalOpen(true);
-  };
+  /*
+   * "Completed" the moment the ranking is first on screen for its owner —
+   * the page gates it past the calculating beat and off a shared result, so
+   * it means the same thing as the ranking `saveSessionData` marks the
+   * session finished with.
+   */
+  const handleRankingShown = useCallback(() => {
+    trackEvent("Calculator completed", { calculator: calculator.id });
+  }, [calculator.id]);
 
-  const donateCardPosition = embed.isEmbed ? (embed.config?.donateCard ?? 1) : 5;
+  const share = useMemo<ResultPageShare>(
+    () => ({
+      url: shareUrl,
+      onRequestShareLink: sessionStatus === "ready" ? requestShareLink : undefined,
+      // The card's pictures go through the same-origin proxy: the canvas
+      // export needs readable pixels, and the data CDN sends no CORS header.
+      assetUrl: (url) => toProxiedAssetUrl(url, { assetBase: baseUrl, group: calculatorGroup, key: calculatorKey }) ?? url,
+      // Only a completed hand-off reaches here — the dialog reports nothing for a dismissed sheet or a failure.
+      onShared: (method) => trackEvent("Result shared", { calculator: calculator.id, method }),
+    }),
+    [shareUrl, sessionStatus, requestShareLink, baseUrl, calculatorGroup, calculatorKey, calculator.id],
+  );
 
+  /*
+   * No donate card: this site has no donation platform (the legacy
+   * `calculator/components/client/donate-card.tsx` is a stub that renders
+   * nothing), so the slot the Czech and Slovak pages fill stays empty rather
+   * than mounting a card with nothing in it.
+   */
   return (
-    <>
-      <AppResultPage
-        embedContext={embed}
-        calculator={calculator}
-        result={result}
-        onNextClick={handleNextClick}
-        onPreviousClick={handlePreviousClick}
-        onCloseClick={handleCloseClick}
-        onShareClick={handleShareClick}
-        showOnlyNested={showOnlyNested}
-        onFilterChange={setShowOnlyNested}
-        donateCardPosition={donateCardPosition}
-      />
-      <ShareModal calculatorId={calculator.id} segments={segments} isOpen={isShareModalOpen} onClose={() => setIsShareModalOpen(false)} />
-    </>
+    <ResultPage
+      appTitle="Изборен калкулатор"
+      electionName={electionName}
+      calculatorName={calculatorName}
+      headerActions={<CalculatorMenu segments={segments} matches={algorithmMatches} />}
+      attributionHref={attributionHref}
+      logoMonochrome={logoMonochrome}
+      onBackClick={handleBackClick}
+      onCompareClick={handleCompareClick}
+      onCompareTopicClick={handleCompareTopicClick}
+      onCompareImportantClick={handleCompareImportantClick}
+      onRankingShown={handleRankingShown}
+      share={share}
+    />
   );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/review.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/review.tsx
@@ -1,56 +1,70 @@
-import { useAnswers, useAnswersStore, useCalculator, useQuestions } from "@kalkulacka-one/app/client";
+import { ReviewPage } from "@kalkulacka-one/app";
+import { useCalculator, useQuestions } from "@kalkulacka-one/app/client";
 
 import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
+import { useEffect } from "react";
 
-import { ReviewPage as AppReviewPage } from "@/calculator";
-import { useEmbed } from "@/components/client";
+import { CalculatorMenu, useEmbed } from "@/components/client";
+import { calculatorNames } from "@/config/calculator-names";
 import { useAutoSave } from "@/hooks/auto-save";
-import { saveSessionData } from "@/lib/api";
-import { reportError } from "@/lib/monitoring";
 import { type RouteSegments, routes } from "@/lib/routing";
 
 export function ReviewPageWithRouting({ segments }: { segments: RouteSegments }) {
   const router = useRouter();
   const calculator = useCalculator();
-  const questions = useQuestions();
-  const answersStore = useAnswersStore((state) => state.answers);
-  const answers = useAnswers();
+  const { total } = useQuestions();
   const embed = useEmbed();
   const locale = useLocale();
 
   useAutoSave();
 
-  const handleNextClick = () => {
-    router.push(routes.result(segments, locale));
+  // A standalone calculator is named by its own data; there is no election
+  // group to name it after — see `config/calculator-names.ts`.
+  const { electionName, calculatorName } = calculatorNames({
+    key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    title: calculator.title || undefined,
+    shortTitle: calculator.shortTitle,
+  });
+
+  // In an embed the wordmark doubles as the attribution — the one way out of a
+  // partner's iframe to the full site — unless the partner opted out of it.
+  const attributionHref = embed.isEmbed && embed.config?.attribution !== false ? (process.env.NEXT_PUBLIC_CANONICAL_URL ?? "/") : undefined;
+  const logoMonochrome = embed.isEmbed && embed.config?.logo === "monochrome";
+
+  const resultRoute = routes.result(segments, locale);
+
+  /*
+   * Warm the results route while the recap is being read. The screen after
+   * this one opens on a loading animation that should start the moment the
+   * button is pressed, not after an RSC round-trip — and the button is a
+   * `router.push`, not a `<Link>`, so nothing prefetches it on its own.
+   * Explicit is cheap. (No-op in dev.)
+   */
+  useEffect(() => {
+    router.prefetch(resultRoute);
+  }, [router, resultRoute]);
+
+  // The recap follows the deck's end, so "back" is the card it came from — the
+  // last question — as 2026 has it, not the first.
+  const handleBackClick = () => {
+    router.push(routes.question(segments, total, locale));
   };
 
-  const handlePreviousClick = () => {
-    router.push(routes.question(segments, questions.total, locale));
-  };
-
-  const handleCloseClick = async () => {
-    try {
-      if (answersStore.length > 0) {
-        await saveSessionData(calculator.id, answersStore, undefined, calculator.version);
-      }
-    } catch (error) {
-      reportError(error);
-    }
-    router.push("/");
+  const handleShowResultsClick = () => {
+    router.push(resultRoute);
   };
 
   return (
-    <div>
-      <AppReviewPage
-        embedContext={embed}
-        calculator={calculator}
-        questions={questions}
-        answers={answers}
-        onNextClick={handleNextClick}
-        onPreviousClick={handlePreviousClick}
-        onCloseClick={handleCloseClick}
-      />
-    </div>
+    <ReviewPage
+      appTitle="Изборен калкулатор"
+      electionName={electionName}
+      calculatorName={calculatorName}
+      headerActions={<CalculatorMenu segments={segments} />}
+      attributionHref={attributionHref}
+      logoMonochrome={logoMonochrome}
+      onBackClick={handleBackClick}
+      onShowResultsClick={handleShowResultsClick}
+    />
   );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/provider-layout.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/provider-layout.tsx
@@ -2,19 +2,28 @@ import type { CalculatorData } from "@kalkulacka-one/app";
 
 import type { PropsWithChildren } from "react";
 
-import { Layout as AppLayout } from "@/calculator";
 import { AnswersStoreProvider, CalculatorStoreProvider } from "@/calculator/client";
 
 export type ProviderLayout = PropsWithChildren<{
   calculatorData: CalculatorData;
 }>;
 
+/**
+ * The stores around every calculator screen — and nothing else in the DOM.
+ *
+ * This used to also wrap the screens in the legacy `Layout` grid. The legacy
+ * pages render that grid themselves, so for them it was a second, redundant
+ * one; for the ported screens it broke the `Shell`'s `height: 100%` chain
+ * from `<body>` (a grid row sized `auto` gives a percentage height nothing to
+ * resolve against), which on a desktop left a reading screen taller than the
+ * viewport unable to scroll — the guide's "Разбирам, почни" was simply below
+ * the fold with no way down to it. The shell is now the body's direct child,
+ * the way 2026 lays it out.
+ */
 export function ProviderLayout({ calculatorData, children }: ProviderLayout) {
   return (
     <CalculatorStoreProvider calculatorData={calculatorData}>
-      <AnswersStoreProvider>
-        <AppLayout>{children}</AppLayout>
-      </AnswersStoreProvider>
+      <AnswersStoreProvider>{children}</AnswersStoreProvider>
     </CalculatorStoreProvider>
   );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/session-initializer.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/session-initializer.tsx
@@ -6,6 +6,7 @@ import { initializeSession } from "@/lib/api";
 import { reportError } from "@/lib/monitoring";
 
 import { useEmbed } from "./embed-context-provider";
+import { useSetSessionStatus } from "./session-status";
 
 type CalculatorWithVariant = {
   variant: { key: string };
@@ -21,6 +22,7 @@ export function SessionInitializer() {
   const initialized = useRef(false);
   const calculator = useCalculatorStore((state) => state.data.calculator);
   const embed = useEmbed();
+  const setSessionStatus = useSetSessionStatus();
 
   useEffect(() => {
     if (initialized.current) {
@@ -38,17 +40,22 @@ export function SessionInitializer() {
       calculatorGroup,
       calculatorVersion: calculator.version,
       embedName: embed.isEmbed ? embed.name : undefined,
-    }).catch((error: Response | Error) => {
-      if (error instanceof Response) {
-        if (error.status === 404 || error.status === 401) {
-          return;
+    })
+      // Answered: there is a backend, and the screens that need one — the
+      // share dialog's public link — may now offer it.
+      .then(() => setSessionStatus("ready"))
+      .catch((error: Response | Error) => {
+        setSessionStatus("unavailable");
+        if (error instanceof Response) {
+          if (error.status === 404 || error.status === 401) {
+            return;
+          }
+          reportError(new Error(`Session initialization failed: ${error.status} ${error.statusText}`));
+        } else {
+          reportError(error);
         }
-        reportError(new Error(`Session initialization failed: ${error.status} ${error.statusText}`));
-      } else {
-        reportError(error);
-      }
-    });
-  }, [calculator, embed]);
+      });
+  }, [calculator, embed, setSessionStatus]);
 
   return null;
 }

--- a/apps/www.izborenkalkulator.mk/components/client/session-provider-layout.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/session-provider-layout.tsx
@@ -5,6 +5,7 @@ import type { PropsWithChildren } from "react";
 import { ProviderLayout } from "./provider-layout";
 import { SessionDataLoader } from "./session-data-loader";
 import { SessionInitializer } from "./session-initializer";
+import { SessionStatusProvider } from "./session-status";
 
 export type SessionProviderLayout = PropsWithChildren<{
   calculatorData: CalculatorData;
@@ -13,9 +14,11 @@ export type SessionProviderLayout = PropsWithChildren<{
 export function SessionProviderLayout({ calculatorData, children }: SessionProviderLayout) {
   return (
     <ProviderLayout calculatorData={calculatorData}>
-      <SessionInitializer />
-      <SessionDataLoader />
-      {children}
+      <SessionStatusProvider>
+        <SessionInitializer />
+        <SessionDataLoader />
+        {children}
+      </SessionStatusProvider>
     </ProviderLayout>
   );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/session-status.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/session-status.tsx
@@ -1,0 +1,36 @@
+import { createContext, type ReactNode, useContext, useMemo, useState } from "react";
+
+/**
+ * Whether the session backend is there.
+ *
+ * `unknown` until `SessionInitializer`'s first call comes back; `ready` once
+ * the sessions endpoint has answered — which is the only honest way to know
+ * there is a database behind it. The session cookie's name is configured in
+ * `.env` for every checkout, so its presence says nothing about that: a local
+ * checkout without a database has the name and no backend, and a "Копирај
+ * линк" gated on the name alone would be a dead button there.
+ */
+export type SessionStatus = "unknown" | "ready" | "unavailable";
+
+type SessionStatusValue = {
+  status: SessionStatus;
+  setStatus: (status: SessionStatus) => void;
+};
+
+const SessionStatusContext = createContext<SessionStatusValue | undefined>(undefined);
+
+export function SessionStatusProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<SessionStatus>("unknown");
+  const value = useMemo(() => ({ status, setStatus }), [status]);
+  return <SessionStatusContext.Provider value={value}>{children}</SessionStatusContext.Provider>;
+}
+
+/** The backend's state, for the screens that offer something only a backend can do. Outside a provider it is simply never `ready`. */
+export function useSessionStatus(): SessionStatus {
+  return useContext(SessionStatusContext)?.status ?? "unknown";
+}
+
+/** The initializer's side: the one place the status is written. */
+export function useSetSessionStatus(): (status: SessionStatus) => void {
+  return useContext(SessionStatusContext)?.setStatus ?? (() => {});
+}

--- a/apps/www.izborenkalkulator.mk/config/calculator-names.ts
+++ b/apps/www.izborenkalkulator.mk/config/calculator-names.ts
@@ -1,0 +1,31 @@
+// The Macedonian counterpart of the Czech app's `config/calculator-names.ts`
+
+/**
+ * Display names for the shell and the introduction.
+ *
+ * The Czech app keys these by election group and calculator key, because a
+ * group calculator's `calculator.json` carries no display name. This site
+ * runs one standalone calculator (`kompas-2025`), and a standalone
+ * calculator's data does carry its own `title` and `shortTitle` — so the
+ * names come from the data, with the same shape the screens expect. There is
+ * no election to name: a standalone calculator sits in no group, and the
+ * header shows the app title on its own.
+ */
+
+export type CalculatorNames = {
+  /** The election's display name; absent for a standalone calculator, which belongs to no election group. */
+  electionName?: string;
+  /** The calculator's display name — the introduction's heading. */
+  calculatorName: string;
+};
+
+/**
+ * The names for a calculator, from the data's own `title` — or, failing that,
+ * its `shortTitle`, or the key itself.
+ */
+export function calculatorNames({ key, title, shortTitle }: { key?: string; title?: string; shortTitle?: string }): CalculatorNames {
+  return {
+    electionName: undefined,
+    calculatorName: title || shortTitle || key || "",
+  };
+}

--- a/apps/www.izborenkalkulator.mk/config/themes.ts
+++ b/apps/www.izborenkalkulator.mk/config/themes.ts
@@ -1,3 +1,15 @@
 export const themeNames = ["default"] as const;
 
 export type ThemeName = (typeof themeNames)[number];
+
+/**
+ * Whether a theme ships one palette only. This site has no partner theme —
+ * the default is the only one, and it is authored for both modes (it is the
+ * Czech default, borrowed; see `components/client/themes/default-theme.tsx`)
+ * — so the shell menu's light/dark toggle is never withheld here. Kept as the
+ * same question the Czech app's menu asks, so a partner theme that pins
+ * `color-scheme: light` in its stylesheet can be added by listing it.
+ */
+export function isSingleModeTheme(name: ThemeName): boolean {
+  return name !== "default";
+}

--- a/apps/www.izborenkalkulator.mk/hooks/calculator-actions.ts
+++ b/apps/www.izborenkalkulator.mk/hooks/calculator-actions.ts
@@ -1,0 +1,67 @@
+import type { calculateMatches } from "@kalkulacka-one/app";
+import { useAnswersStore, useCalculator } from "@kalkulacka-one/app/client";
+
+import { useRouter } from "next/navigation";
+import { useLocale } from "next-intl";
+
+import { saveSessionData } from "@/lib/api";
+import { reportError } from "@/lib/monitoring";
+import { type RouteSegments, routes } from "@/lib/routing";
+
+export type UseCalculatorActionsOptions = {
+  segments: RouteSegments;
+  /** The ranking, on the screens that have one — saved with the answers, which is what marks the session finished server-side. */
+  matches?: ReturnType<typeof calculateMatches>;
+};
+
+/**
+ * The two things the shell menu — and the intro's own "Почни одново" — can do
+ * to the reader's session: leave it, and wipe it.
+ *
+ * Leaving saves first, because the reassurance in the leave dialog is only
+ * true once the answers are on the server; a save that fails is reported,
+ * not fatal, and the exit still happens. Restarting clears the store and then
+ * persists the *empty* answers, because the session loader would otherwise
+ * hand the old ones straight back on the next reload. The ranking stored
+ * with the previous answers is left as it was: the session endpoint has no
+ * way to unset it, and the next visit to the results replaces it.
+ */
+export function useCalculatorActions({ segments, matches }: UseCalculatorActionsOptions) {
+  const router = useRouter();
+  const calculator = useCalculator();
+  const locale = useLocale();
+  const answers = useAnswersStore((state) => state.answers);
+  const clearAnswers = useAnswersStore((state) => state.clearAnswers);
+
+  // A ranking with no computed match in it is not a result worth recording.
+  const validMatches = matches?.some((match) => match.match !== undefined) ? matches : undefined;
+
+  const leave = async () => {
+    try {
+      if (answers.length > 0) {
+        await saveSessionData(calculator.id, answers, validMatches, calculator.version);
+      }
+    } catch (error) {
+      reportError(error);
+    }
+    router.push("/");
+  };
+
+  const restart = async () => {
+    const hadAnswers = answers.length > 0;
+    clearAnswers();
+    try {
+      // Only when there was something to wipe: a visitor with no answers has
+      // no session data yet, and writing an empty set would only manufacture
+      // a "session missing" error to report.
+      if (hadAnswers) {
+        await saveSessionData(calculator.id, [], undefined, calculator.version);
+      }
+    } catch (error) {
+      reportError(error);
+    }
+    router.push(routes.question(segments, 1, locale));
+  };
+
+  return { leave, restart };
+}

--- a/apps/www.izborenkalkulator.mk/lib/analytics/index.ts
+++ b/apps/www.izborenkalkulator.mk/lib/analytics/index.ts
@@ -1,0 +1,1 @@
+export * from "./track-event";

--- a/apps/www.izborenkalkulator.mk/lib/analytics/track-event.test.ts
+++ b/apps/www.izborenkalkulator.mk/lib/analytics/track-event.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { trackEvent } from "./track-event";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  Reflect.deleteProperty(window, "plausible");
+});
+
+describe("trackEvent", () => {
+  it("does nothing when the script never installed window.plausible — this site's everyday case, with analytics off", () => {
+    expect(window.plausible).toBeUndefined();
+    expect(() => trackEvent("Calculator started", { calculator: "abc" })).not.toThrow();
+  });
+
+  it("does nothing without a window at all — a server render calling it by mistake", () => {
+    vi.stubGlobal("window", undefined);
+    expect(() => trackEvent("Calculator started", { calculator: "abc" })).not.toThrow();
+  });
+
+  it("forwards the event with its props under the `props` key the script expects", () => {
+    const plausible = vi.fn();
+    window.plausible = plausible;
+
+    trackEvent("Calculator completed", { calculator: "abc" });
+    expect(plausible).toHaveBeenCalledWith("Calculator completed", { props: { calculator: "abc" } });
+
+    trackEvent("Result shared", { calculator: "abc", method: "link" });
+    expect(plausible).toHaveBeenLastCalledWith("Result shared", { props: { calculator: "abc", method: "link" } });
+  });
+});

--- a/apps/www.izborenkalkulator.mk/lib/analytics/track-event.ts
+++ b/apps/www.izborenkalkulator.mk/lib/analytics/track-event.ts
@@ -1,0 +1,29 @@
+// The custom events the calculator flow reports, fired straight through `window.plausible` — installed by the script
+// `components/server/plausible.tsx` loads. On this site analytics is switched off (`ENABLE_ANALYTICS=false`), so that
+// script never loads and every call here is a no-op; the wiring is kept identical to the other apps' so that turning
+// analytics on is one environment variable, not a port.
+
+/** The four events, with the props each carries: the calculator's id on every one, and which action completed on the share. */
+export type TrackedEvent = {
+  "Calculator started": { calculator: string };
+  "Calculator completed": { calculator: string };
+  "Comparison viewed": { calculator: string };
+  "Result shared": { calculator: string; method: "image" | "image-copy" | "image-download" | "link" };
+};
+
+declare global {
+  interface Window {
+    /** Installed by the Plausible script tag itself — absent whenever that script never loaded, which is the only signal this module needs. */
+    plausible?: (name: string, options?: { props?: Record<string, string | number | boolean> }) => void;
+  }
+}
+
+/**
+ * Fire a Plausible custom event. A no-op wherever `window.plausible` isn't there to answer — analytics off, the script
+ * blocked or still loading, or a server render calling this by mistake — so every call site can fire and forget without
+ * checking whether analytics is even on.
+ */
+export function trackEvent<Name extends keyof TrackedEvent>(name: Name, props: TrackedEvent[Name]): void {
+  if (typeof window === "undefined") return;
+  window.plausible?.(name, { props });
+}

--- a/apps/www.izborenkalkulator.mk/lib/routing/comparison-filter.test.ts
+++ b/apps/www.izborenkalkulator.mk/lib/routing/comparison-filter.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { COMPARISON_FILTER_PARAM, comparisonFilterQuery, parseComparisonFilter } from "./comparison-filter";
+
+describe("comparisonFilterQuery", () => {
+  it("writes nothing for everything", () => {
+    expect(comparisonFilterQuery(undefined)).toBe("");
+  });
+
+  it("writes the starred questions and a topic slug on the one parameter", () => {
+    expect(comparisonFilterQuery("important")).toBe(`?${COMPARISON_FILTER_PARAM}=vazni`);
+    expect(comparisonFilterQuery({ topic: "ekonomija" })).toBe(`?${COMPARISON_FILTER_PARAM}=ekonomija`);
+  });
+
+  it("escapes what a slug should never contain, rather than trusting it", () => {
+    expect(comparisonFilterQuery({ topic: "a b&c" })).toBe(`?${COMPARISON_FILTER_PARAM}=a%20b%26c`);
+  });
+});
+
+describe("parseComparisonFilter", () => {
+  it("reads a missing or empty parameter as everything", () => {
+    expect(parseComparisonFilter(null)).toBeUndefined();
+    expect(parseComparisonFilter(undefined)).toBeUndefined();
+    expect(parseComparisonFilter("")).toBeUndefined();
+  });
+
+  it("reads the starred questions and leaves any other value to the page as a topic slug", () => {
+    expect(parseComparisonFilter("vazni")).toBe("important");
+    expect(parseComparisonFilter("ekonomija")).toEqual({ topic: "ekonomija" });
+  });
+
+  it("round-trips", () => {
+    for (const filter of [undefined, "important" as const, { topic: "vrednosti" }]) {
+      const query = comparisonFilterQuery(filter);
+      expect(parseComparisonFilter(new URLSearchParams(query).get(COMPARISON_FILTER_PARAM))).toEqual(filter);
+    }
+  });
+});

--- a/apps/www.izborenkalkulator.mk/lib/routing/comparison-filter.ts
+++ b/apps/www.izborenkalkulator.mk/lib/routing/comparison-filter.ts
@@ -1,0 +1,43 @@
+import type { ComparisonFilter } from "@kalkulacka-one/app";
+
+/**
+ * The comparison view's filter, as a query parameter.
+ *
+ * The URL grammar of kalkulacka-2026/apps/web/lib/comparison-filters.ts, where
+ * the filter was a route segment (`/porovnani/dulezite`, `/porovnani/<topic>`).
+ * This app's routes have no such segment, so the same two forms ride on
+ * `?filter=` instead: `vazni` is the starred questions, a topic slug one
+ * theme, and no parameter at all is everything — which is what lets a
+ * dashboard card be a plain link and a filtered view survive being shared.
+ * The topic slug is the app package's `topicSlug`, so a link written by the
+ * results page and one typed by hand resolve the same way. (This site's own
+ * topics are Cyrillic, which that slug cannot spell — so no dashboard row
+ * writes a topic link here today; the parameter still reads one, for the day
+ * the slug learns the script.)
+ *
+ * The parameter and the value are Latin transliterations, like the route
+ * slugs in `messages/mk.json` (`voved`, `prasanje`, …): a Cyrillic query
+ * would be percent-encoded into something nobody can read back off a link.
+ */
+export const COMPARISON_FILTER_PARAM = "filter";
+
+const IMPORTANT_SLUG = "vazni";
+
+/** `?filter=…` for a filter, or the empty string for everything — ready to append to the comparison route. */
+export function comparisonFilterQuery(filter: ComparisonFilter | undefined): string {
+  if (filter === undefined) return "";
+
+  const value = filter === "important" ? IMPORTANT_SLUG : filter.topic;
+  return `?${COMPARISON_FILTER_PARAM}=${encodeURIComponent(value)}`;
+}
+
+/**
+ * The inverse, from the raw parameter. Whether a topic slug names a real topic
+ * is the page's call — it has the calculator's topics, this does not — and a
+ * slug that names none degrades to everything there rather than to a 404.
+ */
+export function parseComparisonFilter(value: string | null | undefined): ComparisonFilter | undefined {
+  if (!value) return undefined;
+  if (value === IMPORTANT_SLUG) return "important";
+  return { topic: value };
+}

--- a/apps/www.izborenkalkulator.mk/lib/routing/index.ts
+++ b/apps/www.izborenkalkulator.mk/lib/routing/index.ts
@@ -1,3 +1,4 @@
+export * from "./comparison-filter";
 export * from "./params-mapper";
 export * from "./prefixes";
 export * from "./route-builders";

--- a/apps/www.izborenkalkulator.mk/lib/routing/url-builders.ts
+++ b/apps/www.izborenkalkulator.mk/lib/routing/url-builders.ts
@@ -12,7 +12,8 @@ export function buildCanonicalUrl(path: string): string {
   return `${baseUrl}${normalizedPath}`;
 }
 
-function stripEmbed(segments: RouteSegments): RouteSegments {
+/** The same calculator, addressed outside any embed — what every address that leaves the app is built from. */
+export function stripEmbed(segments: RouteSegments): RouteSegments {
   const { embed: _embed, ...rest } = segments;
   return rest;
 }

--- a/apps/www.izborenkalkulator.mk/lib/share-asset-url.test.ts
+++ b/apps/www.izborenkalkulator.mk/lib/share-asset-url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { toProxiedAssetUrl } from "./share-asset-url";
+
+// This site's one calculator is standalone: addressed under the endpoint by its key alone.
+const calculator = { assetBase: "https://data.kalkulacka.one/www.izborenkalkulator.mk/kompas-2025", key: "kompas-2025" };
+
+describe("toProxiedAssetUrl", () => {
+  it("routes one of the calculator's own pictures through the proxy, addressed by the calculator's key", () => {
+    expect(toProxiedAssetUrl(`${calculator.assetBase}/images/abc/logo.md.webp`, calculator)).toBe("/api/assets/kompas-2025/images/abc/logo.md.webp");
+  });
+
+  it("puts a group calculator's group back in front of its key", () => {
+    const grouped = { assetBase: "https://data.kalkulacka.one/www.izborenkalkulator.mk/parlamentarni-2028/kalkulator", group: "parlamentarni-2028", key: "kalkulator" };
+    expect(toProxiedAssetUrl(`${grouped.assetBase}/images/logo.png`, grouped)).toBe("/api/assets/parlamentarni-2028/kalkulator/images/logo.png");
+  });
+
+  it("leaves anything that is not one of the calculator's own pictures alone", () => {
+    expect(toProxiedAssetUrl("https://elsewhere.example/logo.png", calculator)).toBe("https://elsewhere.example/logo.png");
+    expect(toProxiedAssetUrl(calculator.assetBase, calculator)).toBe(calculator.assetBase);
+    expect(toProxiedAssetUrl(undefined, calculator)).toBeUndefined();
+  });
+});

--- a/apps/www.izborenkalkulator.mk/lib/share-asset-url.ts
+++ b/apps/www.izborenkalkulator.mk/lib/share-asset-url.ts
@@ -1,0 +1,33 @@
+// Ported from kalkulacka-2026/apps/web/lib/share-asset-url.ts
+
+const PROXY_PREFIX = "/api/assets/";
+
+/**
+ * Rewrite one of a calculator's own asset URLs to the same-origin proxy, for
+ * the share-card export only (`app/api/assets/[...path]/route.ts`).
+ *
+ * `html-to-image` re-fetches every `<img>`'s pixels itself to paint the
+ * canvas, and the data CDN sends no `Access-Control-Allow-Origin` — so that
+ * fetch is blocked even though the `<img>` displays fine everywhere else.
+ * `assetBase` is what tells "one of this calculator's own images" apart from
+ * any other absolute URL a candidate's data could carry: only a URL that
+ * actually starts with it is rewritten. Anything else — an archive fixture's
+ * avatar, resolved against a different host entirely — is left as-is rather
+ * than routed through a proxy that would just reject it.
+ *
+ * The proxy resolves its path against `DATA_ENDPOINT`, while `assetBase` is
+ * the *calculator's* base — the store's `baseUrl`, which `loadCalculatorData`
+ * builds as endpoint plus `{group}/{key}` (or just `{key}` for a standalone
+ * calculator). Those segments must therefore be put back in front of the
+ * remainder, or the proxied path points at the endpoint root.
+ */
+export function toProxiedAssetUrl(url: string | undefined, calculator: { assetBase: string; group?: string; key?: string }): string | undefined {
+  const { assetBase, group, key } = calculator;
+  // No key means no way to name the calculator under the endpoint: leave the picture where it is.
+  if (!url || !assetBase || !key || !url.startsWith(assetBase)) return url;
+
+  const rest = url.slice(assetBase.length).replace(/^\/+/, "");
+  if (!rest) return url;
+
+  return `${PROXY_PREFIX}${group ? `${group}/${key}` : key}/${rest}`;
+}

--- a/apps/www.izborenkalkulator.mk/package.json
+++ b/apps/www.izborenkalkulator.mk/package.json
@@ -5,12 +5,15 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev --port 3050",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "start": "next start",
     "ncu": "ncu",
     "ncu:upgrade": "ncu -u",
-    "test": "vitest --passWithNoTests",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/www.izborenkalkulator.mk/playwright.config.ts
+++ b/apps/www.izborenkalkulator.mk/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// This app's own dev port (see `package.json`), or wherever a build is already being served — `next start` on another port, say.
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3050";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: {
+    command: "npm run dev",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/apps/www.izborenkalkulator.mk/tests/e2e/calculator-flow.spec.ts
+++ b/apps/www.izborenkalkulator.mk/tests/e2e/calculator-flow.spec.ts
@@ -1,0 +1,246 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+type CalculatorConfig = {
+  key: string;
+  name: string;
+  path: string;
+  expectedTitle?: string;
+};
+
+// This site runs one standalone calculator, addressed by its key alone — no election group in the path.
+const CALCULATORS: CalculatorConfig[] = [
+  {
+    key: "kompas-2025",
+    name: "Изборен компас",
+    path: "/kompas-2025",
+    expectedTitle: "Изборен компас 2025",
+  },
+];
+
+const TIMEOUTS = {
+  DEFAULT: 30000,
+  STANDARD: 60000,
+  EXTENDED: 90000,
+  LOAD_STATE: 15000,
+  RETRY_DELAY: 1000,
+  ACTION_DELAY: 500,
+  QUESTION_DELAY: 2000,
+  VISIBILITY_CHECK: 10000,
+  HEADING_VISIBILITY: 15000,
+} as const;
+
+// Helper functions
+async function waitForPageLoad(page: Page, timeout = TIMEOUTS.DEFAULT) {
+  try {
+    await page.waitForLoadState("networkidle", { timeout });
+  } catch {
+    await page.waitForLoadState("load", { timeout: TIMEOUTS.LOAD_STATE });
+  }
+}
+
+async function checkForErrors(page: Page): Promise<boolean> {
+  const errorElement = page.locator("text=/Error|error|грешка|Грешка|Failed|failed/i");
+  return (await errorElement.count()) > 0;
+}
+
+async function clickWithRetry(locator: Locator, maxRetries = 3, timeout = TIMEOUTS.VISIBILITY_CHECK) {
+  for (let retry = 0; retry < maxRetries; retry++) {
+    try {
+      await locator.click({ timeout });
+      return true;
+    } catch {
+      if (retry < maxRetries - 1) {
+        await locator.page().waitForTimeout(TIMEOUTS.RETRY_DELAY);
+      }
+    }
+  }
+  return false;
+}
+
+async function navigateToCalculator(page: Page, calculator: CalculatorConfig) {
+  await page.goto("/");
+  await page.locator(`a[href="${calculator.path}"]`).click();
+  await page.waitForURL(new RegExp(`.*${calculator.path}/voved`), { timeout: TIMEOUTS.STANDARD });
+  await expect(page).toHaveURL(new RegExp(`.*${calculator.path}/voved`));
+  await waitForPageLoad(page);
+  await expect(page.locator("main")).toBeVisible();
+  return await checkForErrors(page);
+}
+
+async function navigateToVodic(page: Page, calculator: CalculatorConfig) {
+  const vodicButton = page.locator('a[href*="/vodic"], button:has-text("Водич"), button:has-text("Продолжи")').first();
+  if (await vodicButton.isVisible()) {
+    await vodicButton.click();
+    try {
+      await page.waitForURL(new RegExp(`.*${calculator.path}/vodic`), { timeout: TIMEOUTS.STANDARD });
+      await expect(page).toHaveURL(new RegExp(`.*${calculator.path}/vodic`));
+      await expect(page.locator("main")).toBeVisible();
+    } catch {
+      console.log(`Navigation to guide failed for ${calculator.name}`);
+    }
+  }
+}
+
+async function startQuestions(page: Page, calculator: CalculatorConfig) {
+  const questionButton = page
+    .locator('a[href*="/prasanje"], button:has-text("Разбирам, почни"), button:has-text("Започни со одговарање"), button:has-text("Продолжи"), button:has-text("Прво прашање")')
+    .first();
+
+  let isVisible = false;
+  try {
+    isVisible = await questionButton.isVisible();
+  } catch {
+    try {
+      await page.goto(`${calculator.path}/voved`);
+      await page.waitForLoadState("load", { timeout: TIMEOUTS.LOAD_STATE });
+      isVisible = await questionButton.isVisible();
+    } catch {
+      return false;
+    }
+  }
+
+  if (isVisible) {
+    await questionButton.click();
+    try {
+      await page.waitForURL(new RegExp(`.*${calculator.path}/(prasanje|prasanje/1)`), { timeout: TIMEOUTS.STANDARD });
+    } catch {
+      console.log(`Question navigation timeout for ${calculator.name}`);
+    }
+    return true;
+  }
+  return false;
+}
+
+async function answerQuestions(page: Page, maxQuestions = 3) {
+  for (let i = 0; i < maxQuestions; i++) {
+    try {
+      await expect(page.locator("main")).toBeVisible();
+
+      // By role, so the answer buttons on the cards stacked behind the active one
+      // (inert and `aria-hidden`, but earlier in the DOM) are never the first match.
+      const answerOptions = page.locator('button[role="radio"], input[type="radio"]').or(page.getByRole("button", { name: /^(Да|Не)$/ }));
+
+      if ((await answerOptions.count()) === 0) break;
+
+      if (!(await clickWithRetry(answerOptions.first()))) break;
+      await page.waitForTimeout(TIMEOUTS.ACTION_DELAY);
+
+      // Answering moves to the next question on its own; a "Следно" is only there to press when the question was already answered.
+      const nextButton = page.locator('button:has-text("Следно"), button:has-text("Продолжи"), a:has-text("Следно")').first();
+      if (await nextButton.isVisible()) {
+        await page.waitForTimeout(TIMEOUTS.ACTION_DELAY);
+        if (!(await clickWithRetry(nextButton))) break;
+      }
+
+      await page.waitForTimeout(TIMEOUTS.QUESTION_DELAY);
+    } catch {
+      break;
+    }
+  }
+}
+
+for (const calculator of CALCULATORS) {
+  test.describe(`Calculator Flow: ${calculator.name}`, () => {
+    test("should complete the full calculator flow from homepage", async ({ page }) => {
+      test.setTimeout(TIMEOUTS.EXTENDED);
+
+      const hasError = await navigateToCalculator(page, calculator);
+      if (hasError) {
+        console.log(`Skipping test for ${calculator.name} due to data loading error`);
+        return;
+      }
+
+      await navigateToVodic(page, calculator);
+
+      if (await startQuestions(page, calculator)) {
+        await answerQuestions(page);
+        const currentUrl = page.url();
+        expect(currentUrl).toMatch(new RegExp(`.*${calculator.path}/(prasanje|pregled|rezultat)`));
+      }
+    });
+
+    test("should load introduction page directly", async ({ page }) => {
+      await page.goto(`${calculator.path}/voved`);
+      await expect(page).toHaveURL(new RegExp(`.*${calculator.path}/voved`));
+      await waitForPageLoad(page);
+      await expect(page.locator("main")).toBeVisible();
+
+      const hasError = await checkForErrors(page);
+      if (!hasError && calculator.expectedTitle) {
+        await page.waitForTimeout(TIMEOUTS.QUESTION_DELAY);
+        const heading = page.locator("h1, h2, h3").filter({ hasText: calculator.expectedTitle }).first();
+        await heading.waitFor({ state: "attached", timeout: TIMEOUTS.VISIBILITY_CHECK });
+        await expect(heading).toBeVisible({ timeout: TIMEOUTS.HEADING_VISIBILITY });
+      }
+    });
+
+    test("should handle direct navigation to question page", async ({ page }) => {
+      test.setTimeout(TIMEOUTS.EXTENDED);
+
+      try {
+        await page.goto(`${calculator.path}/prasanje`, { timeout: TIMEOUTS.STANDARD });
+      } catch {
+        console.log(`Direct navigation to question failed for ${calculator.name}, trying voved first`);
+        try {
+          await page.goto(`${calculator.path}/voved`, { timeout: TIMEOUTS.STANDARD });
+        } catch {
+          console.log(`Fallback navigation to voved also failed for ${calculator.name}, skipping test`);
+          return;
+        }
+      }
+
+      await waitForPageLoad(page);
+      expect(page.url()).toMatch(new RegExp(`.*${calculator.path}`));
+      await expect(page.locator("main")).toBeVisible();
+    });
+
+    test("should validate page accessibility and structure", async ({ page }) => {
+      await page.goto(`${calculator.path}/voved`);
+      await waitForPageLoad(page);
+
+      const h1Count = await page.locator("h1").count();
+      expect(h1Count).toBeGreaterThanOrEqual(1);
+
+      const images = page.locator("img");
+      const imageCount = await images.count();
+      if (imageCount > 0) {
+        for (let i = 0; i < imageCount; i++) {
+          await expect(images.nth(i)).toHaveAttribute("alt");
+        }
+      }
+
+      const skipLinks = page.locator('a[href^="#"], [role="button"], button');
+      expect(await skipLinks.count()).toBeGreaterThan(0);
+    });
+  });
+}
+
+test.describe("Calculator System", () => {
+  test("should handle invalid calculator paths gracefully", async ({ page }) => {
+    await page.goto("/izbori/non-existent-calculator");
+    await page.waitForLoadState("networkidle");
+
+    const hasMain = (await page.locator("main").count()) > 0;
+    const hasBody = (await page.locator("body").count()) > 0;
+
+    expect(hasMain || hasBody).toBeTruthy();
+    await expect(page.locator("body")).toBeVisible();
+  });
+
+  test("should maintain consistent navigation patterns", async ({ page }) => {
+    for (const calculator of CALCULATORS) {
+      await page.goto(`${calculator.path}/voved`);
+
+      const navigationElements = page.locator('nav, [role="navigation"], .navigation');
+      if ((await navigationElements.count()) > 0) {
+        await expect(navigationElements.first()).toBeVisible();
+      }
+
+      const progressElements = page.locator('.progress, [role="progressbar"], .breadcrumb');
+      if ((await progressElements.count()) > 0) {
+        await expect(progressElements.first()).toBeVisible();
+      }
+    }
+  });
+});

--- a/apps/www.izborenkalkulator.mk/tests/e2e/menu.spec.ts
+++ b/apps/www.izborenkalkulator.mk/tests/e2e/menu.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+/*
+ * The shell menu in the corner of every calculator screen: what it offers on
+ * the site and inside a partner iframe, and that the mode it switches
+ * survives a reload. This site has no single-mode partner theme, so there is
+ * no themed embed to check the withheld toggle on — see the Czech app's
+ * `menu.spec.ts` for that case.
+ */
+
+const INTRO = "/kompas-2025/voved";
+const EMBED_INTRO = "/embed/default/kompas-2025/voved";
+
+const MENU = "Мени";
+
+test.describe("App menu", () => {
+  test("offers help, dark mode, restart and leave on the site", async ({ page }) => {
+    await page.goto(INTRO);
+    await page.getByRole("button", { name: MENU }).click();
+
+    await expect(page.getByRole("menuitem")).toHaveText([/^Како функционира/, /^Темен режим/, /^Почни одново/, /^Напушти го калкулаторот/]);
+
+    // Escape closes it and hands focus back to the trigger.
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("menu")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: MENU })).toBeFocused();
+  });
+
+  test("the help item opens the guide's steps as a sheet", async ({ page }) => {
+    await page.goto(INTRO);
+    await page.getByRole("button", { name: MENU }).click();
+    await page.getByRole("menuitem", { name: /^Како функционира/ }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Како функционира" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole("listitem")).toHaveCount(5);
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+    // Dismissing the sheet returns focus to the menu it was opened from, not to the top of the document.
+    await expect(page.getByRole("button", { name: MENU })).toBeFocused();
+  });
+
+  test("switching to dark mode is applied at once and remembered across a reload", async ({ page }) => {
+    await page.goto(INTRO);
+    await page.getByRole("button", { name: MENU }).click();
+    await page.getByRole("menuitem", { name: /^Темен режим/ }).click();
+
+    await expect(page.locator("html")).toHaveAttribute("data-mode", "dark");
+    expect(await page.evaluate(() => getComputedStyle(document.documentElement).colorScheme)).toBe("dark");
+
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("data-mode", "dark");
+
+    // Labelled by what it switches *to*.
+    await page.getByRole("button", { name: MENU }).click();
+    await expect(page.getByRole("menuitem", { name: /^Светол режим/ })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: /^Темен режим/ })).toHaveCount(0);
+  });
+
+  test("leaving asks first and then goes to the homepage", async ({ page }) => {
+    await page.goto(INTRO);
+    await page.getByRole("button", { name: MENU }).click();
+    await page.getByRole("menuitem", { name: /^Напушти го калкулаторот/ }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Да го напуштите калкулаторот?" });
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Откажи" }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page).toHaveURL(new RegExp(`${INTRO}$`));
+
+    await page.getByRole("button", { name: MENU }).click();
+    await page.getByRole("menuitem", { name: /^Напушти го калкулаторот/ }).click();
+    await dialog.getByRole("button", { name: "Напушти", exact: true }).click();
+    await page.waitForURL(/\/$/);
+  });
+
+  test("an embed keeps help and restart but drops leaving", async ({ page }) => {
+    await page.goto(EMBED_INTRO);
+    await page.getByRole("button", { name: MENU }).click();
+
+    await expect(page.getByRole("menuitem", { name: /^Како функционира/ })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: /^Почни одново/ })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: /Напушти го калкулаторот/ })).toHaveCount(0);
+  });
+});

--- a/apps/www.izborenkalkulator.mk/tests/e2e/share.spec.ts
+++ b/apps/www.izborenkalkulator.mk/tests/e2e/share.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+
+/*
+ * The share dialog over the results: which actions it offers on a desktop
+ * browser without a backend, and that "Преземи" really hands over a PNG.
+ * The share assertions are ported from kalkulacka-2026/apps/web/e2e/calculator-flow.spec.ts.
+ */
+
+const FIRST_QUESTION = "/kompas-2025/prasanje/1";
+const TOTAL_QUESTIONS = 10;
+
+test.describe("Share dialog", () => {
+  test("opens over the results with the desktop pair — no backend, no share sheet — and downloads the card", async ({ page }) => {
+    // Nine keypresses through the deck, then the calculating beat.
+    test.setTimeout(120_000);
+
+    await page.goto(FIRST_QUESTION);
+    // One answer is all a ranking needs; the card's rows come from it.
+    await page.getByRole("button", { name: "Да", exact: true }).click();
+    await expect(page).toHaveURL(/\/prasanje\/2$/);
+
+    // `.` browses forward without touching the answer store (see
+    // question-page.tsx); past the last question it is the recap's entrance.
+    for (let position = 2; position <= TOTAL_QUESTIONS; position++) {
+      await expect(page).toHaveURL(new RegExp(`/prasanje/${position}$`));
+      await page.keyboard.press(".");
+    }
+    await expect(page).toHaveURL(/\/pregled$/);
+
+    await page.getByRole("button", { name: "Прикажи резултати", exact: true }).click();
+    await expect(page).toHaveURL(/\/rezultat$/);
+
+    await page.getByRole("button", { name: "Сподели", exact: true }).click();
+
+    /*
+     * Matched by role *and* name, which is the assertion that every `Dialog`
+     * on this page (help, restart, leave, this one) labels itself rather than
+     * borrowing a sibling's heading.
+     */
+    const dialog = page.getByRole("dialog", { name: "Сподели го резултатот" });
+    await expect(dialog).toBeVisible();
+
+    // No database locally: the sessions endpoint answers 500, so the session
+    // status never becomes `ready`, the result page never receives
+    // `onRequestShareLink`, and the dialog never renders "Копирај линк"
+    // (see `session-status.tsx`, `result.tsx` and `share-dialog.tsx`).
+    await expect(dialog.getByRole("button", { name: "Копирај линк", exact: true })).toHaveCount(0);
+
+    // `Desktop Chrome` reports a fine, hovering pointer, which `chooseShareMode`
+    // (see `packages/app/src/utilities/share-mode.ts`) always sends to the
+    // copy/download pair — never the OS share sheet, regardless of what
+    // `navigator.share` itself claims to support. So the sheet's own label
+    // must be absent, not merely optional.
+    await expect(dialog.getByRole("button", { name: "Сподели слика", exact: true })).toHaveCount(0);
+
+    await expect(dialog.getByRole("button", { name: "Копирај слика", exact: true })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Преземи", exact: true })).toBeVisible();
+
+    // Four themes and two formats, the first of each pressed; a pick moves the pressed state.
+    await expect(dialog.getByRole("button", { name: "Светла", exact: true })).toHaveAttribute("aria-pressed", "true");
+    await dialog.getByRole("button", { name: "Согласност", exact: true }).click();
+    await expect(dialog.getByRole("button", { name: "Согласност", exact: true })).toHaveAttribute("aria-pressed", "true");
+    await expect(dialog.getByRole("button", { name: "Светла", exact: true })).toHaveAttribute("aria-pressed", "false");
+    await dialog.getByRole("button", { name: "Хоризонтално", exact: true }).click();
+    await expect(dialog.getByRole("button", { name: "Хоризонтално", exact: true })).toHaveAttribute("aria-pressed", "true");
+
+    // The download is a real PNG named after the card that was picked, and the status line says so.
+    const download = page.waitForEvent("download");
+    await dialog.getByRole("button", { name: "Преземи", exact: true }).click();
+    const file = await download;
+    expect(file.suggestedFilename()).toMatch(/^shoda-[0-9a-f-]+-landscape-agree\.png$/);
+    await expect(dialog.getByRole("status")).toHaveText("Сликата е зачувана");
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+  });
+});

--- a/packages/app/src/components/result-page.tsx
+++ b/packages/app/src/components/result-page.tsx
@@ -12,7 +12,7 @@ import { Fragment, type ReactNode, useCallback, useEffect, useMemo, useRef, useS
 import { countAnswered } from "@/answers";
 import { useAnswersStore } from "@/client/stores";
 import { useAnswerDistribution, useCalculatedMatches, useCalculator, useQuestionConsensus, useQuestions, useResult, useTopicMatches } from "@/client/view-models";
-import { buildAiPrompt, selectAgainstTheGrain, selectImportant, topicSlug } from "@/insights";
+import { buildAiPrompt, selectAgainstTheGrain, selectImportant } from "@/insights";
 import type { calculateMatches } from "@/result-calculation";
 
 import { ComparisonPane } from "./comparison-pane";
@@ -693,7 +693,7 @@ export function ResultPage({
                 againstTheGrain={againstTheGrain}
                 prompt={prompt}
                 formatPercent={formatPercent}
-                onCompareTopicClick={shared || !onCompareTopicClick ? undefined : (topic) => onCompareTopicClick(topicSlug(topic))}
+                onCompareTopicClick={shared ? undefined : onCompareTopicClick}
                 onCompareImportantClick={shared ? undefined : onCompareImportantClick}
               />
             </ComparisonPane>

--- a/packages/app/src/components/results-dashboard.test.tsx
+++ b/packages/app/src/components/results-dashboard.test.tsx
@@ -119,7 +119,8 @@ describe("ResultsDashboard", () => {
       expect(rows[0]?.querySelector("svg")).toBeInTheDocument();
 
       await user.click(rows[1] as HTMLElement);
-      expect(onCompareTopicClick).toHaveBeenCalledWith("Školství");
+      // Named by its slug — the form the app puts in a link — not by its display name.
+      expect(onCompareTopicClick).toHaveBeenCalledWith("skolstvi");
       expect(within(topicsCard).getByText("Témata s méně než 3 odpověďmi se nezobrazují.")).toBeInTheDocument();
     });
 
@@ -128,6 +129,25 @@ describe("ResultsDashboard", () => {
       const topicsCard = card("Podle témat");
       expect(within(topicsCard).queryByRole("button")).toBeNull();
       expect(within(topicsCard).getAllByRole("listitem")).toHaveLength(2);
+    });
+
+    it("shows a topic the URL cannot name as plain text, with the link kept for the ones it can", async () => {
+      const user = userEvent.setup();
+      const onCompareTopicClick = vi.fn();
+      // The Macedonian calculator's topics are Cyrillic; the Latin-only slug rule leaves nothing of them.
+      renderDashboard({ onCompareTopicClick, topics: [topic("Економија", alfa, 90, 4), topic("Doprava", beta, 70)] });
+      const topicsCard = card("Podle témat");
+
+      expect(within(topicsCard).getAllByRole("listitem")).toHaveLength(2);
+      // The finding is still there to read, only the row is no control.
+      expect(within(topicsCard).getByText("Економија")).toBeInTheDocument();
+      expect(within(topicsCard).queryByRole("button", { name: "Porovnat odpovědi k tématu Економија" })).toBeNull();
+
+      const rows = within(topicsCard).getAllByRole("button");
+      expect(rows.map((row) => row.getAttribute("aria-label"))).toEqual(["Porovnat odpovědi k tématu Doprava"]);
+      await user.click(rows[0] as HTMLElement);
+      expect(onCompareTopicClick).toHaveBeenCalledTimes(1);
+      expect(onCompareTopicClick).toHaveBeenCalledWith("doprava");
     });
 
     it("says why the list is empty", () => {

--- a/packages/app/src/components/results-dashboard.tsx
+++ b/packages/app/src/components/results-dashboard.tsx
@@ -9,7 +9,7 @@ import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { answerTone } from "@/answers";
-import { type AnswerDistribution, MIN_TOPIC_ANSWERS, type QuestionConsensus, type TopicMatch, topicIcon } from "@/insights";
+import { type AnswerDistribution, MIN_TOPIC_ANSWERS, type QuestionConsensus, type TopicMatch, topicIcon, topicSlug } from "@/insights";
 import { copyText } from "@/utilities";
 import { avatarSrc } from "@/view-models";
 
@@ -27,9 +27,14 @@ export type ResultsDashboard = {
    * becomes an entry point, and the important card gets an action. Absent on
    * a shared result, where that view would compare the *visitor's* (likely
    * empty) answers, not the ones on screen. The app owns the routes, so the
-   * dashboard only says which topic the reader chose.
+   * dashboard only says which topic the reader chose — by its slug
+   * (`topicSlug`), the form a URL carries and the comparison filter reads.
+   *
+   * A topic whose name yields no slug — one written in Cyrillic, say — has
+   * no address for the app to link to, so its row stays plain text even when
+   * the handler is here: a button that led nowhere would be worse than none.
    */
-  onCompareTopicClick?: (topic: string) => void;
+  onCompareTopicClick?: (topicSlug: string) => void;
   onCompareImportantClick?: () => void;
 };
 
@@ -298,16 +303,19 @@ export function ResultsDashboard({ distribution, topics, important, againstTheGr
                     </>
                   );
 
+                  // No slug, no link: the row is a finding on its own, not a way in.
+                  const slug = topicSlug(topic.topic);
+
                   return (
                     <li key={topic.topic}>
-                      {onCompareTopicClick ? (
+                      {onCompareTopicClick && slug !== undefined ? (
                         /*
                           The whole row is the control, with the chevron only
                           saying so — an `aria-label` names the destination,
                           because the row's visible text is a *finding*
                           ("Doprava, nejblíž Piráti") rather than an action.
                         */
-                        <button type="button" className={topicButtonClasses} onClick={() => onCompareTopicClick(topic.topic)} aria-label={t("topicCompare", { topic: topic.topic })}>
+                        <button type="button" className={topicButtonClasses} onClick={() => onCompareTopicClick(slug)} aria-label={t("topicCompare", { topic: topic.topic })}>
                           {row}
                           <span className={topicChevronClasses} aria-hidden="true">
                             <Icon icon={icons.chevronRightThin} size={null} decorative className="koa:size-[1.125rem]" />

--- a/packages/app/src/insights/topic-slug.test.ts
+++ b/packages/app/src/insights/topic-slug.test.ts
@@ -18,8 +18,14 @@ describe("topicSlug", () => {
     expect(topicSlug("Agenda 2030")).toBe("agenda-2030");
   });
 
-  it("is empty for a topic with nothing to keep", () => {
-    expect(topicSlug("—")).toBe("");
+  it("has no slug for a topic with nothing to keep", () => {
+    expect(topicSlug("—")).toBeUndefined();
+  });
+
+  it("has no slug for a name in another script, rather than an empty one to put in a URL", () => {
+    // The Macedonian calculator's topics: Latin-only rules leave nothing of them.
+    expect(topicSlug("Економија")).toBeUndefined();
+    expect(topicSlug("Владеење на правото")).toBeUndefined();
   });
 });
 
@@ -35,5 +41,11 @@ describe("topicFromSlug", () => {
     expect(topicFromSlug("vesmir", topics)).toBeUndefined();
     expect(topicFromSlug(undefined, topics)).toBeUndefined();
     expect(topicFromSlug("", topics)).toBeUndefined();
+  });
+
+  it("never resolves a slug-less topic, whatever the slug asked for", () => {
+    // Two Cyrillic topics both have no slug; neither is "the" match for anything.
+    expect(topicFromSlug("", ["Економија", "Вредности"])).toBeUndefined();
+    expect(topicFromSlug("ekonomija", ["Економија", "Вредности"])).toBeUndefined();
   });
 });

--- a/packages/app/src/insights/topic-slug.ts
+++ b/packages/app/src/insights/topic-slug.ts
@@ -9,19 +9,27 @@
  * segment" rule 2026 used for district names: decomposed, the combining marks
  * dropped, lowercased, everything that isn't a letter or a digit collapsed to
  * one hyphen, and the ends trimmed.
+ *
+ * Latin-only, so a name written in another script — the Macedonian
+ * calculator's Cyrillic topics, say — has nothing left once the rule has run.
+ * That is `undefined`, not the empty string: a topic with no slug has no
+ * address, and every caller that would build a link from it has to say so
+ * (the dashboard shows such a row as plain text) rather than write an empty
+ * filter into a URL. A Unicode-aware rule is a separate change; until then
+ * this is the honest answer.
  */
-export function topicSlug(topic: string): string {
-  return (
-    topic
-      .normalize("NFD")
-      // Combining diacritical marks (U+0300–U+036F), written as an escape rather
-      // than typed literally — a typed range is invisible in review and a
-      // reformat can eat it.
-      .replace(/[̀-ͯ]/g, "")
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "")
-  );
+export function topicSlug(topic: string): string | undefined {
+  const slug = topic
+    .normalize("NFD")
+    // Combining diacritical marks (U+0300–U+036F), written as an escape rather
+    // than typed literally — a typed range is invisible in review and a
+    // reformat can eat it.
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+  return slug || undefined;
 }
 
 /**

--- a/packages/app/src/recap/comparison-filter.ts
+++ b/packages/app/src/recap/comparison-filter.ts
@@ -33,10 +33,11 @@ export function comparisonFilterToId(filter: ComparisonFilter | undefined, topic
 
 /**
  * The inverse — what the page tells the app when a chip is picked. "All" is no
- * filter at all, and so is a topic whose slug comes out empty (a name with no
- * Latin letters or digits in it): a filter the URL cannot spell is not offered
- * to it. The recap's "unanswered" is never a comparison filter; it reads as
- * "all" too rather than as a value the routes have no word for.
+ * filter at all, and so is a topic that has no slug (a name with no Latin
+ * letters or digits in it — `topicSlug` answers `undefined` for those): a
+ * filter the URL cannot spell is not offered to it. The recap's "unanswered"
+ * is never a comparison filter; it reads as "all" too rather than as a value
+ * the routes have no word for.
  */
 export function comparisonFilterFromId(id: RecapFilterId): ComparisonFilter | undefined {
   if (id === RECAP_FILTER_IMPORTANT) return "important";


### PR DESCRIPTION
Part 23 of the new UI port (roadmap: `docs/new-ui-port.md`, #510). Stacked on #536. **Checkpoint C12 (localhost:3050, `/kompas-2025/voved`).**

The Macedonian app renders the shared pages with its own wiring, the same shape the Czech and Slovak apps got: intro, guide, question flow, recap, results with the pane, answers comparison, shared results; the menu with help, restart, leave and dark mode; the share dialog; the assets proxy; the layout and CSS changes dark mode needs; a typed analytics helper (a no-op here, analytics is off). Names come from the calculator data ("Изборен компас 2025"). No donate card: the Macedonian stub renders nothing, so the slot stays empty.

- The topic slug helper is Latin-only, so Cyrillic topic names have no slug. Rather than a broken query, the dashboard now computes the slug itself and renders such topic rows without a deep link (a Unicode-aware slug stays on the deferred list); the important-questions link uses `?filter=vazni`.
- Playwright: flow, menu and share specs on the app's own port (12 passed against a production build); the app had no tests before and now has 25.
- The app package's `mk.json` strings were machine-translated during the port and need a native review; nothing looked broken on screen. Topic icons fall back to the generic one because the rules are Czech regexes.

Legacy Macedonian files stay until the cleanup PR.

**Checks:** typecheck, lint, tests (MK 25, app 474, design-system 463, CZ 31, SK 31), Macedonian app build, Macedonian Playwright suite (12 passed).

**Stack:** based on #536 → next: `port/24-cleanup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
