### PR TITLE
Stop shipping a global element reset from the design system

### DIFF
--- a/apps/www.izborenkalkulator.mk/app/globals.css
+++ b/apps/www.izborenkalkulator.mk/app/globals.css
@@ -9,6 +9,6 @@
 
 @theme static {
   --font-display: var(--ko-font-display);
-  --font-sans: var(--ko-typeface-sans);
-  --font-mono: var(--ko-typeface-mono);
+  --font-sans: var(--ko-font-sans);
+  --font-mono: var(--ko-font-mono);
 }

--- a/apps/www.kalkulacka.one/app/globals.css
+++ b/apps/www.kalkulacka.one/app/globals.css
@@ -5,8 +5,8 @@
 
 @theme static {
   --font-display: var(--ko-font-display);
-  --font-sans: var(--ko-typeface-sans);
-  --font-mono: var(--ko-typeface-mono);
+  --font-sans: var(--ko-font-sans);
+  --font-mono: var(--ko-font-mono);
 
   --ko-drop-shadow-hard-light: var(--color-slate-100);
 }

--- a/apps/www.volebnakalkulacka.sk/app/globals.css
+++ b/apps/www.volebnakalkulacka.sk/app/globals.css
@@ -9,6 +9,6 @@
 
 @theme static {
   --font-display: var(--ko-font-display);
-  --font-sans: var(--ko-typeface-sans);
-  --font-mono: var(--ko-typeface-mono);
+  --font-sans: var(--ko-font-sans);
+  --font-mono: var(--ko-font-mono);
 }

--- a/apps/www.volebnikalkulacka.cz/app/globals.css
+++ b/apps/www.volebnikalkulacka.cz/app/globals.css
@@ -9,6 +9,6 @@
 
 @theme static {
   --font-display: var(--ko-font-display);
-  --font-sans: var(--ko-typeface-sans);
-  --font-mono: var(--ko-typeface-mono);
+  --font-sans: var(--ko-font-sans);
+  --font-mono: var(--ko-font-mono);
 }

--- a/packages/design-system/src/styles.css
+++ b/packages/design-system/src/styles.css
@@ -1,4 +1,7 @@
-@import 'tailwindcss' prefix(ko);
+@layer theme, base, components, utilities;
+
+@import 'tailwindcss/theme' layer(theme) prefix(ko);
+@import 'tailwindcss/utilities' layer(utilities) prefix(ko);
 
 @source not "**/*.test.{ts,tsx}";
 


### PR DESCRIPTION
`@import 'tailwindcss' prefix(ko)` pulls in preflight, and the prefix cannot cover it — preflight targets bare elements. So `@kalkulacka-one/design-system/styles` shipped this:

```css
*, ::after, ::before, ::backdrop, ::file-selector-button {
  box-sizing: border-box; margin: 0; padding: 0; border: 0 solid;
}
html, :host { line-height: 1.5; font-family: …; tab-size: 4; -webkit-tap-highlight-color: transparent; }
```

Any page importing the stylesheet gets every margin, padding and border on it zeroed. That is harmless for our own apps — they own their document and `@import "tailwindcss"` themselves — but `packages/app` and the design system are meant to be usable from someone else's React app (`docs/architecture.md:47`), and a page-wide reset is not ours to ship. The package now imports theme and utilities only, the same shape `packages/app` has had since #566.

## The part worth reviewing

Removing preflight is **not** a no-op, and I nearly shipped it as one.

The design system's preflight loaded *after* each app's own (import order in `globals.css`), so it was what set `html { font-family }` site-wide — from `--ko-default-font-family`, which carries the full fallback stack. Meanwhile each app's `@theme` reached past the design system's `--ko-font-sans` / `--ko-font-mono` to the raw `--ko-typeface-*`, which has no fallbacks:

```css
--font-display: var(--ko-font-display);    /* full stack */
--font-sans: var(--ko-typeface-sans);      /* bare font name */
--font-mono: var(--ko-typeface-mono);      /* bare font name */
```

So dropping preflight left every page on bare `Geist` with nothing behind it — no `ui-sans-serif`, no `system-ui`, no emoji fonts. The apps now use `--ko-font-sans` and `--ko-font-mono`, matching the `--font-display` line already sitting next to them. No duplicated stacks; the design system stays the single source.

## Verification

Computed styles from a production build (`next start`), 10 pages × 2 viewports × 36 properties, 3,642 elements, against the same build from `main`:

| | elements changed |
|---|---|
| removing preflight alone | **3,510** — `fontFamily` on all of them, plus 107 `width` changes on `/metodika` as a knock-on |
| with the font-token fix | **0** |

The `/metodika` widths are incidental but telling: that page's `ko:` classes generate no CSS at all, so its boxes are sized purely by text metrics and moved when the font stack did. That is a separate, known bug — 47 `ko:` classes written in app source are never generated — not addressed here.

Also takes 4 KB off the design system's stylesheet (40,833 → 36,689 B).

`npm run typecheck`, `npm run lint`, `npm run test` and `turbo build --force` (12 tasks) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
