### PR TITLE
Rebuild the app package's stylesheet while developing

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "build": "npm run tailwind && tsc && tsc-alias",
+    "dev": "npm run tailwind -- --watch",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "ncu": "ncu",


### PR DESCRIPTION
Since #560 the app package generates its own `koa:`-prefixed utilities into `packages/app/dist/index.css`, and the apps no longer scan the package with an `@source` directive. Nothing regenerates that stylesheet during development: the `dev` task depends on a one-shot `@kalkulacka-one/app#build`, and `turbo watch` does not re-run it when package sources change.

The effect is that adding a `koa:` class to a package component leaves it unstyled until someone rebuilds the package by hand — a silent failure, since nothing errors.

This adds a `dev` script to the package that runs the Tailwind watcher, which `turbo watch dev` then keeps alive.

**Verified rather than assumed.** With the dev server running, I added a new `koa:` class to a package component:

- before this change — still absent from `packages/app/dist/index.css` 40 seconds later;
- after — present.

Scope: CSS only. Changes to the package's TypeScript still require a rebuild, exactly as before; that is a separate, pre-existing gap. `packages/design-system` has the same shape and could take the same one-line addition, but it is untouched here since nothing in this series changed how it is consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)