### PR TITLE
Decouple share modal from API and routing via callbacks

### DIFF
--- a/apps/www.izborenkalkulator.mk/calculator/components/client/share-modal.tsx
+++ b/apps/www.izborenkalkulator.mk/calculator/components/client/share-modal.tsx
@@ -3,21 +3,16 @@
 import { Button, Icon } from "@kalkulacka-one/design-system/client";
 
 import { mdiCheck, mdiClose, mdiContentCopy } from "@mdi/js";
-import { useLocale } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 
-import { shareSession } from "@/lib/api";
-import { canonical, type RouteSegments } from "@/lib/routing";
-
 export type ShareModalProps = {
-  calculatorId: string;
-  segments: RouteSegments;
   isOpen: boolean;
   onClose: () => void;
+  onShare: () => Promise<{ publicId: string }>;
+  buildShareUrl: (publicId: string) => string;
 };
 
-export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareModalProps) {
-  const locale = useLocale();
+export function ShareModal({ isOpen, onClose, onShare, buildShareUrl }: ShareModalProps) {
   const [publicId, setPublicId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
@@ -29,7 +24,7 @@ export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareMod
     if (isOpen && !publicId) {
       setIsLoading(true);
       setError(null);
-      shareSession(calculatorId)
+      onShare()
         .then((data) => {
           setPublicId(data.publicId);
         })
@@ -40,7 +35,7 @@ export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareMod
           setIsLoading(false);
         });
     }
-  }, [isOpen, publicId, calculatorId]);
+  }, [isOpen, publicId, onShare]);
 
   useEffect(() => {
     if (isOpen && navigator.permissions) {
@@ -71,8 +66,7 @@ export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareMod
 
   if (!isOpen) return null;
 
-  const nonEmbedSegments = { first: segments.first, second: segments.second, third: segments.third };
-  const shareUrl = publicId ? canonical.publicResult(nonEmbedSegments, publicId, locale) : "";
+  const shareUrl = publicId ? buildShareUrl(publicId) : "";
   const xHandle = process.env.NEXT_PUBLIC_X_HANDLE;
   const shareText = xHandle ? `Погледнете како ми излезе ${xHandle}:` : "Погледнете како ми излезе Изборниот калкулатор:";
 

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/result.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/result.tsx
@@ -7,9 +7,9 @@ import { useEffect, useState } from "react";
 import { ShareModal } from "@/calculator/components/client";
 import { ResultPage as AppResultPage } from "@/calculator/components/server";
 import { useEmbed } from "@/components/client";
-import { saveSessionData } from "@/lib/api";
+import { saveSessionData, shareSession } from "@/lib/api";
 import { reportError } from "@/lib/monitoring";
-import { type RouteSegments, routes } from "@/lib/routing";
+import { canonical, type RouteSegments, routes } from "@/lib/routing";
 
 export function ResultPageWithRouting({ segments }: { segments: RouteSegments }) {
   const [showOnlyNested, setShowOnlyNested] = useState(false);
@@ -72,7 +72,12 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
         onFilterChange={setShowOnlyNested}
         donateCardPosition={donateCardPosition}
       />
-      <ShareModal calculatorId={calculator.id} segments={segments} isOpen={isShareModalOpen} onClose={() => setIsShareModalOpen(false)} />
+      <ShareModal
+        isOpen={isShareModalOpen}
+        onClose={() => setIsShareModalOpen(false)}
+        onShare={() => shareSession(calculator.id)}
+        buildShareUrl={(publicId) => canonical.publicResult({ first: segments.first, second: segments.second, third: segments.third }, publicId, locale)}
+      />
     </>
   );
 }

--- a/apps/www.volebnakalkulacka.sk/calculator/components/client/share-modal.tsx
+++ b/apps/www.volebnakalkulacka.sk/calculator/components/client/share-modal.tsx
@@ -3,21 +3,16 @@
 import { Button, Icon } from "@kalkulacka-one/design-system/client";
 
 import { mdiCheck, mdiClose, mdiContentCopy } from "@mdi/js";
-import { useLocale } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 
-import { shareSession } from "@/lib/api";
-import { canonical, type RouteSegments } from "@/lib/routing";
-
 export type ShareModalProps = {
-  calculatorId: string;
-  segments: RouteSegments;
   isOpen: boolean;
   onClose: () => void;
+  onShare: () => Promise<{ publicId: string }>;
+  buildShareUrl: (publicId: string) => string;
 };
 
-export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareModalProps) {
-  const locale = useLocale();
+export function ShareModal({ isOpen, onClose, onShare, buildShareUrl }: ShareModalProps) {
   const [publicId, setPublicId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
@@ -29,7 +24,7 @@ export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareMod
     if (isOpen && !publicId) {
       setIsLoading(true);
       setError(null);
-      shareSession(calculatorId)
+      onShare()
         .then((data) => {
           setPublicId(data.publicId);
         })
@@ -40,7 +35,7 @@ export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareMod
           setIsLoading(false);
         });
     }
-  }, [isOpen, publicId, calculatorId]);
+  }, [isOpen, publicId, onShare]);
 
   useEffect(() => {
     if (isOpen && navigator.permissions) {
@@ -71,8 +66,7 @@ export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareMod
 
   if (!isOpen) return null;
 
-  const nonEmbedSegments = { first: segments.first, second: segments.second, third: segments.third };
-  const shareUrl = publicId ? canonical.publicResult(nonEmbedSegments, publicId, locale) : "";
+  const shareUrl = publicId ? buildShareUrl(publicId) : "";
   const xHandle = process.env.NEXT_PUBLIC_X_HANDLE;
   const shareText = xHandle ? `Pozrite sa, ako mi vyšla ${xHandle}:` : "Pozrite sa, ako mi vyšla Volebná kalkulačka:";
 

--- a/apps/www.volebnakalkulacka.sk/components/client/pages/calculator/result.tsx
+++ b/apps/www.volebnakalkulacka.sk/components/client/pages/calculator/result.tsx
@@ -7,9 +7,9 @@ import { useEffect, useState } from "react";
 import { ShareModal } from "@/calculator/components/client";
 import { ResultPage as AppResultPage } from "@/calculator/components/server";
 import { useEmbed } from "@/components/client";
-import { saveSessionData } from "@/lib/api";
+import { saveSessionData, shareSession } from "@/lib/api";
 import { reportError } from "@/lib/monitoring";
-import { type RouteSegments, routes } from "@/lib/routing";
+import { canonical, type RouteSegments, routes } from "@/lib/routing";
 
 export function ResultPageWithRouting({ segments }: { segments: RouteSegments }) {
   const [showOnlyNested, setShowOnlyNested] = useState(false);
@@ -72,7 +72,12 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
         onFilterChange={setShowOnlyNested}
         donateCardPosition={donateCardPosition}
       />
-      <ShareModal calculatorId={calculator.id} segments={segments} isOpen={isShareModalOpen} onClose={() => setIsShareModalOpen(false)} />
+      <ShareModal
+        isOpen={isShareModalOpen}
+        onClose={() => setIsShareModalOpen(false)}
+        onShare={() => shareSession(calculator.id)}
+        buildShareUrl={(publicId) => canonical.publicResult({ first: segments.first, second: segments.second, third: segments.third }, publicId, locale)}
+      />
     </>
   );
 }

--- a/apps/www.volebnikalkulacka.cz/calculator/components/client/share-modal.tsx
+++ b/apps/www.volebnikalkulacka.cz/calculator/components/client/share-modal.tsx
@@ -1,21 +1,16 @@
 import { Button, Icon } from "@kalkulacka-one/design-system/client";
 
 import { mdiCheck, mdiClose, mdiContentCopy } from "@mdi/js";
-import { useLocale } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 
-import { shareSession } from "@/lib/api";
-import { canonical, type RouteSegments } from "@/lib/routing";
-
 export type ShareModalProps = {
-  calculatorId: string;
-  segments: RouteSegments;
   isOpen: boolean;
   onClose: () => void;
+  onShare: () => Promise<{ publicId: string }>;
+  buildShareUrl: (publicId: string) => string;
 };
 
-export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareModalProps) {
-  const locale = useLocale();
+export function ShareModal({ isOpen, onClose, onShare, buildShareUrl }: ShareModalProps) {
   const [publicId, setPublicId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isCopied, setIsCopied] = useState(false);
@@ -27,7 +22,7 @@ export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareMod
     if (isOpen && !publicId) {
       setIsLoading(true);
       setError(null);
-      shareSession(calculatorId)
+      onShare()
         .then((data) => {
           setPublicId(data.publicId);
         })
@@ -38,7 +33,7 @@ export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareMod
           setIsLoading(false);
         });
     }
-  }, [isOpen, publicId, calculatorId]);
+  }, [isOpen, publicId, onShare]);
 
   useEffect(() => {
     if (isOpen && navigator.permissions) {
@@ -69,8 +64,7 @@ export function ShareModal({ calculatorId, segments, isOpen, onClose }: ShareMod
 
   if (!isOpen) return null;
 
-  const nonEmbedSegments = { first: segments.first, second: segments.second, third: segments.third };
-  const shareUrl = publicId ? canonical.publicResult(nonEmbedSegments, publicId, locale) : "";
+  const shareUrl = publicId ? buildShareUrl(publicId) : "";
   const xHandle = process.env.NEXT_PUBLIC_X_HANDLE;
   const shareText = xHandle ? `Podívejte se, jak mi vyšla ${xHandle}:` : "Podívejte se, jak mi vyšla Volební kalkulačka:";
 

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/result.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/result.tsx
@@ -7,9 +7,9 @@ import { useEffect, useState } from "react";
 import { ShareModal } from "@/calculator/components/client";
 import { ResultPage as AppResultPage } from "@/calculator/components/server";
 import { DonateCard, useEmbed } from "@/components/client";
-import { saveSessionData } from "@/lib/api";
+import { saveSessionData, shareSession } from "@/lib/api";
 import { reportError } from "@/lib/monitoring";
-import { type RouteSegments, routes } from "@/lib/routing";
+import { canonical, type RouteSegments, routes } from "@/lib/routing";
 
 export function ResultPageWithRouting({ segments }: { segments: RouteSegments }) {
   const [showOnlyNested, setShowOnlyNested] = useState(false);
@@ -80,7 +80,12 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
           </DonateCard>
         }
       />
-      <ShareModal calculatorId={calculator.id} segments={segments} isOpen={isShareModalOpen} onClose={() => setIsShareModalOpen(false)} />
+      <ShareModal
+        isOpen={isShareModalOpen}
+        onClose={() => setIsShareModalOpen(false)}
+        onShare={() => shareSession(calculator.id)}
+        buildShareUrl={(publicId) => canonical.publicResult({ first: segments.first, second: segments.second, third: segments.third }, publicId, locale)}
+      />
     </>
   );
 }


### PR DESCRIPTION
The share modal called `shareSession` and the canonical URL builder directly. It now takes `onShare` and `buildShareUrl` callbacks from the result page wrapper, which passes the same implementations — no behavior change. This severs the modal's only app-coupled dependencies so it can move to the app package cleanly in a later part of the series.

Applied identically to CZ, SK, and MK.

Part 2 of the engine-layer extraction series (prep, in-place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)