### PR TITLE
Fix the never-generated navigation card spacer heights

### DIFF
--- a/packages/app/src/components/guide-navigation-card.tsx
+++ b/packages/app/src/components/guide-navigation-card.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 
 import { NavigationCard } from "@/components/navigation-card";
 
-const HEIGHT = "h-[88px]";
+const HEIGHT = "koa:h-[88px]";
 
 export type GuideNavigationCard = {
   onNextClick: () => void;

--- a/packages/app/src/components/introduction-navigation-card.tsx
+++ b/packages/app/src/components/introduction-navigation-card.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 
 import { NavigationCard } from "./navigation-card";
 
-const HEIGHT = "h-[88px]";
+const HEIGHT = "koa:h-[88px]";
 
 export type IntroductionNavigationCard = {
   onNextClick: () => void;

--- a/packages/app/src/components/public-result-navigation-card.tsx
+++ b/packages/app/src/components/public-result-navigation-card.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 
 import { NavigationCard } from "./navigation-card";
 
-const HEIGHT = "h-[88px]";
+const HEIGHT = "koa:h-[88px]";
 
 export type PublicResultNavigationCard = {
   onStartClick: () => void;

--- a/packages/app/src/components/question-navigation-card.tsx
+++ b/packages/app/src/components/question-navigation-card.tsx
@@ -8,7 +8,7 @@ import type { AnswerViewModel } from "@/view-models/answer";
 
 import { NavigationCard } from "./navigation-card";
 
-const HEIGHT = "h-[138px]";
+const HEIGHT = "koa:h-[138px]";
 
 export type QuestionNavigationCard = {
   current: number;

--- a/packages/app/src/components/result-navigation-card.tsx
+++ b/packages/app/src/components/result-navigation-card.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 
 import { NavigationCard } from "./navigation-card";
 
-const HEIGHT = "h-[88px]";
+const HEIGHT = "koa:h-[88px]";
 
 export type ResultNavigationCard = {
   onNextClick: () => void;

--- a/packages/app/src/components/review-navigation-card.tsx
+++ b/packages/app/src/components/review-navigation-card.tsx
@@ -4,7 +4,7 @@ import { useTranslations } from "next-intl";
 
 import { NavigationCard } from "./navigation-card";
 
-const HEIGHT = "h-[88px]";
+const HEIGHT = "koa:h-[88px]";
 
 export type ReviewNavigationCard = {
   onNextClick: () => void;


### PR DESCRIPTION
The navigation cards expose `heightClassNames` statics for layout spacers, but their values (`h-[88px]`, `h-[138px]`) are unprefixed Tailwind classes: the package stylesheet only generates `koa:`-prefixed utilities and app builds never scan package sources, so no stylesheet ever contained these classes. The bottom spacers have rendered with zero height in every app — page content scrolls under the fixed bottom navigation.

Prefixing the statics `koa:` makes the package's own stylesheet provide them.

Six one-line changes, pixel values preserved. Verified with rendered-page probes (Playwright, 1280px and 400px viewports): spacers now measure their real 88/138px on intro, question, and review pages in all three apps.

Part 1 of the engine-layer extraction series; this fix stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)