### PR TITLE
Prefix the extracted components with `koa:` and ship their utilities

### DIFF
--- a/apps/www.izborenkalkulator.mk/app/globals.css
+++ b/apps/www.izborenkalkulator.mk/app/globals.css
@@ -3,9 +3,6 @@
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
-/* Generate utilities for the app package components (they use unprefixed classes) */
-@source "../../../packages/app/dist";
-
 :root {
   color-scheme: light;
 }

--- a/apps/www.volebnakalkulacka.sk/app/globals.css
+++ b/apps/www.volebnakalkulacka.sk/app/globals.css
@@ -3,9 +3,6 @@
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
-/* Generate utilities for the app package components (they use unprefixed classes) */
-@source "../../../packages/app/dist";
-
 :root {
   color-scheme: light;
 }

--- a/apps/www.volebnikalkulacka.cz/app/globals.css
+++ b/apps/www.volebnikalkulacka.cz/app/globals.css
@@ -3,9 +3,6 @@
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
-/* Generate utilities for the app package components (they use unprefixed classes) */
-@source "../../../packages/app/dist";
-
 :root {
   color-scheme: light;
 }

--- a/packages/app/src/client/components/app-header.tsx
+++ b/packages/app/src/client/components/app-header.tsx
@@ -36,23 +36,23 @@ export function AppHeader({ children, condensed = false, calculator }: AppHeader
   const hasBottomLeft = hasNestedChildOfType(children, AppHeaderBottom, AppHeaderBottomLeft);
   const expand = hasPageHeading && !condensed;
 
-  const gridClasses = "grid grid-cols-[auto_1fr_auto] items-center";
-  const expandedRowsClasses = "grid-rows-[3rem_auto]";
-  const collapsedRowsClasses = "grid-rows-[3rem]";
-  const gridSpacingClasses = "gap-x-2 sm:gap-x-3 gap-y-1";
+  const gridClasses = "koa:grid koa:grid-cols-[auto_1fr_auto] koa:items-center";
+  const expandedRowsClasses = "koa:grid-rows-[3rem_auto]";
+  const collapsedRowsClasses = "koa:grid-rows-[3rem]";
+  const gridSpacingClasses = "koa:gap-x-2 koa:sm:gap-x-3 koa:gap-y-1";
   const headerGridClasses = twMerge(gridClasses, expand ? expandedRowsClasses : collapsedRowsClasses, gridSpacingClasses);
 
-  const mainGrid = "grid grid-flow-col grid-cols-[auto_1fr] gap-2";
-  const mainExpandedOrNoLeftContent = expand || !hasBottomLeft ? "col-span-2" : "";
-  const mainCondensedWithLeftContent = condensed && hasBottomLeft ? "col-start-2" : "";
+  const mainGrid = "koa:grid koa:grid-flow-col koa:grid-cols-[auto_1fr] koa:gap-2";
+  const mainExpandedOrNoLeftContent = expand || !hasBottomLeft ? "koa:col-span-2" : "";
+  const mainCondensedWithLeftContent = condensed && hasBottomLeft ? "koa:col-start-2" : "";
   const mainClasses = twMerge(mainGrid, mainExpandedOrNoLeftContent, mainCondensedWithLeftContent);
 
-  const bottomExpanded = "col-span-3 flex items-center h-full";
-  const bottomCondensed = "row-start-1";
+  const bottomExpanded = "koa:col-span-3 koa:flex koa:items-center koa:h-full";
+  const bottomCondensed = "koa:row-start-1";
   const bottomClasses = expand ? bottomExpanded : bottomCondensed;
 
   return (
-    <header className="@container sticky top-0 p-2 sm:p-3 bg-white/60 backdrop-blur-md">
+    <header className="koa:@container koa:sticky koa:top-0 koa:p-2 koa:sm:p-3 koa:bg-white/60 koa:backdrop-blur-md">
       <div className={headerGridClasses}>
         <div className={mainClasses}>
           <AppHeaderMain title={t("appTitle")} calculator={calculator} logoMonochrome={embed.isEmbed && embed.config?.logo === "monochrome"} />
@@ -98,14 +98,14 @@ type AppHeaderMain = {
 
 function AppHeaderMain({ children, title, calculator, logoMonochrome }: AppHeaderMain) {
   return (
-    <div className="grid grid-flow-col items-center gap-2">
+    <div className="koa:grid koa:grid-flow-col koa:items-center koa:gap-2">
       <Logo title={title} size="small" monochrome={logoMonochrome} />
-      <div className="grid text-sm text-slate-700 leading-none">
-        <h1 className="font-light">{title}</h1>
+      <div className="koa:grid koa:text-sm koa:text-slate-700 koa:leading-none">
+        <h1 className="koa:font-light">{title}</h1>
         <div>
-          <h2 className="font-semibold inline">{calculator?.title}</h2>
-          {calculator?.title && calculator?.secondaryTitle && <span className="font-light hidden @[24rem]:inline"> • </span>}
-          <span className="font-light hidden @[24rem]:inline">{calculator?.secondaryTitle}</span>
+          <h2 className="koa:font-semibold koa:inline">{calculator?.title}</h2>
+          {calculator?.title && calculator?.secondaryTitle && <span className="koa:font-light koa:hidden koa:@[24rem]:inline"> • </span>}
+          <span className="koa:font-light koa:hidden koa:@[24rem]:inline">{calculator?.secondaryTitle}</span>
         </div>
         {children}
       </div>
@@ -126,7 +126,7 @@ type AppHeaderBottom = {
 };
 
 export function AppHeaderBottom({ children }: AppHeaderBottom) {
-  return <div className="grid grid-flow-col items-center gap-2">{children}</div>;
+  return <div className="koa:grid koa:grid-flow-col koa:items-center koa:gap-2">{children}</div>;
 }
 
 export type AppHeaderBottomLeft = {
@@ -136,7 +136,7 @@ export type AppHeaderBottomLeft = {
 
 export function AppHeaderBottomLeft({ children, condensed }: AppHeaderBottomLeft) {
   if (condensed) {
-    return <div className="row-start-1 col-start-1 grid grid-flow-col items-center gap-1">{children}</div>;
+    return <div className="koa:row-start-1 koa:col-start-1 koa:grid koa:grid-flow-col koa:items-center koa:gap-1">{children}</div>;
   }
   return <>{children}</>;
 }

--- a/packages/app/src/client/components/comparison-grid.tsx
+++ b/packages/app/src/client/components/comparison-grid.tsx
@@ -16,31 +16,31 @@ export type ComparisonGridDashlinesOverlay = {
 function ComparisonGridDashlinesOverlay({ result, filterNestedCandidates }: ComparisonGridDashlinesOverlay) {
   return (
     <div
-      className="absolute inset-0 pointer-events-none z-0"
+      className="koa:absolute koa:inset-0 koa:pointer-events-none koa:z-0"
       style={{
         top: result.matches.some((match) => match.nestedMatches) ? "180px" : "0px",
       }}
     >
-      <div className="h-full flex gap-8">
+      <div className="koa:h-full koa:flex koa:gap-8">
         {/* User column line - sticky */}
-        <div className="w-[100px] flex justify-center sticky left-4">
-          <div className="w-0 h-full border-r-2 border-dashed border-slate-200" />
+        <div className="koa:w-[100px] koa:flex koa:justify-center koa:sticky koa:left-4">
+          <div className="koa:w-0 koa:h-full koa:border-r-2 koa:border-dashed koa:border-slate-200" />
         </div>
         {/* Candidate columns lines */}
         {result.matches.map((match) => {
           const nestedMatches = filterNestedCandidates(match.nestedMatches);
           if (!nestedMatches) {
             return (
-              <div key={`line-${match.candidate.id}`} className="w-[100px] flex justify-center">
-                <div className="w-0 h-full border-r-2 border-dashed border-slate-200" />
+              <div key={`line-${match.candidate.id}`} className="koa:w-[100px] koa:flex koa:justify-center">
+                <div className="koa:w-0 koa:h-full koa:border-r-2 koa:border-dashed koa:border-slate-200" />
               </div>
             );
           }
           return (
-            <div key={`line-group-${match.candidate.id}`} className="flex gap-8">
+            <div key={`line-group-${match.candidate.id}`} className="koa:flex koa:gap-8">
               {nestedMatches.map((nested: NonNullable<ResultViewModel["matches"][0]["nestedMatches"]>[0]) => (
-                <div key={`line-${nested.candidate.id}`} className="w-[100px] flex justify-center">
-                  <div className="w-0 h-full border-r-2 border-dashed border-slate-200" />
+                <div key={`line-${nested.candidate.id}`} className="koa:w-[100px] koa:flex koa:justify-center">
+                  <div className="koa:w-0 koa:h-full koa:border-r-2 koa:border-dashed koa:border-slate-200" />
                 </div>
               ))}
             </div>
@@ -63,12 +63,12 @@ function OrganizationFilter({ organizations, selectedOrganizations, setSelectedO
   if (organizations.length === 0) return null;
 
   return (
-    <div className="sticky left-4 max-w-dvw z-10 flex flex-col gap-2">
-      <h3 className="text-sm font-medium">{t("selectParty")}</h3>
-      <div className="relative bg-slate-100 rounded-full p-1 flex flex-wrap gap-1 max-w-[90dvw] sm:w-fit">
+    <div className="koa:sticky koa:left-4 koa:max-w-dvw koa:z-10 koa:flex koa:flex-col koa:gap-2">
+      <h3 className="koa:text-sm koa:font-medium">{t("selectParty")}</h3>
+      <div className="koa:relative koa:bg-slate-100 koa:rounded-full koa:p-1 koa:flex koa:flex-wrap koa:gap-1 koa:max-w-[90dvw] koa:sm:w-fit">
         <label
-          className={` text-xs px-4 py-2 rounded-full cursor-pointer transition-colors ${
-            selectedOrganizations.size === 0 ? "bg-slate-700 text-slate-50" : "bg-slate-100 text-slate-700 hover:bg-slate-200"
+          className={` koa:text-xs koa:px-4 koa:py-2 koa:rounded-full koa:cursor-pointer koa:transition-colors ${
+            selectedOrganizations.size === 0 ? "koa:bg-slate-700 koa:text-slate-50" : "koa:bg-slate-100 koa:text-slate-700 koa:hover:bg-slate-200"
           }`}
         >
           <input
@@ -81,15 +81,15 @@ function OrganizationFilter({ organizations, selectedOrganizations, setSelectedO
                 setSelectedOrganizations(new Set(organizations));
               }
             }}
-            className="sr-only"
+            className="koa:sr-only"
           />
           {t("selectAll")}
         </label>
         {organizations.map((org) => (
           <label
             key={org}
-            className={`text-xs px-4 py-2 rounded-full cursor-pointer transition-colors ${
-              selectedOrganizations.has(org) ? "bg-slate-700 text-slate-50" : "bg-slate-100 text-slate-700 hover:bg-slate-200"
+            className={`koa:text-xs koa:px-4 koa:py-2 koa:rounded-full koa:cursor-pointer koa:transition-colors ${
+              selectedOrganizations.has(org) ? "koa:bg-slate-700 koa:text-slate-50" : "koa:bg-slate-100 koa:text-slate-700 koa:hover:bg-slate-200"
             }`}
           >
             <input
@@ -104,7 +104,7 @@ function OrganizationFilter({ organizations, selectedOrganizations, setSelectedO
                 }
                 setSelectedOrganizations(newSelected);
               }}
-              className="sr-only"
+              className="koa:sr-only"
             />
             {org}
           </label>
@@ -136,8 +136,8 @@ function ComparisonHeader({ condensed = false, result, filterNestedCandidates }:
   const t = useTranslations("koa.components.comparisonGrid");
 
   return (
-    <div className={`sticky ${condensed ? "top-[4.75rem]" : "top-32"} gap-8 flex z-40 transition-all duration-500 ease-in-out`}>
-      <div className="rounded-xl bg-blue-100/60 backdrop-blur-lg border-blue-50 border-1 z-50 min-h-[65px] sticky left-4 w-[100px] flex-shrink-0 text-center text-xs flex items-center justify-center">
+    <div className={`koa:sticky ${condensed ? "koa:top-[4.75rem]" : "koa:top-32"} koa:gap-8 koa:flex koa:z-40 koa:transition-all koa:duration-500 koa:ease-in-out`}>
+      <div className="koa:rounded-xl koa:bg-blue-100/60 koa:backdrop-blur-lg koa:border-blue-50 koa:border-1 koa:z-50 koa:min-h-[65px] koa:sticky koa:left-4 koa:w-[100px] koa:flex-shrink-0 koa:text-center koa:text-xs koa:flex koa:items-center koa:justify-center">
         {t("yourAnswers")}
       </div>
       {result.matches.map((match) => {
@@ -145,7 +145,7 @@ function ComparisonHeader({ condensed = false, result, filterNestedCandidates }:
         const nestedCandidates = nestedMatches?.map((nested: NonNullable<ResultViewModel["matches"][0]["nestedMatches"]>[0]) => (
           <div
             key={`header-${nested.candidate.id}`}
-            className=" rounded-xl bg-slate-100/60 backdrop-blur-lg border-slate-100 border-1 w-[100px] flex-shrink-0 flex items-center justify-center text-center text-xs"
+            className=" koa:rounded-xl koa:bg-slate-100/60 koa:backdrop-blur-lg koa:border-slate-100 koa:border-1 koa:w-[100px] koa:flex-shrink-0 koa:flex koa:items-center koa:justify-center koa:text-center koa:text-xs"
           >
             <span>
               {nested.candidate.displayName}
@@ -157,14 +157,14 @@ function ComparisonHeader({ condensed = false, result, filterNestedCandidates }:
           return (
             <div
               key={`header-${match.candidate.id}`}
-              className="rounded-xl bg-slate-100/60 backdrop-blur-lg border-slate-100 border-1 w-[100px] flex-shrink-0 flex items-center justify-center text-center text-xs"
+              className="koa:rounded-xl koa:bg-slate-100/60 koa:backdrop-blur-lg koa:border-slate-100 koa:border-1 koa:w-[100px] koa:flex-shrink-0 koa:flex koa:items-center koa:justify-center koa:text-center koa:text-xs"
             >
               {match.candidate.displayName}
             </div>
           );
         }
         return (
-          <div key={`header-group-${match.candidate.id}`} className="flex gap-8">
+          <div key={`header-group-${match.candidate.id}`} className="koa:flex koa:gap-8">
             {nestedCandidates}
           </div>
         );
@@ -186,22 +186,22 @@ function ComparisonQuestionRow({ question, index, totalQuestions, answers, resul
   const userAnswer = answers.answers.find((answer) => answer.answer?.questionId === question.id);
 
   return (
-    <div key={question.id} className="flex flex-col gap-4 relative z-30">
-      <div className="flex gap-8 relative w-max">
-        <div className="h-auto absolute left-0 top-0" />
-        <div className="px-4 flex justify-start sticky left-4 w-[95dvw]">
+    <div key={question.id} className="koa:flex koa:flex-col koa:gap-4 koa:relative koa:z-30">
+      <div className="koa:flex koa:gap-8 koa:relative koa:w-max">
+        <div className="koa:h-auto koa:absolute koa:left-0 koa:top-0" />
+        <div className="koa:px-4 koa:flex koa:justify-start koa:sticky koa:left-4 koa:w-[95dvw]">
           <ComparisonQuestionCard question={question} current={index + 1} total={totalQuestions} />
         </div>
-        <div className="w-[100px] flex-shrink-0" />
+        <div className="koa:w-[100px] koa:flex-shrink-0" />
         {result.matches.map((match) => {
           const nestedMatches = filterNestedCandidates(match.nestedMatches);
           if (!nestedMatches) {
-            return <div key={`spacer-${match.candidate.id}`} className="w-[100px] flex-shrink-0" />;
+            return <div key={`spacer-${match.candidate.id}`} className="koa:w-[100px] koa:flex-shrink-0" />;
           }
           return (
-            <div key={`spacer-group-${match.candidate.id}`} className="flex gap-8">
+            <div key={`spacer-group-${match.candidate.id}`} className="koa:flex koa:gap-8">
               {nestedMatches.map((nested) => (
-                <div key={`spacer-${nested.candidate.id}`} className="w-[100px] flex-shrink-0" />
+                <div key={`spacer-${nested.candidate.id}`} className="koa:w-[100px] koa:flex-shrink-0" />
               ))}
             </div>
           );
@@ -209,11 +209,11 @@ function ComparisonQuestionRow({ question, index, totalQuestions, answers, resul
       </div>
 
       {/* answers grid */}
-      <div className="flex gap-8 relative">
-        <div className="h-32 absolute left-0 top-0" />
+      <div className="koa:flex koa:gap-8 koa:relative">
+        <div className="koa:h-32 koa:absolute koa:left-0 koa:top-0" />
         {/* user answers */}
-        <div className="w-[100px] z-20 flex-shrink-0 flex justify-center items-center min-h-[40px] sticky left-4">
-          <div className="rounded-full bg-slate-50">
+        <div className="koa:w-[100px] koa:z-20 koa:flex-shrink-0 koa:flex koa:justify-center koa:items-center koa:min-h-[40px] koa:sticky koa:left-4">
+          <div className="koa:rounded-full koa:bg-slate-50">
             <ComparisonAnswerIcon answer={userAnswer?.answer?.answer} />
           </div>
         </div>
@@ -223,17 +223,17 @@ function ComparisonQuestionRow({ question, index, totalQuestions, answers, resul
           if (!nestedMatches) {
             const answer = match.candidateAnswers.find((a) => a.questionId === question.id);
             return (
-              <div key={`answer-${match.candidate.id}`} className="w-[100px] flex-shrink-0 flex justify-center items-center min-h-[40px]">
+              <div key={`answer-${match.candidate.id}`} className="koa:w-[100px] koa:flex-shrink-0 koa:flex koa:justify-center koa:items-center koa:min-h-[40px]">
                 <ComparisonAnswerIcon answer={answer?.answer} />
               </div>
             );
           }
           return (
-            <div key={`answer-group-${match.candidate.id}`} className="flex gap-8">
+            <div key={`answer-group-${match.candidate.id}`} className="koa:flex koa:gap-8">
               {nestedMatches.map((nested: NonNullable<ResultViewModel["matches"][0]["nestedMatches"]>[0]) => {
                 const answer = nested.candidateAnswers.find((a: (typeof nested.candidateAnswers)[0]) => a.questionId === question.id);
                 return (
-                  <div key={`answer-${nested.candidate.id}`} className="w-[100px] flex-shrink-0 flex justify-center items-center min-h-[40px]">
+                  <div key={`answer-${nested.candidate.id}`} className="koa:w-[100px] koa:flex-shrink-0 koa:flex koa:justify-center koa:items-center koa:min-h-[40px]">
                     <ComparisonAnswerIcon answer={answer?.answer} />
                   </div>
                 );
@@ -275,9 +275,9 @@ export function ComparisonGrid({ questions, answers, result, condensed = false }
   };
 
   return (
-    <div className="mt-28 flex flex-col gap-8 relative">
+    <div className="koa:mt-28 koa:flex koa:flex-col koa:gap-8 koa:relative">
       <OrganizationFilter organizations={organizations} selectedOrganizations={selectedOrganizations} setSelectedOrganizations={setSelectedOrganizations} />
-      <div className="mr-[calc(5dvw)] flex flex-col gap-8">
+      <div className="koa:mr-[calc(5dvw)] koa:flex koa:flex-col koa:gap-8">
         <ComparisonGridDashlinesOverlay result={result} filterNestedCandidates={filterNestedCandidates} />
         <ComparisonHeader condensed={condensed} result={result} filterNestedCandidates={filterNestedCandidates} />
         {questions.questions.map((question, index) => (

--- a/packages/app/src/client/components/match-card.tsx
+++ b/packages/app/src/client/components/match-card.tsx
@@ -16,12 +16,12 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
   const [expandedSources, setExpandedSources] = useState<Set<string>>(new Set());
 
   return (
-    <ExpandableCard corner="topLeft" shadow="hard" className="overflow-hidden border border-slate-200">
+    <ExpandableCard corner="topLeft" shadow="hard" className="koa:overflow-hidden koa:border koa:border-slate-200">
       {({ open }) => (
         <>
           {match !== undefined && <ProgressBar value={match} color={order === 1 ? "primary" : "neutral"} corner="sharp" />}
-          <ExpandableCard.Content className="grid gap-3 p-4 sm:gap-4 sm:p-6">
-            <div className="grid grid-cols-[auto_1fr_auto] gap-4 items-center">
+          <ExpandableCard.Content className="koa:grid koa:gap-3 koa:p-4 koa:sm:gap-4 koa:sm:p-6">
+            <div className="koa:grid koa:grid-cols-[auto_1fr_auto] koa:gap-4 koa:items-center">
               {candidate.avatar ? (
                 <Avatar
                   image={candidate.avatar.urls}
@@ -34,36 +34,36 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
                 />
               ) : (
                 <div
-                  className={`flex h-20 w-20 items-center justify-center rounded-2xl ${order === 1 ? "bg-[var(--ko-color-primary)] text-[var(--ko-color-on-bg-primary)]" : "bg-white text-slate-700"}`}
+                  className={`koa:flex koa:h-20 koa:w-20 koa:items-center koa:justify-center koa:rounded-2xl ${order === 1 ? "koa:bg-[var(--ko-color-primary)] koa:text-[var(--ko-color-on-bg-primary)]" : "koa:bg-white koa:text-slate-700"}`}
                 >
-                  <span className="text-3xl font-bold">{order !== undefined ? order : "—"}</span>
+                  <span className="koa:text-3xl koa:font-bold">{order !== undefined ? order : "—"}</span>
                 </div>
               )}
-              <div className="flex flex-col gap-1 items-start justify-center">
-                <h3 className="text-lg font-bold leading-tight text-slate-700">{candidate.displayName}</h3>
-                {candidate.organization && <p className="text-sm text-slate-500">{candidate.organization}</p>}
+              <div className="koa:flex koa:flex-col koa:gap-1 koa:items-start koa:justify-center">
+                <h3 className="koa:text-lg koa:font-bold koa:leading-tight koa:text-slate-700">{candidate.displayName}</h3>
+                {candidate.organization && <p className="koa:text-sm koa:text-slate-500">{candidate.organization}</p>}
                 {respondent === "expert" && (
-                  <p className="text-xs text-gray-500">
+                  <p className="koa:text-xs koa:text-gray-500">
                     {t("expertNoteLine1")}
                     <br /> {t("expertNoteLine2")}
                   </p>
                 )}
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-3xl font-bold tracking-tight text-slate-800">{match !== undefined ? `${Math.round(match)} %` : "—"}</span>
-                {hasDirectAnswers && <ExpandableCard.Chevron open={open} className="text-slate-400" />}
+              <div className="koa:flex koa:items-center koa:gap-2">
+                <span className="koa:text-3xl koa:font-bold koa:tracking-tight koa:text-slate-800">{match !== undefined ? `${Math.round(match)} %` : "—"}</span>
+                {hasDirectAnswers && <ExpandableCard.Chevron open={open} className="koa:text-slate-400" />}
               </div>
             </div>
           </ExpandableCard.Content>
 
           {hasDirectAnswers && (
-            <ExpandableCard.HiddenContent className="px-4 sm:px-6 pb-4 sm:pb-6 bg-white">
-              <div className="border-t border-slate-200 pt-4">
+            <ExpandableCard.HiddenContent className="koa:px-4 koa:sm:px-6 koa:pb-4 koa:sm:pb-6 koa:bg-white">
+              <div className="koa:border-t koa:border-slate-200 koa:pt-4">
                 {/* Answer Comparisons Grid */}
                 {answerComparisons.length > 0 && (
-                  <div className="grid grid-cols-[1fr_auto] gap-y-2 gap-x-1 auto-rows-auto">
-                    <div className="col-span-2 text-right mb-2">
-                      <div className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-amber-100 text-amber-800 border border-amber-200">
+                  <div className="koa:grid koa:grid-cols-[1fr_auto] koa:gap-y-2 koa:gap-x-1 koa:auto-rows-auto">
+                    <div className="koa:col-span-2 koa:text-right koa:mb-2">
+                      <div className="koa:inline-flex koa:items-center koa:px-3 koa:py-1 koa:rounded-full koa:text-xs koa:font-medium koa:bg-amber-100 koa:text-amber-800 koa:border koa:border-amber-200">
                         <span>{t("beta")}</span>
                       </div>
                     </div>
@@ -74,14 +74,16 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
                     {answerComparisons.map((comparison) => (
                       <React.Fragment key={comparison.questionId}>
                         {/* Question + Metadata Wrapper */}
-                        <div className="space-y-2">
+                        <div className="koa:space-y-2">
                           {/* Question Text */}
-                          <div className="text-slate-800 font-medium text-sm">{comparison.questionText}</div>
+                          <div className="koa:text-slate-800 koa:font-medium koa:text-sm">{comparison.questionText}</div>
 
                           {/* Comment if available - candidate or expert - but not if showing expert no-data badge */}
                           {(comparison.candidateComment || comparison.expertComment) &&
                             !((comparison.candidateAnswer === null || comparison.candidateAnswer === undefined) && respondent === "expert") && (
-                              <blockquote className="text-slate-600 italic pl-4 border-l-2 border-slate-200 text-sm">"{comparison.candidateComment || comparison.expertComment}"</blockquote>
+                              <blockquote className="koa:text-slate-600 koa:italic koa:pl-4 koa:border-l-2 koa:border-slate-200 koa:text-sm">
+                                "{comparison.candidateComment || comparison.expertComment}"
+                              </blockquote>
                             )}
 
                           {/* Sources if available - candidate or expert */}
@@ -89,12 +91,12 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
                             (comparison.expertSources && comparison.expertSources.length > 0) ||
                             comparison.candidateAnswer === null ||
                             comparison.candidateAnswer === undefined) && (
-                            <div className="text-xs text-slate-500">
+                            <div className="koa:text-xs koa:text-slate-500">
                               {(comparison.candidateAnswer === null || comparison.candidateAnswer === undefined) && respondent === "expert" ? (
-                                <div className="space-y-1">
+                                <div className="koa:space-y-1">
                                   <div>
-                                    <div className="inline-flex items-center gap-1 px-2 py-1 rounded bg-slate-100 text-slate-700 text-xs">
-                                      <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                    <div className="koa:inline-flex koa:items-center koa:gap-1 koa:px-2 koa:py-1 koa:rounded koa:bg-slate-100 koa:text-slate-700 koa:text-xs">
+                                      <svg className="koa:w-3 koa:h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                                         <path d="M13,14H11V10H13M13,18H11V16H13M1,21H23L12,2L1,21Z" />
                                       </svg>
                                       <span>{t("positionUnknown")}</span>
@@ -107,11 +109,11 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
                                   const isExpanded = expandedSources.has(sourceKey);
 
                                   return (
-                                    <div key={source.url || `source-${i}`} className="space-y-1">
+                                    <div key={source.url || `source-${i}`} className="koa:space-y-1">
                                       <div>
                                         <button
                                           type="button"
-                                          className="inline-flex items-center gap-1 px-2 py-1 rounded bg-slate-100 hover:bg-slate-200 text-slate-700 hover:text-slate-900 text-xs"
+                                          className="koa:inline-flex koa:items-center koa:gap-1 koa:px-2 koa:py-1 koa:rounded koa:bg-slate-100 koa:hover:bg-slate-200 koa:text-slate-700 koa:hover:text-slate-900 koa:text-xs"
                                           onClick={() => {
                                             const newExpanded = new Set(expandedSources);
                                             if (isExpanded) {
@@ -123,19 +125,19 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
                                           }}
                                         >
                                           <span>{source.title || source.url || t("source")}</span>
-                                          <svg className="w-3 h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                                          <svg className="koa:w-3 koa:h-3" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                                             <path d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z" />
                                           </svg>
                                         </button>
                                       </div>
 
                                       {isExpanded && (
-                                        <blockquote className="text-slate-600 italic pl-4 border-l-2 border-slate-200 text-sm">
+                                        <blockquote className="koa:text-slate-600 koa:italic koa:pl-4 koa:border-l-2 koa:border-slate-200 koa:text-sm">
                                           {source.description || t("noDescription")}
                                           {source.url && (
                                             <>
                                               {" "}
-                                              <a href={source.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:text-blue-800 underline">
+                                              <a href={source.url} target="_blank" rel="noopener noreferrer" className="koa:text-blue-600 koa:hover:text-blue-800 koa:underline">
                                                 {t("link")}
                                               </a>
                                             </>
@@ -151,18 +153,18 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
                         </div>
 
                         {/* Answer Comparison */}
-                        <div className="flex items-center gap-1">
+                        <div className="koa:flex koa:items-center koa:gap-1">
                           <div
-                            className={`px-3 py-1 rounded text-sm font-bold ${
+                            className={`koa:px-3 koa:py-1 koa:rounded koa:text-sm koa:font-bold ${
                               comparison.userAnswer === comparison.candidateAnswer && comparison.userAnswer !== null && comparison.userAnswer !== undefined
                                 ? comparison.userAnswer === true
-                                  ? "bg-blue-600 text-white"
-                                  : "bg-red-600 text-white"
-                                : "bg-transparent text-slate-600"
+                                  ? "koa:bg-blue-600 koa:text-white"
+                                  : "koa:bg-red-600 koa:text-white"
+                                : "koa:bg-transparent koa:text-slate-600"
                             }`}
                           >
                             <span>{comparison.userAnswer === true ? "✓" : comparison.userAnswer === false ? "✗" : "—"}</span>
-                            <span className="mx-1">•</span>
+                            <span className="koa:mx-1">•</span>
                             <span>{comparison.candidateAnswer === true ? "✓" : comparison.candidateAnswer === false ? "✗" : "—"}</span>
                           </div>
                         </div>

--- a/packages/app/src/client/components/share-modal.tsx
+++ b/packages/app/src/client/components/share-modal.tsx
@@ -114,30 +114,36 @@ export function ShareModal({ isOpen, onClose, onShare, buildShareUrl, privacyHre
   };
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" onClick={onClose} role="dialog" aria-modal="true">
-      <div className="bg-white rounded-2xl shadow-xl max-w-lg w-full p-6 relative" onClick={(e) => e.stopPropagation()} role="document">
-        <button type="button" onClick={onClose} className="absolute top-4 right-4 text-slate-400 hover:text-slate-600 transition-colors" aria-label={t("close")}>
+    <div className="koa:fixed koa:inset-0 koa:z-50 koa:flex koa:items-center koa:justify-center koa:p-4 koa:bg-black/50 koa:backdrop-blur-sm" onClick={onClose} role="dialog" aria-modal="true">
+      <div className="koa:bg-white koa:rounded-2xl koa:shadow-xl koa:max-w-lg koa:w-full koa:p-6 koa:relative" onClick={(e) => e.stopPropagation()} role="document">
+        <button type="button" onClick={onClose} className="koa:absolute koa:top-4 koa:right-4 koa:text-slate-400 koa:hover:text-slate-600 koa:transition-colors" aria-label={t("close")}>
           <Icon icon={mdiClose} size="medium" decorative />
         </button>
 
-        <h2 className="font-display text-2xl font-bold text-slate-800 mb-4">{t("title")}</h2>
+        <h2 className="koa:font-display koa:text-2xl koa:font-bold koa:text-slate-800 koa:mb-4">{t("title")}</h2>
 
         {isLoading && (
-          <div className="flex items-center justify-center py-8">
-            <div className="text-slate-500">{t("creating")}</div>
+          <div className="koa:flex koa:items-center koa:justify-center koa:py-8">
+            <div className="koa:text-slate-500">{t("creating")}</div>
           </div>
         )}
 
-        {error && <div className="mb-4 p-4 bg-red-50 text-red-700 rounded-lg">{error}</div>}
+        {error && <div className="koa:mb-4 koa:p-4 koa:bg-red-50 koa:text-red-700 koa:rounded-lg">{error}</div>}
 
         {shareUrl && !isLoading && !error && (
           <>
-            <p className="text-slate-600 text-sm mb-4">{t("intro")}</p>
+            <p className="koa:text-slate-600 koa:text-sm koa:mb-4">{t("intro")}</p>
 
-            <div className="flex gap-2 mb-6">
-              <input ref={inputRef} type="text" readOnly value={shareUrl} className="flex-1 min-w-0 px-3 py-2 border border-slate-200 rounded-lg bg-slate-50 text-slate-700 text-sm truncate" />
+            <div className="koa:flex koa:gap-2 koa:mb-6">
+              <input
+                ref={inputRef}
+                type="text"
+                readOnly
+                value={shareUrl}
+                className="koa:flex-1 koa:min-w-0 koa:px-3 koa:py-2 koa:border koa:border-slate-200 koa:rounded-lg koa:bg-slate-50 koa:text-slate-700 koa:text-sm koa:truncate"
+              />
               {hasClipboardAccess && (
-                <div className="shrink-0">
+                <div className="koa:shrink-0">
                   <Button onClick={handleCopy} variant="outline" color="neutral" size="small">
                     <Icon icon={isCopied ? mdiCheck : mdiContentCopy} size="medium" decorative />
                     {isCopied ? t("copied") : t("copy")}
@@ -146,9 +152,9 @@ export function ShareModal({ isOpen, onClose, onShare, buildShareUrl, privacyHre
               )}
             </div>
 
-            <div className="mb-2">
+            <div className="koa:mb-2">
               <Button onClick={handleDownloadInstagramStory} variant="outline" color="neutral" size="small">
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <svg className="koa:w-5 koa:h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z" />
                 </svg>
                 {t("shareInstagram")}
@@ -157,7 +163,7 @@ export function ShareModal({ isOpen, onClose, onShare, buildShareUrl, privacyHre
 
             <div>
               <Button onClick={() => window.open(twitterUrl, "_blank", "noopener,noreferrer")} variant="outline" color="neutral" size="small">
-                <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <svg className="koa:w-5 koa:h-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                   <path d="M18.901 1.153h3.68l-8.04 9.19L24 22.846h-7.406l-5.8-7.584-6.638 7.584H.474l8.6-9.83L0 1.154h7.594l5.243 6.932ZM17.61 20.644h2.039L6.486 3.24H4.298Z" />
                 </svg>
                 {t("shareX")}
@@ -165,9 +171,9 @@ export function ShareModal({ isOpen, onClose, onShare, buildShareUrl, privacyHre
             </div>
 
             {privacyHref && (
-              <p className="text-slate-500 text-xs mt-4">
+              <p className="koa:text-slate-500 koa:text-xs koa:mt-4">
                 {t("consentPrefix")}{" "}
-                <a href={privacyHref} target="_blank" rel="noopener noreferrer" className="text-slate-700 hover:text-slate-900 underline">
+                <a href={privacyHref} target="_blank" rel="noopener noreferrer" className="koa:text-slate-700 koa:hover:text-slate-900 koa:underline">
                   {t("privacyPolicy")}
                 </a>
                 .

--- a/packages/app/src/components/embed-footer.tsx
+++ b/packages/app/src/components/embed-footer.tsx
@@ -2,8 +2,8 @@ import { useTranslations } from "next-intl";
 
 import { EmbedAttribution } from "@/components/embed-attribution";
 
-const HEIGHT = "h-11";
-const MARGIN_BOTTOM = "mb-11";
+const HEIGHT = "koa:h-11";
+const MARGIN_BOTTOM = "koa:mb-11";
 
 export type EmbedFooter = {
   attribution?: boolean;
@@ -15,10 +15,10 @@ export function EmbedFooter({ attribution = true, homepageHref, privacyHref }: E
   const t = useTranslations("koa");
 
   return (
-    <div className="flex items-baseline gap-4">
+    <div className="koa:flex koa:items-baseline koa:gap-4">
       {attribution && <EmbedAttribution href={homepageHref} title={t("appTitle")} />}
       {privacyHref && (
-        <a href={privacyHref} target="_blank" rel="noopener noreferrer" className="text-xs text-slate-400 hover:text-slate-600 hover:underline">
+        <a href={privacyHref} target="_blank" rel="noopener noreferrer" className="koa:text-xs koa:text-slate-400 koa:hover:text-slate-600 koa:hover:underline">
           {t("components.embedFooter.privacy")}
         </a>
       )}

--- a/packages/app/src/components/layout.tsx
+++ b/packages/app/src/components/layout.tsx
@@ -5,7 +5,7 @@ export type Layout = {
 };
 
 function LayoutComponent({ children }: Layout) {
-  return <div className="min-h-screen grid grid-rows-[auto_1fr_auto]">{children}</div>;
+  return <div className="koa:min-h-screen koa:grid koa:grid-rows-[auto_1fr_auto]">{children}</div>;
 }
 
 LayoutComponent.displayName = "Layout";
@@ -16,7 +16,7 @@ export type LayoutHeader = {
 };
 
 function Header({ children, fixed }: LayoutHeader) {
-  return <div className={` ${fixed ? "fixed left-0 w-full" : "sticky"} top-0 z-50`}>{children}</div>;
+  return <div className={` ${fixed ? "koa:fixed koa:left-0 koa:w-full" : "koa:sticky"} koa:top-0 koa:z-50`}>{children}</div>;
 }
 
 Header.displayName = "Layout.Header";
@@ -28,7 +28,7 @@ export type LayoutContent = {
 };
 
 function Content({ children, fullWidth }: LayoutContent) {
-  return <main className={`${fullWidth ? "w-full" : "max-w-xl w-full"} mx-auto p-2 sm:p-4`}>{children}</main>;
+  return <main className={`${fullWidth ? "koa:w-full" : "koa:max-w-xl koa:w-full"} koa:mx-auto koa:p-2 koa:sm:p-4`}>{children}</main>;
 }
 
 Content.displayName = "Layout.Content";
@@ -39,7 +39,7 @@ export type LayoutBottomNavigation = {
 };
 
 function BottomNavigation({ children, className }: LayoutBottomNavigation) {
-  return <div className={twMerge("fixed bottom-0 left-0 right-0 pointer-events-none z-20", className)}>{children}</div>;
+  return <div className={twMerge("koa:fixed koa:bottom-0 koa:left-0 koa:right-0 koa:pointer-events-none koa:z-20", className)}>{children}</div>;
 }
 
 BottomNavigation.displayName = "Layout.BottomNavigation";
@@ -52,7 +52,7 @@ function Footer({ children }: LayoutFooter) {
   if (!children) {
     return null;
   }
-  return <footer className="grid justify-items-center fixed bottom-0 left-0 right-0 z-5 mt-2 sm:mt-3 lg:mt-4 p-1">{children}</footer>;
+  return <footer className="koa:grid koa:justify-items-center koa:fixed koa:bottom-0 koa:left-0 koa:right-0 koa:z-5 koa:mt-2 koa:sm:mt-3 koa:lg:mt-4 koa:p-1">{children}</footer>;
 }
 
 Footer.displayName = "Layout.Footer";

--- a/packages/app/src/components/pages/comparison.tsx
+++ b/packages/app/src/components/pages/comparison.tsx
@@ -45,7 +45,7 @@ export function ComparisonPage({ embedContext, homepageHref, privacyHref, calcul
                     </Button>
                   </AppHeader.BottomLeft>
                   <AppHeader.BottomMain condensed={condensed}>
-                    <h3 className="font-display font-semibold text-2xl tracking-tight text-slate-700">{t("comparison.title")}</h3>
+                    <h3 className="koa:font-display koa:font-semibold koa:text-2xl koa:tracking-tight koa:text-slate-700">{t("comparison.title")}</h3>
                   </AppHeader.BottomMain>
                 </AppHeader.Bottom>
               </AppHeader>
@@ -56,7 +56,7 @@ export function ComparisonPage({ embedContext, homepageHref, privacyHref, calcul
           </>
         )}
       </WithCondenseOnScroll>
-      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} lg:hidden`} />}
+      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} koa:lg:hidden`} />}
       <Layout.Footer>{embedContext.isEmbed && <EmbedFooter attribution={embedContext.config?.attribution} homepageHref={homepageHref} privacyHref={privacyHref} />}</Layout.Footer>
     </Layout>
   );

--- a/packages/app/src/components/pages/guide.tsx
+++ b/packages/app/src/components/pages/guide.tsx
@@ -42,7 +42,7 @@ export function GuidePage({ embedContext, homepageHref, privacyHref, calculator,
               </Button>
             </AppHeader.BottomLeft>
             <AppHeader.BottomMain condensed={false}>
-              <h3 className="font-display font-semibold text-2xl tracking-tight text-slate-700">{t("guide.title")}</h3>
+              <h3 className="koa:font-display koa:font-semibold koa:text-2xl koa:tracking-tight koa:text-slate-700">{t("guide.title")}</h3>
             </AppHeader.BottomMain>
           </AppHeader.Bottom>
         </AppHeader>
@@ -51,8 +51,8 @@ export function GuidePage({ embedContext, homepageHref, privacyHref, calculator,
         <Guide calculator={calculator} />
       </Layout.Content>
       <Layout.BottomSpacer className={GuideNavigationCard.heightClassNames} />
-      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} lg:hidden`} />}
-      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} lg:mb-0` : undefined}>
+      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} koa:lg:hidden`} />}
+      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} koa:lg:mb-0` : undefined}>
         <GuideNavigationCard onNextClick={onNextClick} />
       </Layout.BottomNavigation>
       <Layout.Footer>{embedContext.isEmbed && <EmbedFooter attribution={embedContext.config?.attribution} homepageHref={homepageHref} privacyHref={privacyHref} />}</Layout.Footer>

--- a/packages/app/src/components/pages/introduction.tsx
+++ b/packages/app/src/components/pages/introduction.tsx
@@ -36,7 +36,7 @@ export function IntroductionPage({ embedContext, homepageHref, privacyHref, calc
           </AppHeader.Right>
           <AppHeader.Bottom>
             <AppHeader.BottomMain>
-              <h2 className="font-display font-semibold text-2xl tracking-tight text-slate-700">{calculator?.shortTitle}</h2>
+              <h2 className="koa:font-display koa:font-semibold koa:text-2xl koa:tracking-tight koa:text-slate-700">{calculator?.shortTitle}</h2>
             </AppHeader.BottomMain>
           </AppHeader.Bottom>
         </AppHeader>
@@ -45,8 +45,8 @@ export function IntroductionPage({ embedContext, homepageHref, privacyHref, calc
         <Introduction calculator={calculator} />
       </Layout.Content>
       <Layout.BottomSpacer className={IntroductionNavigationCard.heightClassNames} />
-      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} lg:hidden`} />}
-      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} lg:mb-0` : undefined}>
+      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} koa:lg:hidden`} />}
+      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} koa:lg:mb-0` : undefined}>
         <IntroductionNavigationCard onNextClick={onNextClick} />
       </Layout.BottomNavigation>
       <Layout.Footer>{embedContext.isEmbed && <EmbedFooter attribution={embedContext.config?.attribution} homepageHref={homepageHref} privacyHref={privacyHref} />}</Layout.Footer>

--- a/packages/app/src/components/pages/public-result.tsx
+++ b/packages/app/src/components/pages/public-result.tsx
@@ -26,7 +26,7 @@ export function PublicResultPage({ result, calculator, showOnlyNested, onFilterC
             <AppHeader condensed={condensed} calculator={calculator}>
               <AppHeader.Bottom>
                 <AppHeader.BottomMain condensed={condensed}>
-                  <h3 className="font-display font-semibold text-2xl tracking-tight text-slate-700">{t("publicResult.title")}</h3>
+                  <h3 className="koa:font-display koa:font-semibold koa:text-2xl koa:tracking-tight koa:text-slate-700">{t("publicResult.title")}</h3>
                 </AppHeader.BottomMain>
               </AppHeader.Bottom>
             </AppHeader>
@@ -35,22 +35,26 @@ export function PublicResultPage({ result, calculator, showOnlyNested, onFilterC
       </Layout.Header>
       <Layout.Content>
         {shouldShowToggleComputed && (
-          <div className="mb-6">
-            <div className="flex items-center gap-3 text-sm">
-              <div className="relative bg-slate-100 rounded-full p-1 flex  w-full sm:w-auto text-center">
-                <label className={`grow px-4 py-2 rounded-full cursor-pointer transition-colors ${!showOnlyNested ? "bg-slate-700 text-slate-50" : "bg-slate-100 text-slate-700 hover:bg-slate-200"}`}>
-                  <input type="radio" name="resultView" checked={!showOnlyNested} onChange={() => onFilterChange(false)} className="sr-only" />
+          <div className="koa:mb-6">
+            <div className="koa:flex koa:items-center koa:gap-3 koa:text-sm">
+              <div className="koa:relative koa:bg-slate-100 koa:rounded-full koa:p-1 koa:flex  koa:w-full koa:sm:w-auto koa:text-center">
+                <label
+                  className={`koa:grow koa:px-4 koa:py-2 koa:rounded-full koa:cursor-pointer koa:transition-colors ${!showOnlyNested ? "koa:bg-slate-700 koa:text-slate-50" : "koa:bg-slate-100 koa:text-slate-700 koa:hover:bg-slate-200"}`}
+                >
+                  <input type="radio" name="resultView" checked={!showOnlyNested} onChange={() => onFilterChange(false)} className="koa:sr-only" />
                   {t("publicResult.candidateLists")}
                 </label>
-                <label className={`grow px-4 py-2 rounded-full cursor-pointer transition-colors ${showOnlyNested ? "bg-slate-700 text-slate-50" : "bg-slate-100 text-slate-700 hover:bg-slate-200"}`}>
-                  <input type="radio" name="resultView" checked={showOnlyNested} onChange={() => onFilterChange(true)} className="sr-only" />
+                <label
+                  className={`koa:grow koa:px-4 koa:py-2 koa:rounded-full koa:cursor-pointer koa:transition-colors ${showOnlyNested ? "koa:bg-slate-700 koa:text-slate-50" : "koa:bg-slate-100 koa:text-slate-700 koa:hover:bg-slate-200"}`}
+                >
+                  <input type="radio" name="resultView" checked={showOnlyNested} onChange={() => onFilterChange(true)} className="koa:sr-only" />
                   {t("publicResult.people")}
                 </label>
               </div>
             </div>
           </div>
         )}
-        <div className="grid gap-4">
+        <div className="koa:grid koa:gap-4">
           {result.matches.map((match) => (
             <MatchCard key={match.candidate.id} {...match} />
           ))}

--- a/packages/app/src/components/pages/question.tsx
+++ b/packages/app/src/components/pages/question.tsx
@@ -86,8 +86,8 @@ export function QuestionPage({ embedContext, homepageHref, privacyHref, question
         <QuestionCard question={question} current={number} total={total} />
       </Layout.Content>
       <Layout.BottomSpacer className={QuestionNavigationCard.heightClassNames} />
-      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} lg:hidden`} />}
-      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} lg:mb-0` : undefined}>
+      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} koa:lg:hidden`} />}
+      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} koa:lg:mb-0` : undefined}>
         <QuestionNavigationCard
           current={number}
           total={total}

--- a/packages/app/src/components/pages/result.tsx
+++ b/packages/app/src/components/pages/result.tsx
@@ -66,7 +66,7 @@ export function ResultPage({
                   </Button>
                 </AppHeader.BottomLeft>
                 <AppHeader.BottomMain condensed={condensed}>
-                  <h3 className="font-display font-semibold text-2xl tracking-tight text-slate-700">{t("result.title")}</h3>
+                  <h3 className="koa:font-display koa:font-semibold koa:text-2xl koa:tracking-tight koa:text-slate-700">{t("result.title")}</h3>
                 </AppHeader.BottomMain>
               </AppHeader.Bottom>
             </AppHeader>
@@ -75,22 +75,26 @@ export function ResultPage({
       </Layout.Header>
       <Layout.Content>
         {shouldShowToggleComputed && (
-          <div className="mb-6">
-            <div className="flex items-center gap-3 text-sm">
-              <div className="relative bg-slate-100 rounded-full p-1 flex  w-full sm:w-auto text-center">
-                <label className={`grow px-4 py-2 rounded-full cursor-pointer transition-colors ${!showOnlyNested ? "bg-slate-700 text-slate-50" : "bg-slate-100 text-slate-700 hover:bg-slate-200"}`}>
-                  <input type="radio" name="resultView" checked={!showOnlyNested} onChange={() => onFilterChange(false)} className="sr-only" />
+          <div className="koa:mb-6">
+            <div className="koa:flex koa:items-center koa:gap-3 koa:text-sm">
+              <div className="koa:relative koa:bg-slate-100 koa:rounded-full koa:p-1 koa:flex  koa:w-full koa:sm:w-auto koa:text-center">
+                <label
+                  className={`koa:grow koa:px-4 koa:py-2 koa:rounded-full koa:cursor-pointer koa:transition-colors ${!showOnlyNested ? "koa:bg-slate-700 koa:text-slate-50" : "koa:bg-slate-100 koa:text-slate-700 koa:hover:bg-slate-200"}`}
+                >
+                  <input type="radio" name="resultView" checked={!showOnlyNested} onChange={() => onFilterChange(false)} className="koa:sr-only" />
                   {t("result.candidateLists")}
                 </label>
-                <label className={`grow px-4 py-2 rounded-full cursor-pointer transition-colors ${showOnlyNested ? "bg-slate-700 text-slate-50" : "bg-slate-100 text-slate-700 hover:bg-slate-200"}`}>
-                  <input type="radio" name="resultView" checked={showOnlyNested} onChange={() => onFilterChange(true)} className="sr-only" />
+                <label
+                  className={`koa:grow koa:px-4 koa:py-2 koa:rounded-full koa:cursor-pointer koa:transition-colors ${showOnlyNested ? "koa:bg-slate-700 koa:text-slate-50" : "koa:bg-slate-100 koa:text-slate-700 koa:hover:bg-slate-200"}`}
+                >
+                  <input type="radio" name="resultView" checked={showOnlyNested} onChange={() => onFilterChange(true)} className="koa:sr-only" />
                   {t("result.people")}
                 </label>
               </div>
             </div>
           </div>
         )}
-        <div className="grid gap-4">
+        <div className="koa:grid koa:gap-4">
           {donateCardPosition === 0 && donateCard}
           {result.matches.map((match, index) => (
             <React.Fragment key={match.candidate.id}>
@@ -101,8 +105,8 @@ export function ResultPage({
         </div>
       </Layout.Content>
       <Layout.BottomSpacer className={ResultNavigationCard.heightClassNames} />
-      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} lg:hidden`} />}
-      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} lg:mb-0` : undefined}>
+      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} koa:lg:hidden`} />}
+      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} koa:lg:mb-0` : undefined}>
         <ResultNavigationCard onNextClick={onNextClick} onShareClick={onShareClick} />
       </Layout.BottomNavigation>
       <Layout.Footer>{embedContext.isEmbed && <EmbedFooter attribution={embedContext.config?.attribution} homepageHref={homepageHref} privacyHref={privacyHref} />}</Layout.Footer>

--- a/packages/app/src/components/pages/review.tsx
+++ b/packages/app/src/components/pages/review.tsx
@@ -81,7 +81,7 @@ export function ReviewPage({ embedContext, homepageHref, privacyHref, questions,
                   </Button>
                 </AppHeader.BottomLeft>
                 <AppHeader.BottomMain condensed={condensed}>
-                  <h3 className="font-display font-semibold text-2xl tracking-tight text-slate-700">{t("review.title")}</h3>
+                  <h3 className="koa:font-display koa:font-semibold koa:text-2xl koa:tracking-tight koa:text-slate-700">{t("review.title")}</h3>
                 </AppHeader.BottomMain>
               </AppHeader.Bottom>
             </AppHeader>
@@ -89,7 +89,7 @@ export function ReviewPage({ embedContext, homepageHref, privacyHref, questions,
         </WithCondenseOnScroll>
       </Layout.Header>
       <Layout.Content>
-        <div className="grid gap-4">
+        <div className="koa:grid koa:gap-4">
           {questions.questions.map((question, index) => {
             const answer = answers.answers.find((a) => a.answer?.questionId === question.id) || {
               answer: undefined,
@@ -112,8 +112,8 @@ export function ReviewPage({ embedContext, homepageHref, privacyHref, questions,
         </div>
       </Layout.Content>
       <Layout.BottomSpacer className={ReviewNavigationCard.heightClassNames} />
-      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} lg:hidden`} />}
-      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} lg:mb-0` : undefined}>
+      {hasFooter && <Layout.BottomSpacer className={`${EmbedFooter.heightClassNames} koa:lg:hidden`} />}
+      <Layout.BottomNavigation className={hasFooter ? `${EmbedFooter.marginBottomClassNames} koa:lg:mb-0` : undefined}>
         <ReviewNavigationCard onNextClick={onNextClick} />
       </Layout.BottomNavigation>
       <Layout.Footer>{embedContext.isEmbed && <EmbedFooter attribution={embedContext.config?.attribution} homepageHref={homepageHref} privacyHref={privacyHref} />}</Layout.Footer>

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -1,2 +1,6 @@
 @import 'tailwindcss/theme' prefix(koa);
 @import 'tailwindcss/utilities' prefix(koa);
+
+@theme static {
+  --font-display: var(--ko-font-display);
+}


### PR DESCRIPTION
The components that moved into `@kalkulacka-one/app` during this series kept their unprefixed Tailwind classes, and the apps generated the matching utilities through an `@source` directive pointing back at the package's `dist` (#542). That worked, but it left the package's own components as the only ones that couldn't stand on their own — every app had to remember the directive, and forgetting it produced unstyled markup rather than an error.

They now use the `koa:` prefix like every other component in this package, so their utilities ship in the package's own stylesheet, and the three `@source` directives go away.

## The `--font-display` token

The package stylesheet imports only Tailwind's stock theme, which has no `--font-display` — so `koa:font-display` generated **nothing**. The token is added here, and that fixes more than the components this PR touches:

**`question-card`, `review-question-card` and `comparison-question-card` have been using `koa:font-display` since before this series**, which means their titles have been rendering in the sans fallback instead of the display face on production. Verified on the review page: the same heading computes to `Geist` on `main` and `"Radio Canada"` here.

## Verification

- **Rendered DOM identical on every route of all three apps**, once the `koa:` prefix is normalized away — CZ 12/12, SK 7/7, MK 7/7.
- **Computed-style probes** (grid row templates, header height and stickiness, content width; 1280px and 400px): 9 of 10 identical. The tenth is the font fix above — question card titles change typeface, which changes their height by ~22px over a 7900px review page. Everything structural matches.
- Built stylesheet confirmed to contain the utilities the moved components need, including `koa:grid-rows-[auto_1fr_auto]`, `koa:max-w-xl`, `koa:sticky`, `koa:h-11` and now `koa:font-display`.

Part 21 of the engine-layer extraction series — the last part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)