### PR TITLE
Generate robots.txt from each app's localized slugs

### DIFF
--- a/apps/www.izborenkalkulator.mk/app/robots.txt/robots/robots.txt.production
+++ b/apps/www.izborenkalkulator.mk/app/robots.txt/robots/robots.txt.production
@@ -1,6 +1,0 @@
-User-agent: *
-Allow: /api/images/
-Disallow: /api/
-Disallow: /*/rekapitulace
-Disallow: /*/vysledek
-Allow: /*/vysledek/

--- a/apps/www.izborenkalkulator.mk/app/robots.txt/robots/robots.txt.staging
+++ b/apps/www.izborenkalkulator.mk/app/robots.txt/robots/robots.txt.staging
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/apps/www.izborenkalkulator.mk/app/robots.txt/route.ts
+++ b/apps/www.izborenkalkulator.mk/app/robots.txt/route.ts
@@ -1,17 +1,9 @@
-import { allowCrawling } from "@kalkulacka-one/next";
+import { allowCrawling, buildRobotsTxt } from "@kalkulacka-one/next";
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const currentDir = dirname(fileURLToPath(import.meta.url));
+import { PAGE_SLUGS } from "@/config/localized-slugs";
 
 export async function GET() {
-  const allowIndexing = allowCrawling();
-  const fileName = allowIndexing ? "robots.txt.production" : "robots.txt.staging";
-  const filePath = join(currentDir, "robots", fileName);
-
-  const robotsTxt = readFileSync(filePath, "utf-8");
+  const robotsTxt = buildRobotsTxt({ allow: allowCrawling(), pageSlugs: PAGE_SLUGS });
 
   return new Response(robotsTxt, {
     headers: {

--- a/apps/www.volebnakalkulacka.sk/app/robots.txt/robots/robots.txt.production
+++ b/apps/www.volebnakalkulacka.sk/app/robots.txt/robots/robots.txt.production
@@ -1,6 +1,0 @@
-User-agent: *
-Allow: /api/images/
-Disallow: /api/
-Disallow: /*/rekapitulace
-Disallow: /*/vysledek
-Allow: /*/vysledek/

--- a/apps/www.volebnakalkulacka.sk/app/robots.txt/robots/robots.txt.staging
+++ b/apps/www.volebnakalkulacka.sk/app/robots.txt/robots/robots.txt.staging
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/apps/www.volebnakalkulacka.sk/app/robots.txt/route.ts
+++ b/apps/www.volebnakalkulacka.sk/app/robots.txt/route.ts
@@ -1,17 +1,9 @@
-import { allowCrawling } from "@kalkulacka-one/next";
+import { allowCrawling, buildRobotsTxt } from "@kalkulacka-one/next";
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const currentDir = dirname(fileURLToPath(import.meta.url));
+import { PAGE_SLUGS } from "@/config/localized-slugs";
 
 export async function GET() {
-  const allowIndexing = allowCrawling();
-  const fileName = allowIndexing ? "robots.txt.production" : "robots.txt.staging";
-  const filePath = join(currentDir, "robots", fileName);
-
-  const robotsTxt = readFileSync(filePath, "utf-8");
+  const robotsTxt = buildRobotsTxt({ allow: allowCrawling(), pageSlugs: PAGE_SLUGS });
 
   return new Response(robotsTxt, {
     headers: {

--- a/apps/www.volebnikalkulacka.cz/app/robots.txt/robots/robots.txt.production
+++ b/apps/www.volebnikalkulacka.cz/app/robots.txt/robots/robots.txt.production
@@ -1,6 +1,0 @@
-User-agent: *
-Allow: /api/images/
-Disallow: /api/
-Disallow: /*/rekapitulace
-Disallow: /*/vysledek
-Allow: /*/vysledek/

--- a/apps/www.volebnikalkulacka.cz/app/robots.txt/robots/robots.txt.staging
+++ b/apps/www.volebnikalkulacka.cz/app/robots.txt/robots/robots.txt.staging
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/apps/www.volebnikalkulacka.cz/app/robots.txt/route.ts
+++ b/apps/www.volebnikalkulacka.cz/app/robots.txt/route.ts
@@ -1,17 +1,9 @@
-import { allowCrawling } from "@kalkulacka-one/next";
+import { allowCrawling, buildRobotsTxt } from "@kalkulacka-one/next";
 
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const currentDir = dirname(fileURLToPath(import.meta.url));
+import { PAGE_SLUGS } from "@/config/localized-slugs";
 
 export async function GET() {
-  const allowIndexing = allowCrawling();
-  const fileName = allowIndexing ? "robots.txt.production" : "robots.txt.staging";
-  const filePath = join(currentDir, "robots", fileName);
-
-  const robotsTxt = readFileSync(filePath, "utf-8");
+  const robotsTxt = buildRobotsTxt({ allow: allowCrawling(), pageSlugs: PAGE_SLUGS });
 
   return new Response(robotsTxt, {
     headers: {

--- a/packages/next/src/seo/index.ts
+++ b/packages/next/src/seo/index.ts
@@ -1,1 +1,2 @@
 export { allowCrawling } from "./crawling";
+export { buildRobotsTxt } from "./robots";

--- a/packages/next/src/seo/robots.ts
+++ b/packages/next/src/seo/robots.ts
@@ -1,0 +1,18 @@
+import type { PageType } from "@/routing/localized-slugs";
+
+export function buildRobotsTxt({ allow, pageSlugs }: { allow: boolean; pageSlugs: Record<string, Record<PageType, string>> }): string {
+  if (!allow) {
+    return "User-agent: *\nDisallow: /\n";
+  }
+
+  const lines = ["User-agent: *", "Allow: /api/images/", "Disallow: /api/"];
+
+  const slugRules = new Set<string>();
+  for (const slugs of Object.values(pageSlugs)) {
+    slugRules.add(`Disallow: /*/${slugs.review}`);
+    slugRules.add(`Disallow: /*/${slugs.result}`);
+    slugRules.add(`Allow: /*/${slugs.result}/`);
+  }
+
+  return `${[...lines, ...slugRules].join("\n")}\n`;
+}


### PR DESCRIPTION
**A real SEO bug on SK and MK.** All three apps shipped the same static `robots.txt.production`, carrying Czech slugs:

```
Disallow: /*/rekapitulace
Disallow: /*/vysledek
Allow:    /*/vysledek/
```

SK's review and result pages live at `/*/rekapitulacia` and `/*/vysledok`; MK's at `/*/pregled` and `/*/rezultat`. Those rules have therefore never matched anything on SK or MK, leaving both apps' review and result pages — pages that reflect a voter's own answers — crawlable and indexable.

`buildRobotsTxt()` derives the rules from the app's own slug table instead, so they follow the localized URLs automatically. Output, verified by building each app with `VERCEL_ENV=production` and fetching `/robots.txt`:

| | review | result |
|---|---|---|
| CZ | `/*/rekapitulace` | `/*/vysledek` |
| SK | `/*/rekapitulacia` | `/*/vysledok` |
| MK | `/*/pregled` | `/*/rezultat` |

**CZ output is byte-identical to the old static file** (verified with `diff`), so nothing changes there. The staging variant — `Disallow: /` when not on production — is unchanged for all three.

The static `robots.txt.production` / `.staging` files are deleted; the route now takes its content from the slug table it already had.

Part 18 of the engine-layer extraction series — the first of the small functional fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)