### PR TITLE
Require a resolved app config in the routing factories

### DIFF
--- a/packages/next/src/config-helpers.ts
+++ b/packages/next/src/config-helpers.ts
@@ -1,6 +1,6 @@
 import type { AppConfig } from "@/types/app-config";
 
-type AppConfigWithDefaults = AppConfig & {
+export type AppConfigWithDefaults = AppConfig & {
   i18n: AppConfig["i18n"] & {
     localePrefix: "always" | "as-needed" | "never";
   };

--- a/packages/next/src/routing/create-rewrites.ts
+++ b/packages/next/src/routing/create-rewrites.ts
@@ -1,14 +1,14 @@
+import type { AppConfigWithDefaults } from "@/config-helpers";
 import type { PageType } from "@/routing/localized-slugs";
-import type { AppConfig } from "@/types/app-config";
 
 export type RewritesConfig = {
-  i18n: AppConfig["i18n"];
+  i18n: AppConfigWithDefaults["i18n"];
   pageSlugs: Record<string, Record<PageType, string>>;
   prefixSlugs: Record<string, Record<string, string>>;
 };
 
 export function createRewrites({ i18n, pageSlugs, prefixSlugs }: RewritesConfig) {
-  const { locales, defaultLocale, localePrefix = "as-needed" } = i18n;
+  const { locales, defaultLocale, localePrefix } = i18n;
 
   function validateLocale(locale: string): void {
     if (!locales.includes(locale)) {

--- a/packages/next/src/routing/create-routing.ts
+++ b/packages/next/src/routing/create-routing.ts
@@ -1,9 +1,9 @@
+import type { AppConfigWithDefaults } from "@/config-helpers";
 import { createCanonical, createParamsMapper, createPrefixes, createRouteBuilders, createRouteParsers } from "@/routing/factories";
 import type { PageType } from "@/routing/localized-slugs";
-import type { AppConfig } from "@/types/app-config";
 
 export type RoutingConfig = {
-  i18n: AppConfig["i18n"];
+  i18n: AppConfigWithDefaults["i18n"];
   pageSlugs: Record<string, Record<PageType, string>>;
   prefixSlugs: Record<string, Record<string, string>>;
 };

--- a/packages/next/src/routing/factories/prefixes.ts
+++ b/packages/next/src/routing/factories/prefixes.ts
@@ -1,6 +1,6 @@
-import type { AppConfig } from "@/types/app-config";
+import type { AppConfigWithDefaults } from "@/config-helpers";
 
-export function createPrefixes({ i18n, prefixSlugs }: { i18n: AppConfig["i18n"]; prefixSlugs: Record<string, Record<string, string>> }): string[] {
+export function createPrefixes({ i18n, prefixSlugs }: { i18n: AppConfigWithDefaults["i18n"]; prefixSlugs: Record<string, Record<string, string>> }): string[] {
   const { locales, defaultLocale } = i18n;
 
   if (!locales.includes(defaultLocale)) {

--- a/packages/next/src/routing/factories/route-builders.ts
+++ b/packages/next/src/routing/factories/route-builders.ts
@@ -1,9 +1,9 @@
+import type { AppConfigWithDefaults } from "@/config-helpers";
 import type { PageType } from "@/routing/localized-slugs";
 import { createBaseSegment, type RouteSegments } from "@/routing/segments";
-import type { AppConfig } from "@/types/app-config";
 
-export function createRouteBuilders({ i18n, pageSlugs }: { i18n: AppConfig["i18n"]; pageSlugs: Record<string, Record<PageType, string>> }) {
-  const { locales, defaultLocale, localePrefix = "as-needed" } = i18n;
+export function createRouteBuilders({ i18n, pageSlugs }: { i18n: AppConfigWithDefaults["i18n"]; pageSlugs: Record<string, Record<PageType, string>> }) {
+  const { locales, defaultLocale, localePrefix } = i18n;
 
   function validateLocale(locale: string): void {
     if (!locales.includes(locale)) {


### PR DESCRIPTION
`withDefaults()` fills in `localePrefix` when an app's config omits it. The routing and rewrite factories extracted in #546 and #547 then defaulted it a second time:

```ts
const { locales, defaultLocale, localePrefix = "as-needed" } = i18n;
```

Two sources for one default — change it in `withDefaults` and the factories quietly keep the old one.

The factories now accept `AppConfigWithDefaults["i18n"]` (the type `withDefaults` returns, exported for the purpose) rather than the raw `AppConfig["i18n"]`, so `localePrefix` is required and the duplicated fallback is gone. Every app already passes `appConfig`, which is the resolved value, so nothing changes at any call site.

The guarantee is now enforced rather than assumed — passing an unresolved config no longer compiles:

```
Type '{ defaultLocale: string; locales: readonly ["cs"] }' is not assignable to type
'… & { localePrefix: "always" | "as-needed" | "never" }'
```

No behavior change: `withDefaults` already supplied `"as-needed"`, which is what the factories were re-deriving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)