### PR TITLE
Add the 2026 municipal and Senate calculator selection

### DIFF
--- a/apps/www.volebnikalkulacka.cz/.env.example
+++ b/apps/www.volebnikalkulacka.cz/.env.example
@@ -5,3 +5,6 @@ APPSIGNAL_PUSH_API_KEY=e1d97c41-ff8a-470c-bb3a-1f8ae8854aa6
 NEXT_PUBLIC_APPSIGNAL_FRONTEND_KEY=f226399c-1703-4283-bfce-da121742ad93
 OTEL_EXPORTER_OTLP_ENDPOINT=https://your.eu-central.appsignal-collector.net
 DATABASE_INITIALIZED_AT=2025-09-27T23:30:00+02:00
+
+# Switches the homepage from the "coming soon" teaser to the 2026 election cards.
+ELECTIONS_2026=false

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/ElectionCards.test.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/ElectionCards.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { type ElectionCard, ElectionCards } from "./ElectionCards";
+
+const elections: ElectionCard[] = [
+  {
+    key: "komunalni-2026",
+    name: "Komunální volby 2026",
+    scope: "73 měst",
+    heading: "Jak volit ve vašem městě?",
+    description: "Vyberte své město.",
+    callToAction: "Vybrat město",
+    href: "/volby/komunalni-2026",
+  },
+  {
+    key: "senatni-2026",
+    name: "Senátní volby 2026",
+    scope: "27 obvodů",
+    heading: "Koho poslat do Senátu?",
+    description: "Vyberte svůj obvod.",
+    callToAction: "Vybrat obvod",
+    href: "/volby/senatni-2026",
+  },
+];
+
+describe("ElectionCards", () => {
+  it("links each election to its own selection page", () => {
+    render(<ElectionCards elections={elections} />);
+
+    expect(screen.getByRole("link", { name: "Vybrat město" })).toHaveAttribute("href", "/volby/komunalni-2026");
+    expect(screen.getByRole("link", { name: "Vybrat obvod" })).toHaveAttribute("href", "/volby/senatni-2026");
+  });
+
+  it("shows the name and the scope of each election", () => {
+    render(<ElectionCards elections={elections} />);
+
+    expect(screen.getByText("Komunální volby 2026")).toBeInTheDocument();
+    expect(screen.getByText("73 měst")).toBeInTheDocument();
+    expect(screen.getByText("27 obvodů")).toBeInTheDocument();
+  });
+
+  it("renders nothing but the empty grid when there are no elections", () => {
+    render(<ElectionCards elections={[]} />);
+
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+});

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/ElectionCards.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/ElectionCards.tsx
@@ -1,0 +1,49 @@
+import { Button } from "@kalkulacka-one/design-system/client";
+import { Card } from "@kalkulacka-one/design-system/server";
+
+import Link from "next/link";
+
+export type ElectionCard = {
+  /** The calculator group key — also the React key. */
+  key: string;
+  /** The election's name, e.g. "Komunální volby 2026". */
+  name: string;
+  /** What the voter picks on the page behind the card, e.g. "73 měst". */
+  scope: string;
+  heading: string;
+  description: string;
+  callToAction: string;
+  href: string;
+};
+
+/**
+ * The elections a voter can start from the homepage.
+ *
+ * Kept apart from the page because the homepage is due a redesign: this is the
+ * part that has to survive it, and it should move as one piece.
+ */
+export function ElectionCards({ elections }: { elections: ElectionCard[] }) {
+  return (
+    <div className="grid grid-cols-1 gap-8 md:grid-cols-2 items-stretch">
+      {elections.map((election) => (
+        <Card key={election.key} shadow="hard" border corner="topLeft" className="bg-white h-full !border-slate-200">
+          <div className="p-6 md:p-8 h-full flex flex-col">
+            <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600">
+              <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 font-semibold text-blue-700">{election.name}</span>
+              <span className="rounded-full bg-slate-100 px-2.5 py-1">{election.scope}</span>
+            </div>
+            <h3 className="mt-4 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">{election.heading}</h3>
+            <p className="mt-2 text-slate-500">{election.description}</p>
+            <div className="grid mt-auto pt-4 md:pt-6">
+              <Link href={election.href} className="grid">
+                <Button variant="fill" color="neutral">
+                  {election.callToAction}
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/page.tsx
@@ -5,11 +5,48 @@ import Link from "next/link";
 import { useId } from "react";
 
 import { SubscribeForm } from "@/components/client";
+import { elections2026Live } from "@/config/feature-flags";
+import { loadCalculatorGroup } from "@/lib/api/calculator-group";
 
 import { BeadRow } from "./BeadRow";
+import { type ElectionCard, ElectionCards } from "./ElectionCards";
 
-export default function Page() {
+/**
+ * The two 2026 elections, counted from the data so the homepage never promises
+ * more cities than the picker behind it can offer.
+ */
+async function elections2026(): Promise<ElectionCard[]> {
+  const [municipal, senate] = await Promise.all([loadCalculatorGroup({ group: "komunalni-2026" }), loadCalculatorGroup({ group: "senatni-2026" })]);
+
+  const cities = new Set(municipal.calculators.map((calculator) => calculator.districtKey)).size;
+
+  return [
+    {
+      key: municipal.groupKey,
+      name: municipal.electionName ?? "Komunální volby 2026",
+      scope: `${cities} měst`,
+      heading: "Jak volit ve vašem městě?",
+      description: "Komunální kalkulačka je pro každé město jiná. Vyberte to své a porovnejte se s uskupeními, která u vás kandidují.",
+      callToAction: "Vybrat město",
+      href: `/volby/${municipal.groupKey}`,
+    },
+    {
+      key: senate.groupKey,
+      name: senate.electionName ?? "Senátní volby 2026",
+      scope: `${senate.calculators.length} obvodů`,
+      heading: "Koho poslat do Senátu?",
+      description: "Senát se obměňuje po třetinách. Najděte svůj volební obvod a porovnejte se s jeho kandidáty a kandidátkami.",
+      callToAction: "Vybrat obvod",
+      href: `/volby/${senate.groupKey}`,
+    },
+  ];
+}
+
+export default async function Page() {
   const bgGridId = useId();
+  // Before the campaign starts there is nothing to pick yet, so the homepage
+  // collects e-mail addresses instead. See `config/feature-flags`.
+  const elections = elections2026Live() ? await elections2026() : undefined;
 
   return (
     <div className="relative min-h-screen bg-slate-50 z-0">
@@ -31,37 +68,43 @@ export default function Page() {
       <div className="relative z-10 mx-auto max-w-7xl px-6 sm:px-8 pt-12 md:pt-16 lg:pt-20 pb-12 md:pb-16">
         {/* Campaign: komunální + senátní volby 2026 */}
         <h1 className="font-display ko:font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">Komunální a senátní volby 2026</h1>
-        <div className="mt-10 md:mt-12 grid grid-cols-1 items-stretch">
-          <Card shadow="hard" border corner="topLeft" className="bg-white !border-slate-200">
-            <div className="p-6 md:p-10 grid gap-8 md:grid-cols-2 md:items-center">
-              <div className="flex flex-col items-start gap-3">
-                <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600">
-                  <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 font-semibold text-blue-700">Připravujeme</span>
-                  <span className="rounded-full bg-slate-100 px-2.5 py-1">9.&nbsp;a&nbsp;10.&nbsp;října&nbsp;2026</span>
+        {elections ? (
+          <div className="mt-10 md:mt-12">
+            <ElectionCards elections={elections} />
+          </div>
+        ) : (
+          <div className="mt-10 md:mt-12 grid grid-cols-1 items-stretch">
+            <Card shadow="hard" border corner="topLeft" className="bg-white !border-slate-200">
+              <div className="p-6 md:p-10 grid gap-8 md:grid-cols-2 md:items-center">
+                <div className="flex flex-col items-start gap-3">
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600">
+                    <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 font-semibold text-blue-700">Připravujeme</span>
+                    <span className="rounded-full bg-slate-100 px-2.5 py-1">9.&nbsp;a&nbsp;10.&nbsp;října&nbsp;2026</span>
+                  </div>
+                  <h2 className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Ať vám nové kalkulačky neutečou</h2>
+                  <p className="text-slate-500">Nechte nám na sebe e-mail a dáme vám vědět, jakmile volební kalkulačky pro komunální a senátní volby spustíme.</p>
                 </div>
-                <h2 className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Ať vám nové kalkulačky neutečou</h2>
-                <p className="text-slate-500">Nechte nám na sebe e-mail a dáme vám vědět, jakmile volební kalkulačky pro komunální a senátní volby spustíme.</p>
+                <div className="w-full">
+                  <SubscribeForm />
+                </div>
               </div>
-              <div className="w-full">
-                <SubscribeForm />
-              </div>
-            </div>
-          </Card>
+            </Card>
 
-          <Card border className="mt-8 !border-slate-200 bg-slate-50/50">
-            <div className="p-6 md:p-8 flex flex-col md:flex-row md:items-center gap-4 md:gap-8">
-              <div className="flex-1">
-                <h2 className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-xl md:text-2xl">Pomozte nám s kalkulačkou pro vaše město</h2>
-                <p className="mt-1 text-slate-500">Kalkulačky ke komunálním volbám vznikají s pomocí lidí přímo z místa.</p>
+            <Card border className="mt-8 !border-slate-200 bg-slate-50/50">
+              <div className="p-6 md:p-8 flex flex-col md:flex-row md:items-center gap-4 md:gap-8">
+                <div className="flex-1">
+                  <h2 className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-xl md:text-2xl">Pomozte nám s kalkulačkou pro vaše město</h2>
+                  <p className="mt-1 text-slate-500">Kalkulačky ke komunálním volbám vznikají s pomocí lidí přímo z místa.</p>
+                </div>
+                <Link href="/zapojte-se" className="grid md:shrink-0">
+                  <Button variant="outline" color="neutral">
+                    Přidejte se
+                  </Button>
+                </Link>
               </div>
-              <Link href="/zapojte-se" className="grid md:shrink-0">
-                <Button variant="outline" color="neutral">
-                  Přidejte se
-                </Button>
-              </Link>
-            </div>
-          </Card>
-        </div>
+            </Card>
+          </div>
+        )}
 
         {/* Sněmovní volby 2025 */}
         <h2 className="mt-16 md:mt-20 font-display ko:font-display font-bold tracking-tight text-slate-700 text-3xl">Další kalkulačky</h2>

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/page.tsx
@@ -6,17 +6,21 @@ import { useId } from "react";
 
 import { SubscribeForm } from "@/components/client";
 import { elections2026Live } from "@/config/feature-flags";
-import { loadCalculatorGroup } from "@/lib/api/calculator-group";
+import { loadPublishedCalculatorGroup } from "@/lib/api/calculator-group";
 
 import { BeadRow } from "./BeadRow";
 import { type ElectionCard, ElectionCards } from "./ElectionCards";
 
 /**
  * The two 2026 elections, counted from the data so the homepage never promises
- * more cities than the picker behind it can offer.
+ * more cities than the picker behind it can offer — and nothing at all until
+ * both are published.
  */
-async function elections2026(): Promise<ElectionCard[]> {
-  const [municipal, senate] = await Promise.all([loadCalculatorGroup({ group: "komunalni-2026" }), loadCalculatorGroup({ group: "senatni-2026" })]);
+async function elections2026(): Promise<ElectionCard[] | undefined> {
+  const [municipal, senate] = await Promise.all([loadPublishedCalculatorGroup({ group: "komunalni-2026" }), loadPublishedCalculatorGroup({ group: "senatni-2026" })]);
+  // A card leading to a picker that is not there is worse than no card: with
+  // the flag turned on before the data lands, the teaser stays up.
+  if (!municipal || !senate) return undefined;
 
   const cities = new Set(municipal.calculators.map((calculator) => calculator.districtKey)).size;
 

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/CalculatorSearch.test.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/CalculatorSearch.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CalculatorSearch, type SearchableCalculator } from "./CalculatorSearch";
+
+const cities: SearchableCalculator[] = [
+  { key: "beroun", districtName: "Beroun", variants: [] },
+  { key: "zdar-nad-sazavou", districtName: "Žďár nad Sázavou", variants: [] },
+  { key: "praha", districtName: "Praha", variants: [{ key: "praha-inventura", name: "Inventura hlasování" }] },
+];
+
+function renderSearch(calculators: SearchableCalculator[] = cities, props: Partial<React.ComponentProps<typeof CalculatorSearch>> = {}) {
+  const placeholder = props.placeholder ?? "Hledat město…";
+  render(<CalculatorSearch calculators={calculators} basePath="/volby/komunalni-2026" label="Zvolte své město" {...props} placeholder={placeholder} />);
+  return screen.getByPlaceholderText(placeholder);
+}
+
+describe("CalculatorSearch", () => {
+  it("lists every calculator before anything is typed", () => {
+    renderSearch();
+
+    expect(screen.getByRole("link", { name: "Beroun" })).toHaveAttribute("href", "/volby/komunalni-2026/beroun");
+    expect(screen.getByRole("link", { name: "Žďár nad Sázavou" })).toBeInTheDocument();
+    expect(screen.getByText("Celkem 3")).toBeInTheDocument();
+  });
+
+  it("narrows the list to what was typed", () => {
+    const input = renderSearch();
+
+    fireEvent.change(input, { target: { value: "ber" } });
+
+    expect(screen.getByRole("link", { name: "Beroun" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "Praha" })).not.toBeInTheDocument();
+    expect(screen.getByText("Nalezeno 1 z 3")).toBeInTheDocument();
+  });
+
+  it("matches a name whose diacritics were left off", () => {
+    const input = renderSearch();
+
+    fireEvent.change(input, { target: { value: "zdar" } });
+
+    expect(screen.getByRole("link", { name: "Žďár nad Sázavou" })).toBeInTheDocument();
+  });
+
+  it("offers a city's other calculators alongside it", () => {
+    renderSearch();
+
+    expect(screen.getByRole("link", { name: "Inventura hlasování" })).toHaveAttribute("href", "/volby/komunalni-2026/praha-inventura");
+  });
+
+  it("points at the sign-up page when nothing matches", () => {
+    const input = renderSearch();
+
+    fireEvent.change(input, { target: { value: "lhota" } });
+
+    expect(screen.getByText(/nic nenašli/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /pomozte nám/ })).toHaveAttribute("href", "/zapojte-se");
+  });
+
+  it("matches a constituency by its code, and shows the code where the data asks for it", () => {
+    const districts: SearchableCalculator[] = [
+      { key: "3-cheb", districtName: "Cheb", districtCode: "3" },
+      { key: "6-louny", districtName: "Louny", districtCode: "6" },
+    ];
+    const input = renderSearch(districts, { showCode: true, placeholder: "Hledat obvod…" });
+
+    expect(screen.getByRole("link", { name: "3. Cheb" })).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "6" } });
+
+    expect(screen.getByRole("link", { name: "6. Louny" })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "3. Cheb" })).not.toBeInTheDocument();
+  });
+});

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/CalculatorSearch.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/CalculatorSearch.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { Field, Input, Label } from "@kalkulacka-one/design-system/client";
+import { SearchIcon } from "@kalkulacka-one/design-system/icons";
+
+import Link from "next/link";
+import { useId, useMemo, useState } from "react";
+
+import { normalizeForSearch } from "@/lib/text/normalize-for-search";
+
+export type SearchableCalculator = {
+  key: string;
+  districtName: string;
+  districtCode?: string;
+  /** Further calculators for the same district, e.g. its Inventura hlasování. */
+  variants?: { key: string; name: string }[];
+};
+
+/**
+ * The city picker: one row per district, narrowed by a typed filter.
+ *
+ * The filter is client-side over the whole list rather than a round trip —
+ * seventy-odd names are nothing to ship, and a municipal calculator is useless
+ * until you have found your own town, so the narrowing has to feel instant.
+ */
+export function CalculatorSearch({
+  calculators,
+  basePath,
+  placeholder,
+  label,
+  showCode = false,
+}: {
+  calculators: SearchableCalculator[];
+  basePath: string;
+  placeholder: string;
+  label: string;
+  showCode?: boolean;
+}) {
+  const [query, setQuery] = useState("");
+  const inputId = useId();
+
+  const matches = useMemo(() => {
+    const needle = normalizeForSearch(query.trim());
+    if (!needle) return calculators;
+    return calculators.filter((calculator) => normalizeForSearch(calculator.districtName).includes(needle) || calculator.districtCode?.startsWith(needle));
+  }, [calculators, query]);
+
+  return (
+    <div>
+      <Field>
+        <Label htmlFor={inputId} className="sr-only">
+          {label}
+        </Label>
+        <Input id={inputId} type="search" autoComplete="off" value={query} placeholder={placeholder} onChange={(event) => setQuery(event.target.value)}>
+          <SearchIcon className="w-4 h-4 text-slate-500" decorative />
+        </Input>
+      </Field>
+
+      <p aria-live="polite" className="mt-3 text-sm text-slate-500">
+        {matches.length === calculators.length ? `Celkem ${calculators.length}` : `Nalezeno ${matches.length} z ${calculators.length}`}
+      </p>
+
+      {matches.length === 0 ? (
+        <p className="mt-8 text-slate-500">
+          Pro „{query.trim()}“ jsme nic nenašli. Kalkulačku zatím připravujeme jen pro některá města —{" "}
+          <Link href="/zapojte-se" className="text-slate-700 underline underline-offset-2">
+            pomozte nám s tou pro vaše
+          </Link>
+          .
+        </p>
+      ) : (
+        <ul className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {matches.map((calculator) => (
+            <li key={calculator.key}>
+              <div className="h-full rounded-lg border-2 border-slate-200 bg-white p-4 flex flex-col gap-2">
+                <Link
+                  href={`${basePath}/${calculator.key}`}
+                  className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-lg hover:text-slate-900 underline-offset-4 hover:underline"
+                >
+                  {showCode && calculator.districtCode ? `${calculator.districtCode}. ${calculator.districtName}` : calculator.districtName}
+                </Link>
+                {calculator.variants && calculator.variants.length > 0 && (
+                  <ul className="flex flex-wrap gap-x-3 gap-y-1">
+                    {calculator.variants.map((variant) => (
+                      <li key={variant.key}>
+                        <Link href={`${basePath}/${variant.key}`} className="text-sm text-slate-500 hover:text-slate-700 underline underline-offset-2">
+                          {variant.name}
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/komunalni-2026/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/komunalni-2026/page.tsx
@@ -1,15 +1,16 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
-import { type GroupCalculator, loadCalculatorGroup } from "@/lib/api/calculator-group";
+import { type GroupCalculator, loadPublishedCalculatorGroup } from "@/lib/api/calculator-group";
 
 import { CalculatorSearch, type SearchableCalculator } from "../CalculatorSearch";
 
 const GROUP = "komunalni-2026";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { electionName } = await loadCalculatorGroup({ group: GROUP });
-  return { title: electionName };
+  const group = await loadPublishedCalculatorGroup({ group: GROUP });
+  return { title: group?.electionName };
 }
 
 /**
@@ -39,7 +40,10 @@ function citiesWithVariants(calculators: GroupCalculator[]): SearchableCalculato
 }
 
 export default async function Page() {
-  const group = await loadCalculatorGroup({ group: GROUP });
+  const group = await loadPublishedCalculatorGroup({ group: GROUP });
+  // Until the election's data is published there is no list to pick from, so
+  // the page is not there either.
+  if (!group) notFound();
   const cities = citiesWithVariants(group.calculators);
 
   return (

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/komunalni-2026/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/komunalni-2026/page.tsx
@@ -1,0 +1,83 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { type GroupCalculator, loadCalculatorGroup } from "@/lib/api/calculator-group";
+
+import { CalculatorSearch, type SearchableCalculator } from "../CalculatorSearch";
+
+const GROUP = "komunalni-2026";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { electionName } = await loadCalculatorGroup({ group: GROUP });
+  return { title: electionName };
+}
+
+/**
+ * One row per city, with the city's other calculators — its Inventura
+ * hlasování — hanging off that row rather than competing with it in the list.
+ */
+function citiesWithVariants(calculators: GroupCalculator[]): SearchableCalculator[] {
+  const cities = new Map<string, SearchableCalculator>();
+
+  for (const calculator of calculators.filter((calculator) => !calculator.variantKey)) {
+    cities.set(calculator.districtKey, { key: calculator.key, districtName: calculator.districtName, districtCode: calculator.districtCode, variants: [] });
+  }
+
+  for (const calculator of calculators.filter((calculator) => calculator.variantKey)) {
+    // A variant of a city the group does not otherwise cover still deserves a
+    // row of its own rather than being dropped for having no parent.
+    const city = cities.get(calculator.districtKey);
+    const name = calculator.variantKey === "inventura" ? "Inventura hlasování" : (calculator.variantKey ?? calculator.key);
+    if (city) {
+      city.variants?.push({ key: calculator.key, name });
+    } else {
+      cities.set(calculator.districtKey, { key: calculator.key, districtName: `${calculator.districtName} — ${name}`, districtCode: calculator.districtCode, variants: [] });
+    }
+  }
+
+  return [...cities.values()];
+}
+
+export default async function Page() {
+  const group = await loadCalculatorGroup({ group: GROUP });
+  const cities = citiesWithVariants(group.calculators);
+
+  return (
+    <div className="relative min-h-screen bg-slate-50 z-0">
+      {/* Background dashed lines */}
+      <div aria-hidden className="pointer-events-none absolute inset-0 z-0">
+        <div className="mx-auto h-full max-w-7xl px-6 sm:px-8">
+          <div className="relative h-full grid grid-cols-6 gap-x-6">
+            {Array.from({ length: 6 }, (_, i) => i).map((columnIndex) => (
+              <div key={`bg-grid-col-${columnIndex}`} className="relative">
+                <div className="absolute inset-y-0 left-0 border-l-2 border-dashed border-slate-200" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="relative z-10 mx-auto max-w-7xl px-6 sm:px-8 pt-12 md:pt-16 lg:pt-20 pb-12 md:pb-16">
+        <Link href="/" className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700">
+          <span aria-hidden>←</span> Zpět na hlavní stránku
+        </Link>
+
+        <h1 className="mt-4 font-display ko:font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">{group.electionName}</h1>
+        <p className="mt-4 max-w-prose text-slate-500">{group.selection?.description ?? "Komunální kalkulačka je pro každé město jiná — vyberte to své a porovnejte se s kandidujícími uskupeními."}</p>
+
+        <h2 className="mt-10 md:mt-12 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">{group.selection?.title ?? "Zvolte své město"}</h2>
+
+        <div className="mt-6">
+          <CalculatorSearch
+            calculators={cities}
+            basePath={`/volby/${GROUP}`}
+            label={group.selection?.title ?? "Zvolte své město"}
+            placeholder={group.selection?.searchPlaceholder ?? "Hledat město…"}
+            showCode={group.selection?.showCode ?? false}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/senatni-2026/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/senatni-2026/page.tsx
@@ -1,13 +1,14 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
-import { type GroupCalculator, loadCalculatorGroup } from "@/lib/api/calculator-group";
+import { type GroupCalculator, loadPublishedCalculatorGroup } from "@/lib/api/calculator-group";
 
 const GROUP = "senatni-2026";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const { electionName } = await loadCalculatorGroup({ group: GROUP });
-  return { title: electionName };
+  const group = await loadPublishedCalculatorGroup({ group: GROUP });
+  return { title: group?.electionName };
 }
 
 type Region = { key: string; name: string; calculators: GroupCalculator[] };
@@ -41,7 +42,10 @@ function roundLabel(calculators: GroupCalculator[]): string | undefined {
 }
 
 export default async function Page() {
-  const group = await loadCalculatorGroup({ group: GROUP });
+  const group = await loadPublishedCalculatorGroup({ group: GROUP });
+  // Until the election's data is published there is no list to pick from, so
+  // the page is not there either.
+  if (!group) notFound();
   const regions = byRegion(group.calculators);
   const sharedRound = roundLabel(group.calculators);
 

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/senatni-2026/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/senatni-2026/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { type GroupCalculator, loadCalculatorGroup } from "@/lib/api/calculator-group";
+
+const GROUP = "senatni-2026";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const { electionName } = await loadCalculatorGroup({ group: GROUP });
+  return { title: electionName };
+}
+
+type Region = { key: string; name: string; calculators: GroupCalculator[] };
+
+/**
+ * The constituencies under the region each one belongs to.
+ *
+ * A Senate constituency is named after a town, not a region, so "Louny" alone
+ * does not tell a voter whether it is theirs; the region above it does.
+ * Constituencies whose region the data does not give fall under one unnamed
+ * heading rather than disappearing.
+ */
+function byRegion(calculators: GroupCalculator[]): Region[] {
+  const regions = new Map<string, Region>();
+
+  for (const calculator of calculators) {
+    const key = calculator.region?.key ?? "";
+    const region = regions.get(key) ?? { key, name: calculator.region?.name ?? "Ostatní obvody", calculators: [] };
+    region.calculators.push(calculator);
+    regions.set(key, region);
+  }
+
+  return [...regions.values()].sort((a, b) => a.name.localeCompare(b.name, "cs"));
+}
+
+/** "1. kolo" — shown once where every constituency is in the same round, which is the usual case. */
+function roundLabel(calculators: GroupCalculator[]): string | undefined {
+  const rounds = new Set(calculators.map((calculator) => calculator.round));
+  const [round] = [...rounds];
+  return rounds.size === 1 && round !== undefined ? `${round}. kolo` : undefined;
+}
+
+export default async function Page() {
+  const group = await loadCalculatorGroup({ group: GROUP });
+  const regions = byRegion(group.calculators);
+  const sharedRound = roundLabel(group.calculators);
+
+  return (
+    <div className="relative min-h-screen bg-slate-50 z-0">
+      {/* Background dashed lines */}
+      <div aria-hidden className="pointer-events-none absolute inset-0 z-0">
+        <div className="mx-auto h-full max-w-7xl px-6 sm:px-8">
+          <div className="relative h-full grid grid-cols-6 gap-x-6">
+            {Array.from({ length: 6 }, (_, i) => i).map((columnIndex) => (
+              <div key={`bg-grid-col-${columnIndex}`} className="relative">
+                <div className="absolute inset-y-0 left-0 border-l-2 border-dashed border-slate-200" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="relative z-10 mx-auto max-w-7xl px-6 sm:px-8 pt-12 md:pt-16 lg:pt-20 pb-12 md:pb-16">
+        <Link href="/" className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700">
+          <span aria-hidden>←</span> Zpět na hlavní stránku
+        </Link>
+
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <h1 className="font-display ko:font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">{group.electionName}</h1>
+          {sharedRound && <span className="rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700">{sharedRound}</span>}
+        </div>
+        <p className="mt-4 max-w-prose text-slate-500">
+          {group.selection?.description ?? "Senát se obměňuje po třetinách — volí se jen ve třetině obvodů. Najděte ten svůj a porovnejte se s jeho kandidáty a kandidátkami."}
+        </p>
+
+        <h2 className="mt-10 md:mt-12 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">{group.selection?.title ?? "Zvolte svůj volební obvod"}</h2>
+        <p className="mt-2 text-sm text-slate-500">Celkem {group.calculators.length} obvodů</p>
+
+        <div className="mt-8 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 items-start">
+          {regions.map((region) => (
+            <section key={region.key || "bez-kraje"}>
+              <h3 className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-lg">{region.name}</h3>
+              <ul className="mt-3 grid gap-2">
+                {region.calculators.map((calculator) => (
+                  <li key={calculator.key}>
+                    <Link href={`/volby/${GROUP}/${calculator.key}`} className="flex items-baseline gap-2 rounded-lg border-2 border-slate-200 bg-white px-4 py-3 hover:border-slate-300">
+                      {(group.selection?.showCode ?? true) && calculator.districtCode && <span className="text-sm tabular-nums text-slate-500">{calculator.districtCode}.</span>}
+                      <span className="font-semibold text-slate-700">{calculator.districtName}</span>
+                      {!sharedRound && calculator.round !== undefined && <span className="ml-auto text-xs text-slate-500">{calculator.round}. kolo</span>}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/comparison.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/comparison.tsx
@@ -24,6 +24,7 @@ export function ComparisonPageWithRouting({ segments }: { segments: RouteSegment
   const { electionName, calculatorName } = calculatorNames({
     group: "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined,
     key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    shortTitle: calculator.shortTitle || undefined,
     fallback: calculator.title || undefined,
   });
 

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/guide.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/guide.tsx
@@ -23,6 +23,7 @@ export function GuidePageWithRouting({ segments }: { segments: RouteSegments }) 
   const { electionName, calculatorName } = calculatorNames({
     group: "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined,
     key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    shortTitle: calculator.shortTitle || undefined,
     fallback: calculator.title || undefined,
   });
 

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/introduction.tsx
@@ -29,6 +29,7 @@ export function IntroductionPageWithRouting({ segments }: { segments: RouteSegme
   const { electionName, calculatorName } = calculatorNames({
     group: "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined,
     key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    shortTitle: calculator.shortTitle || undefined,
     fallback: calculator.title || undefined,
   });
 

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/public-result.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/public-result.tsx
@@ -64,6 +64,7 @@ export function PublicResultPageWithData({ algorithmMatches, answers, segments }
   const { electionName, calculatorName } = calculatorNames({
     group: "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined,
     key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    shortTitle: calculator.shortTitle || undefined,
     fallback: calculator.title || undefined,
   });
 

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/question.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/question.tsx
@@ -52,6 +52,7 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
   const { electionName, calculatorName } = calculatorNames({
     group: "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined,
     key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    shortTitle: calculator.shortTitle || undefined,
     fallback: calculator.title || undefined,
   });
 

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/result.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/result.tsx
@@ -55,6 +55,7 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
   const { electionName, calculatorName } = calculatorNames({
     group: calculatorGroup,
     key: calculatorKey,
+    shortTitle: calculator.shortTitle || undefined,
     fallback: calculator.title || undefined,
   });
 

--- a/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/review.tsx
+++ b/apps/www.volebnikalkulacka.cz/components/client/pages/calculator/review.tsx
@@ -25,6 +25,7 @@ export function ReviewPageWithRouting({ segments }: { segments: RouteSegments })
   const { electionName, calculatorName } = calculatorNames({
     group: "calculatorGroup" in calculator ? calculator.calculatorGroup.key : undefined,
     key: ("variant" in calculator ? calculator.variant?.key : undefined) ?? calculator.key,
+    shortTitle: calculator.shortTitle || undefined,
     fallback: calculator.title || undefined,
   });
 

--- a/apps/www.volebnikalkulacka.cz/config/calculator-names.test.ts
+++ b/apps/www.volebnikalkulacka.cz/config/calculator-names.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { calculatorNames, electionName } from "./calculator-names";
+
+describe("calculatorNames", () => {
+  it("names a variant calculator from the config, which the data does not carry", () => {
+    expect(calculatorNames({ group: "snemovni-2025", key: "expresni" })).toEqual({
+      electionName: "Sněmovní volby 2025",
+      calculatorName: "Expresní kalkulačka",
+    });
+  });
+
+  it("names a district calculator from the data, next to the election name from the config", () => {
+    // The full title would repeat the election name above it.
+    expect(calculatorNames({ group: "komunalni-2026", key: "beroun", shortTitle: "Beroun", fallback: "Komunální volby 2026: Beroun" })).toEqual({
+      electionName: "Komunální volby 2026",
+      calculatorName: "Beroun",
+    });
+  });
+
+  it("keeps the configured name where the data also offers a short title", () => {
+    expect(calculatorNames({ group: "snemovni-2025", key: "kalkulacka", shortTitle: "Kalkulačka" }).calculatorName).toBe("Volební kalkulačka");
+  });
+
+  it("falls back to the full title, then to the key", () => {
+    expect(calculatorNames({ key: "nekde", fallback: "Kalkulačka odněkud" }).calculatorName).toBe("Kalkulačka odněkud");
+    expect(calculatorNames({ key: "nekde" }).calculatorName).toBe("nekde");
+    expect(calculatorNames({}).calculatorName).toBe("");
+  });
+
+  it("has no election name for a calculator outside a known group", () => {
+    expect(calculatorNames({ group: "krajske-2028", key: "brno" }).electionName).toBeUndefined();
+  });
+});
+
+describe("electionName", () => {
+  it("names the elections the site knows", () => {
+    expect(electionName("komunalni-2026")).toBe("Komunální volby 2026");
+    expect(electionName("senatni-2026")).toBe("Senátní volby 2026");
+    expect(electionName("krajske-2028")).toBeUndefined();
+  });
+});

--- a/apps/www.volebnikalkulacka.cz/config/calculator-names.ts
+++ b/apps/www.volebnikalkulacka.cz/config/calculator-names.ts
@@ -63,15 +63,20 @@ export function electionName(group: string): string | undefined {
 
 /**
  * The names for a calculator, from the config where it is listed and from the
- * data's own `title` / `shortTitle` (passed as `fallback`) — or, failing both,
- * the key itself — where it is not.
+ * data where it is not — or, failing both, the key itself.
+ *
+ * `shortTitle` is preferred over `fallback` (the data's full `title`) because
+ * the two are shown together with the election name: a district election's
+ * full title repeats it ("Komunální volby 2026: Beroun" under "Komunální volby
+ * 2026"), where its short title is the one thing the election name does not
+ * already say — the city or constituency.
  */
-export function calculatorNames({ group, key, fallback }: { group?: string; key?: string; fallback?: string }): CalculatorNames {
+export function calculatorNames({ group, key, shortTitle, fallback }: { group?: string; key?: string; shortTitle?: string; fallback?: string }): CalculatorNames {
   const election = group ? ELECTIONS[group] : undefined;
   const configured = key ? election?.calculators?.[key] : undefined;
 
   return {
     electionName: election?.name,
-    calculatorName: configured ?? fallback ?? key ?? "",
+    calculatorName: configured ?? shortTitle ?? fallback ?? key ?? "",
   };
 }

--- a/apps/www.volebnikalkulacka.cz/config/calculator-names.ts
+++ b/apps/www.volebnikalkulacka.cz/config/calculator-names.ts
@@ -19,7 +19,14 @@ export type CalculatorNames = {
 
 type ElectionNames = {
   name: string;
-  calculators: Record<string, string>;
+  /**
+   * Display names for the calculators of an election whose calculators are
+   * told apart by a variant (`snemovni-2025/expresni`). Elections whose
+   * calculators are told apart by a district (`komunalni-2026/beroun`) name
+   * them from the data instead — the district titles in `election.json` — so
+   * they list no calculators here.
+   */
+  calculators?: Record<string, string>;
 };
 
 /*
@@ -39,7 +46,20 @@ const ELECTIONS: Record<string, ElectionNames> = {
       kompas: "Volební kompas",
     },
   },
+  // District elections: one calculator per city / constituency, named from the
+  // data. Only the election's own name is configuration.
+  "komunalni-2026": {
+    name: "Komunální volby 2026",
+  },
+  "senatni-2026": {
+    name: "Senátní volby 2026",
+  },
 };
+
+/** The display name of an election, by its calculator group key. */
+export function electionName(group: string): string | undefined {
+  return ELECTIONS[group]?.name;
+}
 
 /**
  * The names for a calculator, from the config where it is listed and from the
@@ -48,7 +68,7 @@ const ELECTIONS: Record<string, ElectionNames> = {
  */
 export function calculatorNames({ group, key, fallback }: { group?: string; key?: string; fallback?: string }): CalculatorNames {
   const election = group ? ELECTIONS[group] : undefined;
-  const configured = key ? election?.calculators[key] : undefined;
+  const configured = key ? election?.calculators?.[key] : undefined;
 
   return {
     electionName: election?.name,

--- a/apps/www.volebnikalkulacka.cz/config/feature-flags.test.ts
+++ b/apps/www.volebnikalkulacka.cz/config/feature-flags.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { elections2026Live } from "./feature-flags";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("elections2026Live", () => {
+  it("is on only for an explicit `true`", () => {
+    vi.stubEnv("ELECTIONS_2026", "true");
+    expect(elections2026Live()).toBe(true);
+  });
+
+  it("is off when unset, so the teaser is what a fresh environment serves", () => {
+    vi.stubEnv("ELECTIONS_2026", undefined);
+    expect(elections2026Live()).toBe(false);
+  });
+
+  it("is off for anything else, rather than treating any value as truthy", () => {
+    vi.stubEnv("ELECTIONS_2026", "1");
+    expect(elections2026Live()).toBe(false);
+    vi.stubEnv("ELECTIONS_2026", "false");
+    expect(elections2026Live()).toBe(false);
+  });
+});

--- a/apps/www.volebnikalkulacka.cz/config/feature-flags.ts
+++ b/apps/www.volebnikalkulacka.cz/config/feature-flags.ts
@@ -1,0 +1,11 @@
+/**
+ * Flags for work that is finished but not yet the public face of the site.
+ *
+ * The 2026 calculators land long before the 2026 campaign starts, so the
+ * homepage has to be able to show either state: the "coming soon" teaser with
+ * its subscribe form, or the elections themselves. One env var switches
+ * between them, so turning the campaign on is a deploy, not a code change.
+ */
+export function elections2026Live(): boolean {
+  return process.env.ELECTIONS_2026 === "true";
+}

--- a/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.test.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment node
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { loadCalculatorGroup } from "./calculator-group";
+import { loadCalculatorGroup, loadPublishedCalculatorGroup } from "./calculator-group";
 
 const fetchMock = vi.fn();
 
@@ -115,5 +115,28 @@ describe("loadCalculatorGroup", () => {
     const listing = await loadCalculatorGroup({ group: "krajske-2028" });
 
     expect(listing.electionName).toBeUndefined();
+  });
+});
+
+describe("loadPublishedCalculatorGroup", () => {
+  it("returns the listing where the group is published", async () => {
+    serveGroupFiles({ "calculator-group.json": calculatorGroup, "election.json": election });
+
+    await expect(loadPublishedCalculatorGroup({ group: "senatni-2026" })).resolves.toMatchObject({ groupKey: "senatni-2026" });
+  });
+
+  it("returns nothing where the data endpoint does not serve the group, rather than throwing", async () => {
+    // What every endpoint but a local mirror does for the 2026 groups today,
+    // and what the real ones will do until the day they are published. These
+    // pages are prerendered, so a throw here fails the whole build.
+    serveGroupFiles({});
+
+    await expect(loadPublishedCalculatorGroup({ group: "komunalni-2026" })).resolves.toBeUndefined();
+  });
+
+  it("still throws where the group is served but broken, so a real fault is not swallowed", async () => {
+    serveGroupFiles({ "calculator-group.json": { key: "senatni-2026" }, "election.json": election });
+
+    await expect(loadPublishedCalculatorGroup({ group: "senatni-2026" })).rejects.toThrow();
   });
 });

--- a/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.test.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loadCalculatorGroup } from "./calculator-group";
+
+const fetchMock = vi.fn();
+
+const calculatorGroup = {
+  id: "55487ccc-5da8-5ba5-9901-283f5f58d051",
+  key: "senatni-2026",
+  createdAt: "2026-09-05T00:00:00+02:00",
+  title: "Volby do Senátu Parlamentu ČR 2026",
+  election: { id: "1e30f4af-56c7-5dd1-9e4f-548c9d85cef7", key: "senatni-2026" },
+  selection: { title: "Zvolte svůj volební obvod", searchPlaceholder: "Hledat obvod…", showCode: true },
+  calculators: [
+    { id: "b2813d6f-895a-5883-8412-2d64a67feb4f", key: "3-cheb", district: { key: "3-cheb" } },
+    { id: "226e80f0-989c-5f24-a53f-415da4238d3d", key: "6-louny", district: { key: "6-louny" } },
+    // A calculator whose district the election does not describe.
+    { id: "f42f87a6-1542-513a-8d2e-89dfd9a4d54a", key: "99-nikde", district: { key: "99-nikde" } },
+  ],
+};
+
+const election = {
+  id: "1e30f4af-56c7-5dd1-9e4f-548c9d85cef7",
+  key: "senatni-2026",
+  createdAt: "2026-09-05T00:00:00+02:00",
+  title: "Volby do Senátu Parlamentu ČR 2026",
+  shortTitle: "Senátní 2026",
+  calculatorGroup: { id: "55487ccc-5da8-5ba5-9901-283f5f58d051", key: "senatni-2026" },
+  districts: [
+    { key: "karlovarsky-kraj", kind: "region", title: "Karlovarský kraj" },
+    { key: "ustecky-kraj", kind: "region", title: "Ústecký kraj" },
+    { key: "3-cheb", kind: "electoral-district", code: "3", title: "Cheb", shortTitle: "Cheb", parent: "karlovarsky-kraj" },
+    { key: "6-louny", kind: "electoral-district", code: "6", title: "Louny", shortTitle: "Louny", parent: "ustecky-kraj" },
+  ],
+  rounds: [{ number: 1 }, { number: 2 }],
+};
+
+function serveGroupFiles(files: Record<string, unknown>) {
+  fetchMock.mockImplementation((url: string) => {
+    const body = Object.entries(files).find(([filename]) => String(url).endsWith(filename))?.[1];
+    if (!body) return Promise.resolve(new Response("", { status: 404 }));
+    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+  });
+}
+
+beforeEach(() => {
+  vi.stubEnv("DATA_ENDPOINT", "https://cdn.example/site");
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("loadCalculatorGroup", () => {
+  it("names each calculator from the election's districts, not from its key", async () => {
+    serveGroupFiles({ "calculator-group.json": calculatorGroup, "election.json": election });
+
+    const listing = await loadCalculatorGroup({ group: "senatni-2026" });
+
+    expect(listing.calculators).toEqual([
+      { key: "3-cheb", districtName: "Cheb", districtCode: "3", region: { key: "karlovarsky-kraj", name: "Karlovarský kraj" }, variantKey: undefined, round: 1 },
+      { key: "6-louny", districtName: "Louny", districtCode: "6", region: { key: "ustecky-kraj", name: "Ústecký kraj" }, variantKey: undefined, round: 1 },
+    ]);
+  });
+
+  it("drops a calculator whose district the election does not describe", async () => {
+    serveGroupFiles({ "calculator-group.json": calculatorGroup, "election.json": election });
+
+    const listing = await loadCalculatorGroup({ group: "senatni-2026" });
+
+    expect(listing.calculators.map((calculator) => calculator.key)).not.toContain("99-nikde");
+  });
+
+  it("takes the election name from the config and the picker copy from the data", async () => {
+    serveGroupFiles({ "calculator-group.json": calculatorGroup, "election.json": election });
+
+    const listing = await loadCalculatorGroup({ group: "senatni-2026" });
+
+    expect(listing.electionName).toBe("Senátní volby 2026");
+    expect(listing.selection?.title).toBe("Zvolte svůj volební obvod");
+    expect(listing.selection?.showCode).toBe(true);
+    expect(listing.rounds?.map((round) => round.number)).toEqual([1, 2]);
+  });
+
+  it("falls back to the election's first round where a calculator names no round of its own", async () => {
+    serveGroupFiles({ "calculator-group.json": calculatorGroup, "election.json": { ...election, rounds: [{ number: 2 }] } });
+
+    const listing = await loadCalculatorGroup({ group: "senatni-2026" });
+
+    expect(listing.calculators.map((calculator) => calculator.round)).toEqual([2, 2]);
+  });
+
+  it("carries the variant of a calculator that is a variant of its district's", async () => {
+    const municipal = {
+      ...calculatorGroup,
+      key: "komunalni-2026",
+      election: { id: "804f325a-2a52-512a-b5ec-3b9aab1d9ffc", key: "komunalni-2026" },
+      calculators: [{ id: "67a2b41b-dd66-5651-8aa1-4006908008a9", key: "cheb-inventura", variant: { key: "inventura" }, district: { key: "3-cheb" } }],
+    };
+    serveGroupFiles({ "calculator-group.json": municipal, "election.json": election });
+
+    const listing = await loadCalculatorGroup({ group: "komunalni-2026" });
+
+    expect(listing.calculators[0]?.variantKey).toBe("inventura");
+    expect(listing.calculators[0]?.districtName).toBe("Cheb");
+  });
+
+  it("has no election name for a group the config does not list", async () => {
+    serveGroupFiles({ "calculator-group.json": calculatorGroup, "election.json": election });
+
+    const listing = await loadCalculatorGroup({ group: "krajske-2028" });
+
+    expect(listing.electionName).toBeUndefined();
+  });
+});

--- a/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.test.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.test.ts
@@ -62,8 +62,8 @@ describe("loadCalculatorGroup", () => {
     const listing = await loadCalculatorGroup({ group: "senatni-2026" });
 
     expect(listing.calculators).toEqual([
-      { key: "3-cheb", districtName: "Cheb", districtCode: "3", region: { key: "karlovarsky-kraj", name: "Karlovarský kraj" }, variantKey: undefined, round: 1 },
-      { key: "6-louny", districtName: "Louny", districtCode: "6", region: { key: "ustecky-kraj", name: "Ústecký kraj" }, variantKey: undefined, round: 1 },
+      { key: "3-cheb", districtKey: "3-cheb", districtName: "Cheb", districtCode: "3", region: { key: "karlovarsky-kraj", name: "Karlovarský kraj" }, variantKey: undefined, round: 1 },
+      { key: "6-louny", districtKey: "6-louny", districtName: "Louny", districtCode: "6", region: { key: "ustecky-kraj", name: "Ústecký kraj" }, variantKey: undefined, round: 1 },
     ]);
   });
 

--- a/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.ts
@@ -1,0 +1,101 @@
+import { buildDataUrl, fetchFile, parseWithSchema } from "@kalkulacka-one/app";
+import { type CalculatorGroup, calculatorGroupSchema, type District, type Election, electionSchema, type Round } from "@kalkulacka-one/schema";
+
+import type { z } from "zod";
+
+import { electionName } from "@/config/calculator-names";
+
+/**
+ * One calculator of a district election, ready to be listed in a picker.
+ *
+ * The group's own `calculator-group.json` lists nothing but keys, so the names
+ * come from the districts in the election's `election.json`, joined on the
+ * district key. That join is the whole point of this loader: a city or
+ * constituency must never be named by a map in the app.
+ */
+export type GroupCalculator = {
+  /** The calculator's key — the last URL segment. */
+  key: string;
+  /** The district's name, e.g. "Beroun" or "Cheb". */
+  districtName: string;
+  /** The district's official code, e.g. a Senate constituency number. */
+  districtCode?: string;
+  /** The region the district sits in, where the data groups districts under one. */
+  region?: { key: string; name: string };
+  /** The variant key for a calculator that is a variant of its district's, e.g. `inventura`. */
+  variantKey?: string;
+  /** The round this calculator is for — its own, or the election's first where the data gives it no round of its own. */
+  round?: number;
+};
+
+export type CalculatorGroupListing = {
+  groupKey: string;
+  /** The election's display name, from the config. */
+  electionName?: string;
+  /** Picker copy the data may override. */
+  selection?: {
+    title?: string;
+    description?: string;
+    searchPlaceholder?: string;
+    showCode?: boolean;
+  };
+  /** Every round the election has, in the data's order. */
+  rounds?: Round[];
+  calculators: GroupCalculator[];
+};
+
+function dataEndpoint(): string {
+  if (!process.env.DATA_ENDPOINT) {
+    throw new Error("DATA_ENDPOINT environment variable is not set");
+  }
+  return process.env.DATA_ENDPOINT;
+}
+
+async function loadGroupFile<T>({ group, filename, schema }: { group: string; filename: string; schema: z.ZodSchema<T> }): Promise<T> {
+  const url = buildDataUrl({ endpoint: dataEndpoint(), key: group, resourcePath: filename });
+  return parseWithSchema({ data: await fetchFile({ url }), schema });
+}
+
+/**
+ * The calculators of a district election, named from the data.
+ *
+ * Districts a calculator group references but the election does not describe
+ * are dropped rather than shown under their bare key — a picker entry with no
+ * name is worse than one entry fewer.
+ */
+export async function loadCalculatorGroup({ group }: { group: string }): Promise<CalculatorGroupListing> {
+  const [calculatorGroup, election] = await Promise.all([
+    loadGroupFile<CalculatorGroup>({ group, filename: "calculator-group.json", schema: calculatorGroupSchema }),
+    loadGroupFile<Election>({ group, filename: "election.json", schema: electionSchema }),
+  ]);
+
+  const districts = new Map<string, District>((election.districts ?? []).map((district) => [district.key, district]));
+  const defaultRound = election.rounds?.[0]?.number;
+
+  const calculators = calculatorGroup.calculators.flatMap((calculator) => {
+    const districtKey = "district" in calculator ? calculator.district?.key : undefined;
+    const district = districtKey ? districts.get(districtKey) : undefined;
+    if (!district) return [];
+
+    const region = district.parent ? districts.get(district.parent) : undefined;
+
+    return [
+      {
+        key: calculator.key,
+        districtName: district.shortTitle ?? district.title,
+        districtCode: district.code,
+        region: region ? { key: region.key, name: region.title } : undefined,
+        variantKey: calculator.variant?.key,
+        round: ("round" in calculator ? calculator.round?.number : undefined) ?? defaultRound,
+      },
+    ];
+  });
+
+  return {
+    groupKey: group,
+    electionName: electionName(group),
+    selection: calculatorGroup.selection,
+    rounds: election.rounds,
+    calculators,
+  };
+}

--- a/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.ts
@@ -1,4 +1,4 @@
-import { buildDataUrl, fetchFile, parseWithSchema } from "@kalkulacka-one/app";
+import { buildDataUrl, fetchFile, NotFoundError, parseWithSchema } from "@kalkulacka-one/app";
 import { type CalculatorGroup, calculatorGroupSchema, type District, type Election, electionSchema, type Round } from "@kalkulacka-one/schema";
 
 import type { z } from "zod";
@@ -101,4 +101,23 @@ export async function loadCalculatorGroup({ group }: { group: string }): Promise
     rounds: election.rounds,
     calculators,
   };
+}
+
+/**
+ * The same listing, or nothing at all where the group is not published yet.
+ *
+ * A calculator group appears in the data only once its election is ready, and
+ * the page for one that is not there yet has to be a 404 rather than a crash:
+ * these pages are prerendered, so a group the data endpoint does not serve
+ * would otherwise fail the whole build — which is exactly what the 2026 groups
+ * do everywhere but a local mirror, and what the real ones will do until the
+ * day they are published.
+ */
+export async function loadPublishedCalculatorGroup({ group }: { group: string }): Promise<CalculatorGroupListing | undefined> {
+  try {
+    return await loadCalculatorGroup({ group });
+  } catch (error) {
+    if (error instanceof NotFoundError) return undefined;
+    throw error;
+  }
 }

--- a/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/api/calculator-group.ts
@@ -16,6 +16,8 @@ import { electionName } from "@/config/calculator-names";
 export type GroupCalculator = {
   /** The calculator's key — the last URL segment. */
   key: string;
+  /** The district's key, the one thing that ties a district's calculators together. */
+  districtKey: string;
   /** The district's name, e.g. "Beroun" or "Cheb". */
   districtName: string;
   /** The district's official code, e.g. a Senate constituency number. */
@@ -82,6 +84,7 @@ export async function loadCalculatorGroup({ group }: { group: string }): Promise
     return [
       {
         key: calculator.key,
+        districtKey: district.key,
         districtName: district.shortTitle ?? district.title,
         districtCode: district.code,
         region: region ? { key: region.key, name: region.title } : undefined,

--- a/apps/www.volebnikalkulacka.cz/lib/text/normalize-for-search.test.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/text/normalize-for-search.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeForSearch } from "./normalize-for-search";
+
+describe("normalizeForSearch", () => {
+  it("strips the diacritics people leave off when typing", () => {
+    expect(normalizeForSearch("Žďár nad Sázavou")).toBe("zdar nad sazavou");
+    expect(normalizeForSearch("Ústí nad Labem")).toBe("usti nad labem");
+    expect(normalizeForSearch("Plzeň-město")).toBe("plzen-mesto");
+  });
+
+  it("lowercases so the match is case-insensitive", () => {
+    expect(normalizeForSearch("BRNO")).toBe("brno");
+  });
+
+  it("leaves a string with nothing to normalise alone", () => {
+    expect(normalizeForSearch("kolin 42")).toBe("kolin 42");
+  });
+});

--- a/apps/www.volebnikalkulacka.cz/lib/text/normalize-for-search.ts
+++ b/apps/www.volebnikalkulacka.cz/lib/text/normalize-for-search.ts
@@ -1,0 +1,13 @@
+/**
+ * A string reduced to what a typed search should match.
+ *
+ * Czech city names are full of diacritics that people leave off when typing —
+ * "zdar" has to find "Žďár nad Sázavou" — so the comparison runs on the
+ * decomposed, mark-stripped, lowercased form of both sides.
+ */
+export function normalizeForSearch(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLocaleLowerCase("cs");
+}

--- a/apps/www.volebnikalkulacka.cz/tests/e2e/calculator-flow.spec.ts
+++ b/apps/www.volebnikalkulacka.cz/tests/e2e/calculator-flow.spec.ts
@@ -292,3 +292,80 @@ test.describe("Calculator System", () => {
     }
   });
 });
+
+// A municipal calculator is reached the other way round from a 2025 one: there
+// is no card per calculator, only a city picker, and the URL is only knowable
+// once a city has been picked out of it.
+const MUNICIPAL: CalculatorConfig & { selectionPath: string; city: string } = {
+  key: "komunalni-2026",
+  group: "beroun",
+  name: "Beroun",
+  path: "/volby/komunalni-2026/beroun",
+  expectedTitle: "Beroun",
+  selectionPath: "/volby/komunalni-2026",
+  city: "Beroun",
+};
+
+test.describe(`Calculator Flow: Komunální volby 2026 (${MUNICIPAL.name})`, () => {
+  // The 2026 data is not on every data endpoint this suite runs against, and a
+  // missing calculator group is not a regression in the app.
+  async function skipUnlessPublished(page: Page) {
+    await page.goto(MUNICIPAL.selectionPath);
+    await waitForPageLoad(page);
+    const picker = page.getByRole("searchbox");
+    test.skip((await picker.count()) === 0, `${MUNICIPAL.key} is not published on this data endpoint`);
+  }
+
+  test("should find a city in the picker and complete its flow", async ({ page }) => {
+    test.setTimeout(TIMEOUTS.EXTENDED);
+    await skipUnlessPublished(page);
+
+    await page.getByRole("searchbox").fill(MUNICIPAL.city);
+    await page.locator(`a[href="${MUNICIPAL.path}"]`).click();
+    await page.waitForURL(new RegExp(`.*${MUNICIPAL.path}/uvod`), { timeout: TIMEOUTS.STANDARD });
+    await waitForPageLoad(page);
+    await expect(page.locator("main")).toBeVisible();
+
+    // Driven by exact button names rather than the shared helpers above: those
+    // match on substrings, and "Smazat a začít znovu" inside the restart dialog
+    // is an earlier, invisible match for their "Začít".
+    await page.getByRole("button", { name: "Pokračovat", exact: true }).click();
+    await page.waitForURL(new RegExp(`.*${MUNICIPAL.path}/navod`), { timeout: TIMEOUTS.STANDARD });
+
+    await page.getByRole("button", { name: "Rozumím, začít", exact: true }).click();
+    await page.waitForURL(new RegExp(`.*${MUNICIPAL.path}/otazka/1`), { timeout: TIMEOUTS.STANDARD });
+
+    // `getByRole` skips the `aria-hidden` copies on the cards stacked behind
+    // the active question, so this is the answer the voter can actually press.
+    for (const question of [1, 2, 3]) {
+      await expect(page).toHaveURL(new RegExp(`.*${MUNICIPAL.path}/otazka/${question}`));
+      await page.getByRole("button", { name: "Ano", exact: true }).click();
+      await page.waitForURL(new RegExp(`.*${MUNICIPAL.path}/otazka/${question + 1}`), { timeout: TIMEOUTS.STANDARD });
+    }
+  });
+
+  test("should narrow the picker to what was typed", async ({ page }) => {
+    await skipUnlessPublished(page);
+
+    // A city that is in the data but is not the one being searched for.
+    await expect(page.locator('a[href="/volby/komunalni-2026/brno"]')).toBeVisible();
+
+    await page.getByRole("searchbox").fill(MUNICIPAL.city);
+
+    await expect(page.locator(`a[href="${MUNICIPAL.path}"]`)).toBeVisible();
+    await expect(page.locator('a[href="/volby/komunalni-2026/brno"]')).toHaveCount(0);
+  });
+
+  test("should show the election and the city on the introduction", async ({ page }) => {
+    await skipUnlessPublished(page);
+
+    await page.goto(`${MUNICIPAL.path}/uvod`);
+    await waitForPageLoad(page);
+
+    await expect(page.locator("h1").filter({ hasText: MUNICIPAL.city }).first()).toBeVisible({ timeout: TIMEOUTS.HEADING_VISIBILITY });
+    // The shell composes the election name around the city: "Komunální volby Beroun 2026".
+    const shellHeader = page.locator("header").first();
+    await expect(shellHeader).toContainText("Komunální volby");
+    await expect(shellHeader).toContainText(MUNICIPAL.city);
+  });
+});

--- a/turbo.json
+++ b/turbo.json
@@ -9,7 +9,7 @@
     "www.volebnikalkulacka.cz#build": {
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"],
-      "env": ["NEXT_PUBLIC_*", "DATA_ENDPOINT", "X_HANDLE", "ANALYTICS_DOMAIN", "ANALYTICS_PROXY", "ENABLE_ANALYTICS", "DATABASE_URL"]
+      "env": ["NEXT_PUBLIC_*", "DATA_ENDPOINT", "X_HANDLE", "ANALYTICS_DOMAIN", "ANALYTICS_PROXY", "ENABLE_ANALYTICS", "DATABASE_URL", "ELECTIONS_2026"]
     },
     "www.volebnakalkulacka.sk#build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
Builds the homepage entry point and the two calculator pickers for the 2026 municipal and Senate elections.

Stacked on #538 (`port/24-cleanup`). Followed by `port/26-inventura-people`.

## What's here

- **`/volby/komunalni-2026`** — every city, narrowed by a typed filter. The query is matched against names stripped of diacritics, because people type `zdar` for Žďár nad Sázavou. A city's *Inventura hlasování* hangs off that city's row rather than competing with it in the list.
- **`/volby/senatni-2026`** — constituencies grouped under their region, with the round from the data. A Senate constituency is named after a town, so "Louny" alone doesn't tell a voter whether it's theirs; the region above it does.
- **Homepage** — behind `ELECTIONS_2026`. Off: the existing teaser and subscribe form, unchanged. On: a card per election. The cards are their own component (`ElectionCards.tsx`) because the homepage is due a redesign and they're the part that has to survive it.
- **Introduction** — a district calculator is now named by its city, not its full title (see below).

## Names come from the data, not a map

73 cities would have been 73 hardcoded strings. `lib/api/calculator-group.ts` reads a group's `calculator-group.json` and `election.json` and joins them on the district key, so every city and constituency is named by `election.json`. The config keeps only what the data has no field for: the election's own display name.

It's deliberately **not** in the `@/lib/api` barrel — that barrel is imported by client components and this loader is server-only.

## One fix beyond the feature

The shell composes an election name *around* a calculator name — "Komunální volby" · "Beroun" · "2026". Handed its full title, a district calculator read "Komunální volby **Komunální volby 2026: Beroun** 2026". It now prefers the data's `shortTitle`, applied to all seven `calculatorNames` call sites so the header doesn't change mid-flow. The configured 2025 names still win, so that election is untouched.

## ⚠️ Reviewing this needs the test data, which is not deployed

The `komunalni-2026` and `senatni-2026` groups exist only on kalkulacka-one/data#75 (`test-data/2026-municipal-senate`), **which must never be merged**. It is reachable neither way you'd expect:

- `data.kalkulacka.one` serves only `main`/`staging` — the data repo's `sync.yaml` deploys on push to those branches alone.
- `raw.githubusercontent.com` 404s, because `kalkulacka-one/data` is private and `fetchFile` issues a plain unauthenticated `fetch`.

So mirror it and serve it yourself:

```bash
git clone --depth 1 --branch test-data/2026-municipal-senate --filter=blob:none --sparse \
  https://github.com/kalkulacka-one/data.git data-2026
cd data-2026 && git sparse-checkout set www.volebnikalkulacka.cz
python3 -m http.server 3030 --bind 127.0.0.1
```

then in `apps/www.volebnikalkulacka.cz/.env.development.local` (gitignored):

```
DATA_ENDPOINT=http://127.0.0.1:3030/www.volebnikalkulacka.cz
ELECTIONS_2026=true
```

The branch is cut from `main`, so `snemovni-2025` comes along and the existing pages keep working.

## Without that data, everything still holds

Both pages **404 rather than crash** when their group isn't served, and the homepage falls back to its teaser. This matters for CI: the pages are prerendered, so an unpublished group failed the whole build — the first push of this branch would have broken it. A group that is served but *malformed* still throws, so a real fault isn't swallowed into a 404. The new e2e case skips itself where the group isn't published.

## Checks

`npm run typecheck`, `npm run lint:fix`, `npm run test` and `npm run build` green from the repo root; 40/40 Playwright against a local mirror. New unit tests cover the loader, the search filter, the election cards, the flag and the name resolution; one e2e case walks a municipal calculator whole — picking Beroun out of 73 and answering its first questions.

It drives the flow by exact button names rather than the helpers already in that file: those match `"Začít"` as a substring and resolve it to the invisible "Smazat a začít znovu" in the restart dialog, so the flow they walk quietly stops at the guide. That looks like it silently weakens the seven 2025 cases too, but I left it alone rather than widen this PR.
