### PR TITLE
Mark the match card icons decorative and drop the stale CZ fallback title

### DIFF
--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
@@ -37,8 +37,6 @@ export function IntroductionPageWithRouting({ segments }: { segments: RouteSegme
 
   return (
     <IntroductionPage
-      // TODO: drop this fallback — it hardcodes a past election as the heading for any calculator whose data has no shortTitle, which hides the missing data instead of surfacing it
-      fallbackShortTitle="Sněmovní 2025"
       homepageHref={canonical.homepage()}
       privacyHref={appConfig.links?.privacy}
       embedContext={embed}

--- a/packages/app/src/client/components/match-card.tsx
+++ b/packages/app/src/client/components/match-card.tsx
@@ -94,7 +94,7 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
                                 <div className="space-y-1">
                                   <div>
                                     <div className="inline-flex items-center gap-1 px-2 py-1 rounded bg-slate-100 text-slate-700 text-xs">
-                                      <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+                                      <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                                         <path d="M13,14H11V10H13M13,18H11V16H13M1,21H23L12,2L1,21Z" />
                                       </svg>
                                       <span>{t("positionUnknown")}</span>
@@ -123,7 +123,7 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
                                           }}
                                         >
                                           <span>{source.title || source.url || t("source")}</span>
-                                          <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor">
+                                          <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                                             <path d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z" />
                                           </svg>
                                         </button>

--- a/packages/app/src/components/pages/introduction.tsx
+++ b/packages/app/src/components/pages/introduction.tsx
@@ -14,13 +14,12 @@ export type IntroductionPage = {
   embedContext: EmbedContextType;
   homepageHref: string;
   privacyHref?: string;
-  fallbackShortTitle?: string;
   calculator: CalculatorViewModel;
   onNextClick: () => void;
   onCloseClick: () => void;
 };
 
-export function IntroductionPage({ embedContext, homepageHref, privacyHref, fallbackShortTitle = "", calculator, onNextClick, onCloseClick }: IntroductionPage) {
+export function IntroductionPage({ embedContext, homepageHref, privacyHref, calculator, onNextClick, onCloseClick }: IntroductionPage) {
   const t = useTranslations("koa.pages");
   const hasFooter = embedContext.isEmbed && embedContext.config?.attribution !== false;
 
@@ -37,7 +36,7 @@ export function IntroductionPage({ embedContext, homepageHref, privacyHref, fall
           </AppHeader.Right>
           <AppHeader.Bottom>
             <AppHeader.BottomMain>
-              <h2 className="font-display font-semibold text-2xl tracking-tight text-slate-700">{calculator?.shortTitle || fallbackShortTitle}</h2>
+              <h2 className="font-display font-semibold text-2xl tracking-tight text-slate-700">{calculator?.shortTitle}</h2>
             </AppHeader.BottomMain>
           </AppHeader.Bottom>
         </AppHeader>


### PR DESCRIPTION
Two small changes the extraction deliberately deferred, each its own commit.

## 1. The match card's inline icons become decorative

The three apps disagreed about the two inline SVG icons in the match card — the warning beside "position could not be determined", and the external-link glyph on a source link. MK gave both an English `<title>`; CZ and SK gave them nothing. Unifying the component forced a choice.

Neither was right. Both icons sit next to text that already says what they mean, so an accessible name adds noise rather than information — and MK's was English inside otherwise localized markup, so a Macedonian or Czech screen reader user heard "Info" and "External link" mid-sentence. They are now `aria-hidden="true"`, which is what a purely decorative icon should be, and what the design system's own `Icon` component does for its decorative variant. Verified this satisfies the `noSvgWithoutTitle` lint rule.

## 2. The stale CZ introduction fallback title goes away

The CZ introduction heading fell back to a hardcoded `Sněmovní 2025` whenever calculator data carried no short title — naming a past election on any calculator with incomplete data, and hiding the gap instead of surfacing it. SK and MK already rendered an empty heading in that case.

**Scope, precisely:** the schema makes `shortTitle` required for standalone calculators but optional for grouped and election ones, and exactly **one** of the 125 calculators in the data repo omits it — CZ's `snemovni-2025/kalkulacka`. That page's sub-heading goes from `Sněmovní 2025` to empty. Every `komunalni-2026` and `senatni-2026` calculator carries a short title, so nothing launching in October is affected.

If you would rather that page kept a heading, the cleaner fix is a one-line data change adding a `shortTitle` to that calculator, after which this commit has no visible effect anywhere.

Part 20 of the engine-layer extraction series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)