### PR TITLE
Scan the app package for Tailwind utilities in every calculator app

### DIFF
--- a/apps/www.izborenkalkulator.mk/app/globals.css
+++ b/apps/www.izborenkalkulator.mk/app/globals.css
@@ -3,6 +3,9 @@
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
+/* Generate utilities for the app package components (they use unprefixed classes) */
+@source "../../../packages/app/dist";
+
 :root {
   color-scheme: light;
 }

--- a/apps/www.volebnakalkulacka.sk/app/globals.css
+++ b/apps/www.volebnakalkulacka.sk/app/globals.css
@@ -3,6 +3,9 @@
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
+/* Generate utilities for the app package components (they use unprefixed classes) */
+@source "../../../packages/app/dist";
+
 :root {
   color-scheme: light;
 }

--- a/apps/www.volebnikalkulacka.cz/app/globals.css
+++ b/apps/www.volebnikalkulacka.cz/app/globals.css
@@ -3,6 +3,9 @@
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
+/* Generate utilities for the app package components (they use unprefixed classes) */
+@source "../../../packages/app/dist";
+
 :root {
   color-scheme: light;
 }


### PR DESCRIPTION
Components in `@kalkulacka-one/app` that use unprefixed utility classes are invisible to the apps' Tailwind builds, which only scan app sources — such classes render unstyled unless an app file happens to use the same utility. An explicit `@source` directive makes every app generate utilities for the package's shipped code.

No-op today (current package components use the prefixed `koa:` classes from the package's own stylesheet); this takes effect as calculator components move into the package in the following parts of the series, and is removed again at the end of the series when the moved components convert to `koa:`.

Note the path: `../../../packages/app/dist`, relative to each app's `app/globals.css`, pointing at the workspace package directly — a `node_modules`-relative path would silently scan nothing, because npm workspaces hoist `node_modules` to the repo root.

Part 4 of the engine-layer extraction series (prep, in-place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)