### PR TITLE
Restore the SK privacy link

### DIFF
--- a/apps/www.volebnakalkulacka.sk/config/app-config.ts
+++ b/apps/www.volebnakalkulacka.sk/config/app-config.ts
@@ -7,4 +7,8 @@ export const appConfig = withDefaults({
     defaultLocale: "sk",
     locales: ["sk"],
   },
+
+  links: {
+    privacy: "/soukromi",
+  },
 });


### PR DESCRIPTION
**Production regression from #549 and #552.**

#549 moved the embed footer's privacy path out of the shared component (where it was hardcoded to the Czech `/soukromi`) into each app's config, and #552 did the same for the share modal. SK never received the config entry: the change was scripted to insert it above the `footer` block, and SK's config has no `footer` block, so the edit silently did nothing.

Effect on production today:

- SK embed footer renders no `Súkromie` link.
- SK share modal renders no consent sentence (it is wrapped in the same conditional).

Both components deliberately render nothing when no link is supplied — that is what MK needs, since MK has no privacy page at all — so nothing failed loudly. Typecheck cannot catch it either, because the prop is optional by design.

CZ was unaffected. MK is correct as-is.

Found by comparing SK's rendered output against a pre-series build; my earlier per-PR verification had leaned on CZ. I am now running the render comparison for all three apps on every remaining part of the series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)