### PR TITLE
Localize the Czech close and back labels

### DIFF
--- a/packages/app/src/locales/cs.json
+++ b/packages/app/src/locales/cs.json
@@ -92,7 +92,7 @@
     },
     "pages": {
       "common": {
-        "close": "Close"
+        "close": "Zavřít"
       },
       "comparison": {
         "title": "Porovnání",
@@ -109,7 +109,7 @@
       },
       "result": {
         "title": "Výsledek",
-        "back": "Back",
+        "back": "Zpět",
         "candidateLists": "Kandidátní listiny",
         "people": "Lidé"
       },


### PR DESCRIPTION
The CZ app shipped untranslated English `aria-label`s on the calculator page chrome — `Close` on the close button of every flow page, `Back` on the result page — while SK and MK were localized. Czech screen reader users heard English words for two of the most-used controls.

Now that those labels are messages rather than strings hardcoded in three copies of each page, fixing them is two values in the `cs` locale:

```
koa.pages.common.close   "Close" → "Zavřít"
koa.pages.result.back    "Back"  → "Zpět"
```

Nothing else changes; the labels are not visible text, so nothing moves on screen.

Part 19 of the engine-layer extraction series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)