### PR TITLE
Write app markup in the app's own namespace, not the design system's

### DIFF
--- a/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(content)/BeadRow.tsx
+++ b/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(content)/BeadRow.tsx
@@ -30,10 +30,10 @@ export function BeadRow({ anchorId = "other-calcs-heading" }: { anchorId?: strin
     <div ref={rootRef} className="absolute left-0 right-0" style={{ top }}>
       <div className="grid grid-cols-6 gap-x-6">
         <div className="relative col-start-4">
-          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 ko:text-primary" />
+          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-primary)]" />
         </div>
         <div className="relative col-start-5">
-          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 ko:text-secondary" />
+          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-secondary)]" />
         </div>
         <div className="relative col-start-6">
           <BeadTickSlate className="absolute left-0 -translate-x-1/2 h-8 w-8 text-slate-700" />

--- a/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(content)/BeadRow.tsx
+++ b/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(content)/BeadRow.tsx
@@ -30,10 +30,10 @@ export function BeadRow({ anchorId = "other-calcs-heading" }: { anchorId?: strin
     <div ref={rootRef} className="absolute left-0 right-0" style={{ top }}>
       <div className="grid grid-cols-6 gap-x-6">
         <div className="relative col-start-4">
-          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-primary)]" />
+          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 text-primary" />
         </div>
         <div className="relative col-start-5">
-          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-secondary)]" />
+          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 text-secondary" />
         </div>
         <div className="relative col-start-6">
           <BeadTickSlate className="absolute left-0 -translate-x-1/2 h-8 w-8 text-slate-700" />

--- a/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(content)/page.tsx
+++ b/apps/www.izborenkalkulator.mk/app/[locale]/(web)/(content)/page.tsx
@@ -31,7 +31,7 @@ export default function Page() {
                 <span className="inline-flex items-center gap-1 rounded-full bg-primary-50 px-2.5 py-1 font-semibold text-primary-700">Изборен компас</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">10 минути</span>
               </div>
-              <h2 className="mt-4 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Кој ги споделува вашите вредности?</h2>
+              <h2 className="mt-4 font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Кој ги споделува вашите вредности?</h2>
               <p className="mt-2 text-slate-500">Откријте кои партии застапуваат слични вредности како вас.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <Link href="/kompas-2025" className="grid">

--- a/apps/www.izborenkalkulator.mk/app/globals.css
+++ b/apps/www.izborenkalkulator.mk/app/globals.css
@@ -1,14 +1,9 @@
 @import "tailwindcss";
+@import "@kalkulacka-one/design-system/tokens.css";
 
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
 :root {
   color-scheme: light;
-}
-
-@theme static {
-  --font-display: var(--ko-font-display);
-  --font-sans: var(--ko-font-sans);
-  --font-mono: var(--ko-font-mono);
 }

--- a/apps/www.kalkulacka.one/app/globals.css
+++ b/apps/www.kalkulacka.one/app/globals.css
@@ -1,12 +1,9 @@
 @import "tailwindcss";
+@import "@kalkulacka-one/design-system/tokens.css";
 
 @import "@kalkulacka-one/design-system/themes/www.kalkulacka.one/default.css";
 @import "@kalkulacka-one/design-system/styles";
 
 @theme static {
-  --font-display: var(--ko-font-display);
-  --font-sans: var(--ko-font-sans);
-  --font-mono: var(--ko-font-mono);
-
   --ko-drop-shadow-hard-light: var(--color-slate-100);
 }

--- a/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/(pages)/metodika/page.tsx
+++ b/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/(pages)/metodika/page.tsx
@@ -8,276 +8,274 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <div className="ko:max-w-4xl ko:mx-auto ko:p-6">
-      <h1 className="ko:text-3xl ko:font-bold ko:mb-8">Metodika výberu a tvorby otázok</h1>
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="text-3xl font-bold mb-8">Metodika výberu a tvorby otázok</h1>
 
-      <div className="ko:space-y-8">
+      <div className="space-y-8">
         {/* Introduction */}
-        <div className="ko:bg-gray-50 ko:p-6 ko:rounded-lg">
-          <div className="ko:flex ko:items-center ko:gap-3 ko:mb-4">
-            <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center">
-              <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+        <div className="bg-gray-50 p-6 rounded-lg">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center">
+              <span className="text-white text-sm font-bold">✕</span>
             </div>
-            <h2 className="ko:text-xl ko:font-semibold ko:text-red-700">Nevyhovujúci príklad</h2>
+            <h2 className="text-xl font-semibold text-red-700">Nevyhovujúci príklad</h2>
           </div>
-          <div className="ko:flex ko:items-center ko:gap-3">
-            <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center">
-              <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+          <div className="flex items-center gap-3">
+            <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
+              <span className="text-white text-sm font-bold">✓</span>
             </div>
-            <h2 className="ko:text-xl ko:font-semibold ko:text-green-700">Vyhovujúci príklad</h2>
+            <h2 className="text-xl font-semibold text-green-700">Vyhovujúci príklad</h2>
           </div>
         </div>
 
         {/* Rule 1 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">1. Otázka sa musí týkať toho, čo majú zvolení politici šancu ovplyvniť.</h2>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">1. Otázka sa musí týkať toho, čo majú zvolení politici šancu ovplyvniť.</h2>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">ČR by mala vystúpiť z EÚ. (otázka v krajských voľbách)</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Krajskí politici nemôžu ovplyvniť vystúpenie z EÚ</p>
+                <p className="font-medium text-red-800">ČR by mala vystúpiť z EÚ. (otázka v krajských voľbách)</p>
+                <p className="text-sm text-red-600 mt-1">Krajskí politici nemôžu ovplyvniť vystúpenie z EÚ</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">ČR by mala vystúpiť z EÚ. (otázka v celoštátnych voľbách)</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Celoštátni politici môžu ovplyvniť vystúpenie z EÚ</p>
+                <p className="font-medium text-green-800">ČR by mala vystúpiť z EÚ. (otázka v celoštátnych voľbách)</p>
+                <p className="text-sm text-green-600 mt-1">Celoštátni politici môžu ovplyvniť vystúpenie z EÚ</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Chcel/a by som, aby sa v nasledujúcich voľbách Praha vrátila k systému jediného volebného obvodu. (otázka v pražských voľbách)</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Pražskí politici môžu ovplyvniť volebný systém v Prahe</p>
+                <p className="font-medium text-green-800">Chcel/a by som, aby sa v nasledujúcich voľbách Praha vrátila k systému jediného volebného obvodu. (otázka v pražských voľbách)</p>
+                <p className="text-sm text-green-600 mt-1">Pražskí politici môžu ovplyvniť volebný systém v Prahe</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 2 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">2. Na otázku musí ísť odpovedať áno aj nie a nemala by navádzať k odpovedi.</h2>
-          <p className="ko:text-gray-700 ko:mb-4">
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">2. Na otázku musí ísť odpovedať áno aj nie a nemala by navádzať k odpovedi.</h2>
+          <p className="text-gray-700 mb-4">
             Pri tvorbe si musíme vedieť predstaviť ľudí, ktorí si vyberajú obe varianty odpovede, áno aj nie. Z otázky by tiež nemalo byť poznať, ako na ňu odpovedá samotný autor otázky.
           </p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Mala by sa zlepšiť dopravná situácia v mestských častiach Považský Chlmec a Vranie?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Otázka je príliš všeobecná a nekonkrétna</p>
+                <p className="font-medium text-red-800">Mala by sa zlepšiť dopravná situácia v mestských častiach Považský Chlmec a Vranie?</p>
+                <p className="text-sm text-red-600 mt-1">Otázka je príliš všeobecná a nekonkrétna</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">
-                  Chcel/a by som, aby Opencard nebola pre cestujúcich cenovo výhodnejšia oproti „papierovej električenke", aby si cestujúci mohli vybrať.
-                </p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">„aby si mohli vybrať“ navádza k odpovedi</p>
+                <p className="font-medium text-red-800">Chcel/a by som, aby Opencard nebola pre cestujúcich cenovo výhodnejšia oproti „papierovej električenke", aby si cestujúci mohli vybrať.</p>
+                <p className="text-sm text-red-600 mt-1">„aby si mohli vybrať“ navádza k odpovedi</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Mala by sa vybudovať oddychová zóna pri Rajčianke?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Konkrétna otázka s jasným cieľom (iba za predpokladu, že „každý“ vie, o čo ide)</p>
+                <p className="font-medium text-green-800">Mala by sa vybudovať oddychová zóna pri Rajčianke?</p>
+                <p className="text-sm text-green-600 mt-1">Konkrétna otázka s jasným cieľom (iba za predpokladu, že „každý“ vie, o čo ide)</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Malo by sa aspoň 1 % z rozpočtu mesta určeného na dopravu vyčleniť na cyklistickú dopravu?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Konkrétna, merateľná otázka s jasným cieľom</p>
+                <p className="font-medium text-green-800">Malo by sa aspoň 1 % z rozpočtu mesta určeného na dopravu vyčleniť na cyklistickú dopravu?</p>
+                <p className="text-sm text-green-600 mt-1">Konkrétna, merateľná otázka s jasným cieľom</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 3 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">3. Otázky majú byť dôležité</h2>
-          <p className="ko:text-gray-700 ko:mb-4">
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">3. Otázky majú byť dôležité</h2>
+          <p className="text-gray-700 mb-4">
             Berieme napr. do úvahy, na čo dáva dané zastupiteľstvo/parlament najviac verejných peňazí. Témy vyberáme tak, aby boli relevantné pre všetky skupiny voličov (vekové, príjmové, záujmové).
           </p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Malo sa mesto ospravedlniť p. Lorenzovej a p. Cejthamrovi za výroky, ktoré pri tejto konfrontácii odzneli?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Príliš špecifická situácia, ktorá nie je dôležitá pre väčšinu voličov</p>
+                <p className="font-medium text-red-800">Malo sa mesto ospravedlniť p. Lorenzovej a p. Cejthamrovi za výroky, ktoré pri tejto konfrontácii odzneli?</p>
+                <p className="text-sm text-red-600 mt-1">Príliš špecifická situácia, ktorá nie je dôležitá pre väčšinu voličov</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Hlasovali by ste za zrušenie garancie a automatický vstup do druhého piliera?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Dôležitá téma pre všetkých občanov</p>
+                <p className="font-medium text-green-800">Hlasovali by ste za zrušenie garancie a automatický vstup do druhého piliera?</p>
+                <p className="text-sm text-green-600 mt-1">Dôležitá téma pre všetkých občanov</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Hlasovali by ste za dôveru vláde a permanentný euroval?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Dôležitá téma s dopadom na všetkých občanov</p>
+                <p className="font-medium text-green-800">Hlasovali by ste za dôveru vláde a permanentný euroval?</p>
+                <p className="text-sm text-green-600 mt-1">Dôležitá téma s dopadom na všetkých občanov</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 4 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">4. Otázka má byť čo najkonkrétnejšia</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Ide nám o to, aby sa dala odpoveď skontrolovať po 4 rokoch / na konci volebného obdobia.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">4. Otázka má byť čo najkonkrétnejšia</h2>
+          <p className="text-gray-700 mb-4">Ide nám o to, aby sa dala odpoveď skontrolovať po 4 rokoch / na konci volebného obdobia.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Mala by sa zahusťovať výstavba v centre mesta?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Príliš všeobecná otázka, nedá sa overiť splnenie</p>
+                <p className="font-medium text-red-800">Mala by sa zahusťovať výstavba v centre mesta?</p>
+                <p className="text-sm text-red-600 mt-1">Príliš všeobecná otázka, nedá sa overiť splnenie</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Podľa môjho názoru by z letiska Ruzyně do centra Prahy mala viesť rýchlodráha.</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Správne by bolo: „Budem presadzovať / chcem, aby sa rýchlodráha z letiska do centra Prahy začala budovať v nasledujúcich 4 rokoch“</p>
+                <p className="font-medium text-red-800">Podľa môjho názoru by z letiska Ruzyně do centra Prahy mala viesť rýchlodráha.</p>
+                <p className="text-sm text-red-600 mt-1">Správne by bolo: „Budem presadzovať / chcem, aby sa rýchlodráha z letiska do centra Prahy začala budovať v nasledujúcich 4 rokoch“</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Mali by sa dotácie pre MHD zvýšiť minimálne o 10 % oproti roku 2010?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Konkrétna, merateľná otázka s jasným cieľom</p>
+                <p className="font-medium text-green-800">Mali by sa dotácie pre MHD zvýšiť minimálne o 10 % oproti roku 2010?</p>
+                <p className="text-sm text-green-600 mt-1">Konkrétna, merateľná otázka s jasným cieľom</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 5 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">5. Otázka musí byť krátka a zrozumiteľná</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Chceme, aby opýtaný/á otázky naozaj prečítal/a a porozumel/a im. Formulujeme ich preto na max. 20 slov, prípadný popis obmedzujeme na 50 slov.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">5. Otázka musí byť krátka a zrozumiteľná</h2>
+          <p className="text-gray-700 mb-4">Chceme, aby opýtaný/á otázky naozaj prečítal/a a porozumel/a im. Formulujeme ich preto na max. 20 slov, prípadný popis obmedzujeme na 50 slov.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">
+                <p className="font-medium text-red-800">
                   Hlasovali by ste za: zrušenie sociálneho príplatku pre sólo rodičov, zníženie dávky – pôrodného len pre nízkopríjmových rodičov, jednotnú celkovú vyplatenú sumu rodičovského
                   príspevku (220 000) a väčšiu flexibilitu pri voľbe výšky a dĺžky RP, zníženie príspevku na starostlivosť, zníženie podpory v nezamestnanosti a zrušenie možnosti minimálneho
                   privyrobenia popri podpore, zavedenie príspevku pre začínajúcich podnikateľov/ky, sprísnenie podmienok nároku na nemocenské a materskú u SZČO?
                 </p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Príliš dlhá otázka s mnohými časťami</p>
+                <p className="text-sm text-red-600 mt-1">Príliš dlhá otázka s mnohými časťami</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Súhlasím so zavedením turniketov do metra.</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Krátka, jasná otázka</p>
+                <p className="font-medium text-green-800">Súhlasím so zavedením turniketov do metra.</p>
+                <p className="text-sm text-green-600 mt-1">Krátka, jasná otázka</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 6 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">6. Otázky s popisom musia dávať zmysel aj bez neho</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Veľký počet ľudí totiž číta iba otázku samotnú, nie jej popis. Môže sa tiež stať, že sa popis na mobilnom zariadení nezobrazí.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">6. Otázky s popisom musia dávať zmysel aj bez neho</h2>
+          <p className="text-gray-700 mb-4">Veľký počet ľudí totiž číta iba otázku samotnú, nie jej popis. Môže sa tiež stať, že sa popis na mobilnom zariadení nezobrazí.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Hlasovali by ste za zrušenie garancie a automatický vstup do druhého piliera?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Bez popisu nie je jasné, o čo ide</p>
+                <p className="font-medium text-red-800">Hlasovali by ste za zrušenie garancie a automatický vstup do druhého piliera?</p>
+                <p className="text-sm text-red-600 mt-1">Bez popisu nie je jasné, o čo ide</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Má podľa vás zmysel pripájať sa k podobným projektom?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Bez kontextu nie je jasné, o aké projekty ide</p>
+                <p className="font-medium text-red-800">Má podľa vás zmysel pripájať sa k podobným projektom?</p>
+                <p className="text-sm text-red-600 mt-1">Bez kontextu nie je jasné, o aké projekty ide</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Súhlasím so spoplatnením vjazdu áut do centra mesta, napríklad formou mýta.</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Jasná otázka aj bez popisu</p>
+                <p className="font-medium text-green-800">Súhlasím so spoplatnením vjazdu áut do centra mesta, napríklad formou mýta.</p>
+                <p className="text-sm text-green-600 mt-1">Jasná otázka aj bez popisu</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 7 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">7. Uprednostňujeme otázky v pozitívnom tvare, vyhýbame sa mätúcej dvojitej negácii.</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Z príkladu nižšie je vidieť, že dvojitá negácia je zavádzajúca a nepresná.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">7. Uprednostňujeme otázky v pozitívnom tvare, vyhýbame sa mätúcej dvojitej negácii.</h2>
+          <p className="text-gray-700 mb-4">Z príkladu nižšie je vidieť, že dvojitá negácia je zavádzajúca a nepresná.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Na Vysočine by úložisko jadrového odpadu nemalo vzniknúť za žiadnu cenu.</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">
+                <p className="font-medium text-red-800">Na Vysočine by úložisko jadrového odpadu nemalo vzniknúť za žiadnu cenu.</p>
+                <p className="text-sm text-red-600 mt-1">
                   Tu totiž nie je jasné, s čím opýtaný/á nesúhlasí:
                   <br />
                   a) nie, nemalo by vzniknúť,
@@ -290,68 +288,68 @@ export default function Page() {
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Stredné školy by sa mali naďalej zlučovať do väčších celkov.</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Nie „Stredné školy by sa už naďalej nemali zlučovať do väčších celkov“.</p>
+                <p className="font-medium text-green-800">Stredné školy by sa mali naďalej zlučovať do väčších celkov.</p>
+                <p className="text-sm text-green-600 mt-1">Nie „Stredné školy by sa už naďalej nemali zlučovať do väčších celkov“.</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 8 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">8. Otázka musí byť napísaná ľahko pochopiteľným jazykom</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Otázky píšeme tak, aby im a téme porozumeli rôzne spoločenské skupiny.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">8. Otázka musí byť napísaná ľahko pochopiteľným jazykom</h2>
+          <p className="text-gray-700 mb-4">Otázky píšeme tak, aby im a téme porozumeli rôzne spoločenské skupiny.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Nový územný plán musí regulovať výškovú výstavbu, ktorá môže poškodiť panorámu Prahy.</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Príliš odborný jazyk, zložitá formulácia</p>
+                <p className="font-medium text-red-800">Nový územný plán musí regulovať výškovú výstavbu, ktorá môže poškodiť panorámu Prahy.</p>
+                <p className="text-sm text-red-600 mt-1">Príliš odborný jazyk, zložitá formulácia</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Výstavba mrakodrapov v historickom centre má byť zakázaná.</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Jasný, zrozumiteľný jazyk</p>
+                <p className="font-medium text-green-800">Výstavba mrakodrapov v historickom centre má byť zakázaná.</p>
+                <p className="text-sm text-green-600 mt-1">Jasný, zrozumiteľný jazyk</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 9 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">9. Vyberáme aj otázky, ktoré sú zaujímavé, aj keď nie celkom dôležité.</h2>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">9. Vyberáme aj otázky, ktoré sú zaujímavé, aj keď nie celkom dôležité.</h2>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Hlasovali by ste za (myslené ironicky) návrh farebne napovedať poslancom, ako hlasovať?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Zaujímavá otázka na testovanie postojov</p>
+                <p className="font-medium text-green-800">Hlasovali by ste za (myslené ironicky) návrh farebne napovedať poslancom, ako hlasovať?</p>
+                <p className="text-sm text-green-600 mt-1">Zaujímavá otázka na testovanie postojov</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Hlasovali by ste za zákon „Václav Havel sa zaslúžil o slobodu a demokraciu.“?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Zaujímavá otázka na testovanie postojov</p>
+                <p className="font-medium text-green-800">Hlasovali by ste za zákon „Václav Havel sa zaslúžil o slobodu a demokraciu.“?</p>
+                <p className="text-sm text-green-600 mt-1">Zaujímavá otázka na testovanie postojov</p>
               </div>
             </div>
           </div>

--- a/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/BeadRow.tsx
+++ b/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/BeadRow.tsx
@@ -30,10 +30,10 @@ export function BeadRow({ anchorId = "other-calcs-heading" }: { anchorId?: strin
     <div ref={rootRef} className="absolute left-0 right-0" style={{ top }}>
       <div className="grid grid-cols-6 gap-x-6">
         <div className="relative col-start-4">
-          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 ko:text-primary" />
+          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-primary)]" />
         </div>
         <div className="relative col-start-5">
-          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 ko:text-secondary" />
+          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-secondary)]" />
         </div>
         <div className="relative col-start-6">
           <BeadTickSlate className="absolute left-0 -translate-x-1/2 h-8 w-8 text-slate-700" />

--- a/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/BeadRow.tsx
+++ b/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/BeadRow.tsx
@@ -30,10 +30,10 @@ export function BeadRow({ anchorId = "other-calcs-heading" }: { anchorId?: strin
     <div ref={rootRef} className="absolute left-0 right-0" style={{ top }}>
       <div className="grid grid-cols-6 gap-x-6">
         <div className="relative col-start-4">
-          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-primary)]" />
+          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 text-primary" />
         </div>
         <div className="relative col-start-5">
-          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-secondary)]" />
+          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 text-secondary" />
         </div>
         <div className="relative col-start-6">
           <BeadTickSlate className="absolute left-0 -translate-x-1/2 h-8 w-8 text-slate-700" />

--- a/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/page.tsx
+++ b/apps/www.volebnakalkulacka.sk/app/[locale]/(web)/(content)/page.tsx
@@ -24,7 +24,7 @@ export default function Page() {
       {/* Content */}
       <div className="relative z-10 mx-auto max-w-7xl px-6 sm:px-8 pt-12 md:pt-16 lg:pt-20 pb-12 md:pb-16">
         {/* Campaign: komunálne + župné voľby 2026 */}
-        <h1 className="font-display ko:font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">Komunálne a župné voľby 2026</h1>
+        <h1 className="font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">Komunálne a župné voľby 2026</h1>
         <div className="mt-10 md:mt-12 grid grid-cols-1 items-stretch">
           <Card shadow="hard" border corner="topLeft" className="bg-white !border-slate-200">
             <div className="p-6 md:p-10 grid gap-8 md:grid-cols-2 md:items-center">
@@ -33,7 +33,7 @@ export default function Page() {
                   <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 font-semibold text-blue-700">Pripravujeme</span>
                   <span className="rounded-full bg-slate-100 px-2.5 py-1">24.&nbsp;októbra&nbsp;2026</span>
                 </div>
-                <h2 className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Nech vám nové kalkulačky neujdú</h2>
+                <h2 className="font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Nech vám nové kalkulačky neujdú</h2>
                 <p className="text-slate-500">Nechajte nám na seba e-mail a dáme vám vedieť, hneď ako volebné kalkulačky pre komunálne a župné voľby spustíme.</p>
               </div>
               <div className="w-full">
@@ -44,7 +44,7 @@ export default function Page() {
         </div>
 
         {/* Other calculators */}
-        <h2 className="mt-16 md:mt-20 font-display ko:font-display font-bold tracking-tight text-slate-700 text-3xl">Ďalšie kalkulačky</h2>
+        <h2 className="mt-16 md:mt-20 font-display font-bold tracking-tight text-slate-700 text-3xl">Ďalšie kalkulačky</h2>
         <div className="mt-8 grid grid-cols-1 gap-8 md:grid-cols-2 items-stretch">
           <Card shadow="hard" border corner="topLeft" className="bg-white h-full !border-slate-200">
             <div className="p-6 md:p-8 h-full flex flex-col">
@@ -52,7 +52,7 @@ export default function Page() {
                 <span className="inline-flex items-center gap-1 rounded-full bg-red-50 px-2.5 py-1 font-semibold text-red-700">Inventúra hlasovania</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">10 minút</span>
               </div>
-              <h3 className="mt-4 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Kto vás naozaj zastupuje?</h3>
+              <h3 className="mt-4 font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Kto vás naozaj zastupuje?</h3>
               <p className="mt-2 text-slate-500">Žiadne sľuby, ale skutočné hlasovania 2023-2025.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <Link href="/inventura-2023-2025" className="grid">
@@ -69,7 +69,7 @@ export default function Page() {
               <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600">
                 <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-1 font-semibold text-slate-600">Staršie voľby</span>
               </div>
-              <h3 className="mt-4 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Archív kalkulačiek</h3>
+              <h3 className="mt-4 font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Archív kalkulačiek</h3>
               <p className="mt-2 text-slate-500">Volebné kalkulačky k starším voľbám nájdete v archíve.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <a href="https://archiv.volebnakalkulacka.sk" target="_blank" rel="noopener noreferrer" className="grid">

--- a/apps/www.volebnakalkulacka.sk/app/globals.css
+++ b/apps/www.volebnakalkulacka.sk/app/globals.css
@@ -1,14 +1,9 @@
 @import "tailwindcss";
+@import "@kalkulacka-one/design-system/tokens.css";
 
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
 :root {
   color-scheme: light;
-}
-
-@theme static {
-  --font-display: var(--ko-font-display);
-  --font-sans: var(--ko-font-sans);
-  --font-mono: var(--ko-font-mono);
 }

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/(pages)/metodika/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/(pages)/metodika/page.tsx
@@ -6,274 +6,274 @@ export const metadata: Metadata = {
 
 export default function Page() {
   return (
-    <div className="ko:max-w-4xl ko:mx-auto ko:p-6">
-      <h1 className="ko:text-3xl ko:font-bold ko:mb-8">Metodika výběru a tvorby otázek</h1>
+    <div className="max-w-4xl mx-auto p-6">
+      <h1 className="text-3xl font-bold mb-8">Metodika výběru a tvorby otázek</h1>
 
-      <div className="ko:space-y-8">
+      <div className="space-y-8">
         {/* Introduction */}
-        <div className="ko:bg-gray-50 ko:p-6 ko:rounded-lg">
-          <div className="ko:flex ko:items-center ko:gap-3 ko:mb-4">
-            <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center">
-              <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+        <div className="bg-gray-50 p-6 rounded-lg">
+          <div className="flex items-center gap-3 mb-4">
+            <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center">
+              <span className="text-white text-sm font-bold">✕</span>
             </div>
-            <h2 className="ko:text-xl ko:font-semibold ko:text-red-700">Nevyhovující příklad</h2>
+            <h2 className="text-xl font-semibold text-red-700">Nevyhovující příklad</h2>
           </div>
-          <div className="ko:flex ko:items-center ko:gap-3">
-            <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center">
-              <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+          <div className="flex items-center gap-3">
+            <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center">
+              <span className="text-white text-sm font-bold">✓</span>
             </div>
-            <h2 className="ko:text-xl ko:font-semibold ko:text-green-700">Vyhovující příklad</h2>
+            <h2 className="text-xl font-semibold text-green-700">Vyhovující příklad</h2>
           </div>
         </div>
 
         {/* Rule 1 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">1. Otázka se musí týkat toho, co mají zvolení politici šanci ovlivnit.</h2>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">1. Otázka se musí týkat toho, co mají zvolení politici šanci ovlivnit.</h2>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">ČR by měla vystoupit z EU. (otázka v krajských volbách)</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Krajští politici nemohou ovlivnit vystoupení z EU</p>
+                <p className="font-medium text-red-800">ČR by měla vystoupit z EU. (otázka v krajských volbách)</p>
+                <p className="text-sm text-red-600 mt-1">Krajští politici nemohou ovlivnit vystoupení z EU</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">ČR by měla vystoupit z EU. (otázka v celostátních volbách)</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Celostátní politici mohou ovlivnit vystoupení z EU</p>
+                <p className="font-medium text-green-800">ČR by měla vystoupit z EU. (otázka v celostátních volbách)</p>
+                <p className="text-sm text-green-600 mt-1">Celostátní politici mohou ovlivnit vystoupení z EU</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Chtěl/a bych, aby se v příštích volbách Praha vrátila k systému jediného volebního obvodu. (otázka v pražských volbách)</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Pražští politici mohou ovlivnit volební systém v Praze</p>
+                <p className="font-medium text-green-800">Chtěl/a bych, aby se v příštích volbách Praha vrátila k systému jediného volebního obvodu. (otázka v pražských volbách)</p>
+                <p className="text-sm text-green-600 mt-1">Pražští politici mohou ovlivnit volební systém v Praze</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 2 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">2. Na otázku musí jít odpovědět ano i ne a neměla by navádět k odpovědi.</h2>
-          <p className="ko:text-gray-700 ko:mb-4">
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">2. Na otázku musí jít odpovědět ano i ne a neměla by navádět k odpovědi.</h2>
+          <p className="text-gray-700 mb-4">
             Při tvorbě si musíme umět představit lidi, kteří vybírají obě varianty odpovědi, ano i ne. Z otázky by také nemělo být poznat, jak na ni odpovídá sám autor otázky.
           </p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Měla by se zlepšit dopravní situace v městských částech Považský Chlmec a Vranie?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Otázka je příliš obecná a nekonkrétní</p>
+                <p className="font-medium text-red-800">Měla by se zlepšit dopravní situace v městských částech Považský Chlmec a Vranie?</p>
+                <p className="text-sm text-red-600 mt-1">Otázka je příliš obecná a nekonkrétní</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Chtěl/a bych, aby Opencard nebyla pro cestující cenově výhodnější oproti „papírové tramvajence", aby si cestující mohli vybrat.</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">"aby si mohli vybrat" navádí k odpovědi</p>
+                <p className="font-medium text-red-800">Chtěl/a bych, aby Opencard nebyla pro cestující cenově výhodnější oproti „papírové tramvajence", aby si cestující mohli vybrat.</p>
+                <p className="text-sm text-red-600 mt-1">"aby si mohli vybrat" navádí k odpovědi</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Měla by se vybudovat oddychová zóna pri Rajčianke?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Konkrétní otázka s jasným cílem (pouze za předpokladu, že "každý" ví, o co jde)</p>
+                <p className="font-medium text-green-800">Měla by se vybudovat oddychová zóna pri Rajčianke?</p>
+                <p className="text-sm text-green-600 mt-1">Konkrétní otázka s jasným cílem (pouze za předpokladu, že "každý" ví, o co jde)</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Mělo by se alespoň 1% z rozpočtu města určeného na dopravu vyčlenit na cyklistickou dopravu?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Konkrétní, měřitelná otázka s jasným cílem</p>
+                <p className="font-medium text-green-800">Mělo by se alespoň 1% z rozpočtu města určeného na dopravu vyčlenit na cyklistickou dopravu?</p>
+                <p className="text-sm text-green-600 mt-1">Konkrétní, měřitelná otázka s jasným cílem</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 3 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">3. Otázky mají být důležité</h2>
-          <p className="ko:text-gray-700 ko:mb-4">
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">3. Otázky mají být důležité</h2>
+          <p className="text-gray-700 mb-4">
             Bereme např. v potaz, na co vydává dané zastupitelstvo/parlament nejvíce veřejných peněz. Témata vybíráme tak, aby byla relevantní pro všechny skupiny voličů (věkové, příjmové, zájmové).
           </p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Mělo se město omluvit pí. Lorenzové a p. Cejthamrovi za výroky, které při této konfrontaci byly vysloveny?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Příliš specifická situace, která není důležitá pro většinu voličů</p>
+                <p className="font-medium text-red-800">Mělo se město omluvit pí. Lorenzové a p. Cejthamrovi za výroky, které při této konfrontaci byly vysloveny?</p>
+                <p className="text-sm text-red-600 mt-1">Příliš specifická situace, která není důležitá pro většinu voličů</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Hlasovali byste za zrušení garance a automatický vstup do druhého pilíře?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Důležité téma pro všechny občany</p>
+                <p className="font-medium text-green-800">Hlasovali byste za zrušení garance a automatický vstup do druhého pilíře?</p>
+                <p className="text-sm text-green-600 mt-1">Důležité téma pro všechny občany</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Hlasovali byste za důvěru vládě a permanentní euroval?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Důležité téma s dopadem na všechny občany</p>
+                <p className="font-medium text-green-800">Hlasovali byste za důvěru vládě a permanentní euroval?</p>
+                <p className="text-sm text-green-600 mt-1">Důležité téma s dopadem na všechny občany</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 4 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">4. Otázka má být co nejkonkrétnější</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Jde nám o to, aby se dala odpověď zkontrolovat po 4 letech/na konci volebního období.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">4. Otázka má být co nejkonkrétnější</h2>
+          <p className="text-gray-700 mb-4">Jde nám o to, aby se dala odpověď zkontrolovat po 4 letech/na konci volebního období.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Měla by sa zahušťovat výstavba v centru města?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Příliš obecná otázka, nelze ověřit splnění</p>
+                <p className="font-medium text-red-800">Měla by sa zahušťovat výstavba v centru města?</p>
+                <p className="text-sm text-red-600 mt-1">Příliš obecná otázka, nelze ověřit splnění</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Podle mého názoru by z letiště Ruzyně do centra Prahy měla vést rychlodráha.</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Správně by bylo: "Budu prosazovat/chci, aby se rychlodráha z letiště do centra Prahy začala budovat v následujících 4 letech"</p>
+                <p className="font-medium text-red-800">Podle mého názoru by z letiště Ruzyně do centra Prahy měla vést rychlodráha.</p>
+                <p className="text-sm text-red-600 mt-1">Správně by bylo: "Budu prosazovat/chci, aby se rychlodráha z letiště do centra Prahy začala budovat v následujících 4 letech"</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Měla by se zvýšit dotace pro MHD minimálně o 10% oproti roku 2010?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Konkrétní, měřitelná otázka s jasným cílem</p>
+                <p className="font-medium text-green-800">Měla by se zvýšit dotace pro MHD minimálně o 10% oproti roku 2010?</p>
+                <p className="text-sm text-green-600 mt-1">Konkrétní, měřitelná otázka s jasným cílem</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 5 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">5. Otázka musí být krátká a srozumitelná</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Chceme, aby tázaný/á otázky opravdu pročetl/a a porozuměl/a jim. Formulujeme je tedy o max. délce 20 slov, případný popis omezujeme na 50 slov.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">5. Otázka musí být krátká a srozumitelná</h2>
+          <p className="text-gray-700 mb-4">Chceme, aby tázaný/á otázky opravdu pročetl/a a porozuměl/a jim. Formulujeme je tedy o max. délce 20 slov, případný popis omezujeme na 50 slov.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">
+                <p className="font-medium text-red-800">
                   Hlasovali byste pro: zrušení sociálního příplatku pro sólo rodiče, redukci dávky – porodného jen na nízkopříjmové rodiče, jednotnou celkovou vyplacenou částku rodičovského příspěvku
                   (220 000) a větší flexibilitu ve volbě výše a délky RP, snížení příspěvku na péči, snížení podpory v nezaměstnanosti a zrušení možnosti minimálního přivýdělku k podpoře, zavedení
                   příspěvku pro začínající podnikatele/ky, zpřísnění podmínek nároku na nemocenské a mateřskou u OSVČ?
                 </p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Příliš dlouhá otázka s mnoha částmi</p>
+                <p className="text-sm text-red-600 mt-1">Příliš dlouhá otázka s mnoha částmi</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Souhlasím se zavedením turniketů do metra.</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Krátká, jasná otázka</p>
+                <p className="font-medium text-green-800">Souhlasím se zavedením turniketů do metra.</p>
+                <p className="text-sm text-green-600 mt-1">Krátká, jasná otázka</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 6 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">6. Otázky s popisem musejí dávat smysl i bez něj</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Velký počet lidí totiž čte pouze otázku samotnou, ne její popis. Může se take stát, že popis na mobilním zařízení nezobrazí.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">6. Otázky s popisem musejí dávat smysl i bez něj</h2>
+          <p className="text-gray-700 mb-4">Velký počet lidí totiž čte pouze otázku samotnou, ne její popis. Může se take stát, že popis na mobilním zařízení nezobrazí.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Hlasovali by ste za zrušení garancie a automatický vstup do druhého pilíře?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Bez popisu není jasné, o co jde</p>
+                <p className="font-medium text-red-800">Hlasovali by ste za zrušení garancie a automatický vstup do druhého pilíře?</p>
+                <p className="text-sm text-red-600 mt-1">Bez popisu není jasné, o co jde</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Má podle Vás smysl připojovat se k podobným projektům?</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Bez kontextu není jasné, o jaké projekty jde</p>
+                <p className="font-medium text-red-800">Má podle Vás smysl připojovat se k podobným projektům?</p>
+                <p className="text-sm text-red-600 mt-1">Bez kontextu není jasné, o jaké projekty jde</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Souhlasím se zpoplatněním vjezdu automobilů do centra města, například formou mýtného.</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Jasná otázka i bez popisu</p>
+                <p className="font-medium text-green-800">Souhlasím se zpoplatněním vjezdu automobilů do centra města, například formou mýtného.</p>
+                <p className="text-sm text-green-600 mt-1">Jasná otázka i bez popisu</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 7 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">7. Upřednostňujeme otázky v pozitivním tvaru, vyhýbáme se matoucí dvojité negaci.</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Z příkladu níže je viditelné, že dvojitá negace je zavádějící a nepřesná.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">7. Upřednostňujeme otázky v pozitivním tvaru, vyhýbáme se matoucí dvojité negaci.</h2>
+          <p className="text-gray-700 mb-4">Z příkladu níže je viditelné, že dvojitá negace je zavádějící a nepřesná.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Na Vysočině by úložiště jaderného odpadu nemělo vzniknout za žádnou cenu.</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">
+                <p className="font-medium text-red-800">Na Vysočině by úložiště jaderného odpadu nemělo vzniknout za žádnou cenu.</p>
+                <p className="text-sm text-red-600 mt-1">
                   Zde totiž není jasné, s čím tázaný/á nesouhlasí:
                   <br />
                   a) ne, nemělo by vzniknout,
@@ -286,68 +286,68 @@ export default function Page() {
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Střední školy by se měly nadále slučovat do větších celků.</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Nikoliv "Střední školy už by se nadále neměly slučovat do větších celků".</p>
+                <p className="font-medium text-green-800">Střední školy by se měly nadále slučovat do větších celků.</p>
+                <p className="text-sm text-green-600 mt-1">Nikoliv "Střední školy už by se nadále neměly slučovat do větších celků".</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 8 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">8. Otázka musí být psána snadno pochopitelným jazykem</h2>
-          <p className="ko:text-gray-700 ko:mb-4">Otázky píšeme tak, aby ji a tématu porozuměli různé společenské skupiny.</p>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">8. Otázka musí být psána snadno pochopitelným jazykem</h2>
+          <p className="text-gray-700 mb-4">Otázky píšeme tak, aby ji a tématu porozuměli různé společenské skupiny.</p>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-red-50 ko:border-l-4 ko:border-red-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-red-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✕</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-red-50 border-l-4 border-red-500 rounded">
+              <div className="w-6 h-6 bg-red-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✕</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-red-800">Nový územní plán musí regulovat výškovou výstavbu, která může poškodit panorama Prahy.</p>
-                <p className="ko:text-sm ko:text-red-600 ko:mt-1">Příliš odborný jazyk, složitá formulace</p>
+                <p className="font-medium text-red-800">Nový územní plán musí regulovat výškovou výstavbu, která může poškodit panorama Prahy.</p>
+                <p className="text-sm text-red-600 mt-1">Příliš odborný jazyk, složitá formulace</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Výstavba mrakodrapů v historickém centru má být zakázána.</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Jasný, srozumitelný jazyk</p>
+                <p className="font-medium text-green-800">Výstavba mrakodrapů v historickém centru má být zakázána.</p>
+                <p className="text-sm text-green-600 mt-1">Jasný, srozumitelný jazyk</p>
               </div>
             </div>
           </div>
         </section>
 
         {/* Rule 9 */}
-        <section className="ko:space-y-4">
-          <h2 className="ko:text-2xl ko:font-bold ko:mb-4">9. Vybíráme i otázky, které jsou zajímavé, i když ne zcela důležité.</h2>
+        <section className="space-y-4">
+          <h2 className="text-2xl font-bold mb-4">9. Vybíráme i otázky, které jsou zajímavé, i když ne zcela důležité.</h2>
 
-          <div className="ko:space-y-3">
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+          <div className="space-y-3">
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Hlasovali byste za (myšleno ironicky) návrh barevně napovídat poslancům, jak hlasovat?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Zajímavá otázka pro testování postojů</p>
+                <p className="font-medium text-green-800">Hlasovali byste za (myšleno ironicky) návrh barevně napovídat poslancům, jak hlasovat?</p>
+                <p className="text-sm text-green-600 mt-1">Zajímavá otázka pro testování postojů</p>
               </div>
             </div>
 
-            <div className="ko:flex ko:items-start ko:gap-3 ko:p-4 ko:bg-green-50 ko:border-l-4 ko:border-green-500 ko:rounded">
-              <div className="ko:w-6 ko:h-6 ko:bg-green-500 ko:rounded-full ko:flex ko:items-center ko:justify-center ko:flex-shrink-0 ko:mt-1">
-                <span className="ko:text-white ko:text-sm ko:font-bold">✓</span>
+            <div className="flex items-start gap-3 p-4 bg-green-50 border-l-4 border-green-500 rounded">
+              <div className="w-6 h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
+                <span className="text-white text-sm font-bold">✓</span>
               </div>
               <div>
-                <p className="ko:font-medium ko:text-green-800">Hlasovali byste pro zákon "Václav Havel se zasloužil o svobodu a demokracii."?</p>
-                <p className="ko:text-sm ko:text-green-600 ko:mt-1">Zajímavá otázka pro testování postojů</p>
+                <p className="font-medium text-green-800">Hlasovali byste pro zákon "Václav Havel se zasloužil o svobodu a demokracii."?</p>
+                <p className="text-sm text-green-600 mt-1">Zajímavá otázka pro testování postojů</p>
               </div>
             </div>
           </div>

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/BeadRow.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/BeadRow.tsx
@@ -30,10 +30,10 @@ export function BeadRow({ anchorId = "other-calcs-heading" }: { anchorId?: strin
     <div ref={rootRef} className="absolute left-0 right-0" style={{ top }}>
       <div className="grid grid-cols-6 gap-x-6">
         <div className="relative col-start-4">
-          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 ko:text-primary" />
+          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-primary)]" />
         </div>
         <div className="relative col-start-5">
-          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 ko:text-secondary" />
+          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-secondary)]" />
         </div>
         <div className="relative col-start-6">
           <BeadTickSlate className="absolute left-0 -translate-x-1/2 h-8 w-8 text-slate-700" />

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/BeadRow.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/BeadRow.tsx
@@ -30,10 +30,10 @@ export function BeadRow({ anchorId = "other-calcs-heading" }: { anchorId?: strin
     <div ref={rootRef} className="absolute left-0 right-0" style={{ top }}>
       <div className="grid grid-cols-6 gap-x-6">
         <div className="relative col-start-4">
-          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-primary)]" />
+          <BeadCheckBlue className="absolute left-0 -translate-x-1/2 h-8 w-8 text-primary" />
         </div>
         <div className="relative col-start-5">
-          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 text-[var(--ko-color-secondary)]" />
+          <BeadCrossRed className="absolute left-0 -translate-x-1/2 h-8 w-8 text-secondary" />
         </div>
         <div className="relative col-start-6">
           <BeadTickSlate className="absolute left-0 -translate-x-1/2 h-8 w-8 text-slate-700" />

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/page.tsx
@@ -30,7 +30,7 @@ export default function Page() {
       {/* Content */}
       <div className="relative z-10 mx-auto max-w-7xl px-6 sm:px-8 pt-12 md:pt-16 lg:pt-20 pb-12 md:pb-16">
         {/* Campaign: komunální + senátní volby 2026 */}
-        <h1 className="font-display ko:font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">Komunální a senátní volby 2026</h1>
+        <h1 className="font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">Komunální a senátní volby 2026</h1>
         <div className="mt-10 md:mt-12 grid grid-cols-1 items-stretch">
           <Card shadow="hard" border corner="topLeft" className="bg-white !border-slate-200">
             <div className="p-6 md:p-10 grid gap-8 md:grid-cols-2 md:items-center">
@@ -39,7 +39,7 @@ export default function Page() {
                   <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 font-semibold text-blue-700">Připravujeme</span>
                   <span className="rounded-full bg-slate-100 px-2.5 py-1">9.&nbsp;a&nbsp;10.&nbsp;října&nbsp;2026</span>
                 </div>
-                <h2 className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Ať vám nové kalkulačky neutečou</h2>
+                <h2 className="font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Ať vám nové kalkulačky neutečou</h2>
                 <p className="text-slate-500">Nechte nám na sebe e-mail a dáme vám vědět, jakmile volební kalkulačky pro komunální a senátní volby spustíme.</p>
               </div>
               <div className="w-full">
@@ -51,7 +51,7 @@ export default function Page() {
           <Card border className="mt-8 !border-slate-200 bg-slate-50/50">
             <div className="p-6 md:p-8 flex flex-col md:flex-row md:items-center gap-4 md:gap-8">
               <div className="flex-1">
-                <h2 className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-xl md:text-2xl">Pomozte nám s kalkulačkou pro vaše město</h2>
+                <h2 className="font-display font-bold tracking-tight text-slate-700 text-xl md:text-2xl">Pomozte nám s kalkulačkou pro vaše město</h2>
                 <p className="mt-1 text-slate-500">Kalkulačky ke komunálním volbám vznikají s pomocí lidí přímo z místa.</p>
               </div>
               <Link href="/zapojte-se" className="grid md:shrink-0">
@@ -64,7 +64,7 @@ export default function Page() {
         </div>
 
         {/* Sněmovní volby 2025 */}
-        <h2 className="mt-16 md:mt-20 font-display ko:font-display font-bold tracking-tight text-slate-700 text-3xl">Další kalkulačky</h2>
+        <h2 className="mt-16 md:mt-20 font-display font-bold tracking-tight text-slate-700 text-3xl">Další kalkulačky</h2>
         <div className="mt-8 grid grid-cols-1 gap-8 md:grid-cols-2 items-stretch">
           <Card shadow="hard" border corner="topLeft" className="bg-white h-full !border-slate-200">
             <div className="p-6 md:p-8 h-full flex flex-col">
@@ -72,7 +72,7 @@ export default function Page() {
                 <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-1 font-semibold text-slate-600">Sněmovní volby 2025</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">7 kalkulaček</span>
               </div>
-              <h3 className="mt-4 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Kalkulačky ke sněmovním volbám</h3>
+              <h3 className="mt-4 font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Kalkulačky ke sněmovním volbám</h3>
               <p className="mt-2 text-slate-500">Všech sedm kalkulaček ke sněmovním volbám 2025 si můžete vyplnit i po volbách — od expresní po ultimátní.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <Link href="/volby/snemovni-2025" className="grid">
@@ -89,7 +89,7 @@ export default function Page() {
               <div className="flex flex-wrap items-center gap-2 text-xs text-slate-600">
                 <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-1 font-semibold text-slate-600">Starší volby</span>
               </div>
-              <h3 className="mt-4 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Archiv kalkulaček</h3>
+              <h3 className="mt-4 font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Archiv kalkulaček</h3>
               <p className="mt-2 text-slate-500">Volební kalkulačky ke starším volbám najdete v archivu.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <a href="https://archiv-2024.volebnikalkulacka.cz" target="_blank" rel="noopener noreferrer" className="grid">

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/snemovni-2025/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/volby/snemovni-2025/page.tsx
@@ -31,7 +31,7 @@ export default function Page() {
         </Link>
 
         {/* Heading */}
-        <h1 className="mt-4 font-display ko:font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">Sněmovní volby 2025</h1>
+        <h1 className="mt-4 font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">Sněmovní volby 2025</h1>
         <p className="mt-4 max-w-prose text-slate-500">Volby do Poslanecké sněmovny proběhly 3. a 4. října 2025. Všechny kalkulačky si můžete vyplnit i po volbách.</p>
 
         {/* Featured cards */}
@@ -44,7 +44,7 @@ export default function Page() {
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">42 otázek</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">10 minut</span>
               </div>
-              <h2 className="mt-4 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Kdo zastává vaše postoje?</h2>
+              <h2 className="mt-4 font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Kdo zastává vaše postoje?</h2>
               <p className="mt-2 text-slate-500">Klasická Volební kalkulačka, jak ji znáte už skoro 20 let.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <Link href="/volby/snemovni-2025/kalkulacka" className="grid">
@@ -64,7 +64,7 @@ export default function Page() {
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">35 hlasování</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">10 minut</span>
               </div>
-              <h2 className="mt-4 font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Kdo vás zastupoval ve Sněmovně?</h2>
+              <h2 className="mt-4 font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Kdo vás zastupoval ve Sněmovně?</h2>
               <p className="mt-2 text-slate-500">Žádné sliby, ale skutečná hlasování poslanců ve Sněmovně za končící volební období.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <Link href="/volby/snemovni-2025/inventura" className="grid">
@@ -78,7 +78,7 @@ export default function Page() {
         </div>
 
         {/* Other calculators */}
-        <h2 className="mt-16 md:mt-20 font-display ko:font-display font-bold tracking-tight text-slate-700 text-3xl">Další volební kalkulačky</h2>
+        <h2 className="mt-16 md:mt-20 font-display font-bold tracking-tight text-slate-700 text-3xl">Další volební kalkulačky</h2>
         <div className="mt-8 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 items-stretch">
           <Card shadow="hard" border corner="topLeft" className="h-full !border-slate-200">
             <div className="p-6 h-full flex flex-col">
@@ -87,7 +87,7 @@ export default function Page() {
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">25 otázek</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">5 minut</span>
               </div>
-              <h3 className="mt-3 font-display ko:font-display font-bold tracking-tight text-slate-700 text-xl">Nejužitečnějších 5 minut před volbami</h3>
+              <h3 className="mt-3 font-display font-bold tracking-tight text-slate-700 text-xl">Nejužitečnějších 5 minut před volbami</h3>
               <p className="mt-1 text-slate-500">Těch 25 nejklíčovějších otázek, které vám zaberou jen 5 minut.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <Link href="/volby/snemovni-2025/expresni" className="grid">
@@ -106,7 +106,7 @@ export default function Page() {
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">100 otázek</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">30 minut</span>
               </div>
-              <h3 className="mt-3 font-display ko:font-display font-bold tracking-tight text-slate-700 text-xl">Všech 100 otázek pro „politické fajnšmekry"</h3>
+              <h3 className="mt-3 font-display font-bold tracking-tight text-slate-700 text-xl">Všech 100 otázek pro „politické fajnšmekry"</h3>
               <p className="mt-1 text-slate-500">Nejrozsáhlejší verze se všemi 100 otázkami, na které jsme se ptali.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <Link href="/volby/snemovni-2025/ultimatni" className="grid">
@@ -120,7 +120,7 @@ export default function Page() {
         </div>
 
         {/* Thematic calculators */}
-        <h2 className="mt-12 font-display ko:font-display font-bold tracking-tight text-slate-700 text-3xl">Tématické volební kalkulačky</h2>
+        <h2 className="mt-12 font-display font-bold tracking-tight text-slate-700 text-3xl">Tématické volební kalkulačky</h2>
         <div className="mt-8 grid grid-cols-1 gap-8 md:grid-cols-3 items-stretch">
           <Card shadow="hard" border corner="topLeft" className="h-full !border-slate-200">
             <div className="p-6 h-full flex flex-col">
@@ -131,7 +131,7 @@ export default function Page() {
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">35 otázek</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">10 minut</span>
               </div>
-              <h3 className="mt-3 font-display ko:font-display font-bold tracking-tight text-slate-700 text-xl">35 otázek, které pálí nejen mladou generaci</h3>
+              <h3 className="mt-3 font-display font-bold tracking-tight text-slate-700 text-xl">35 otázek, které pálí nejen mladou generaci</h3>
               <p className="mt-1 text-slate-500">
                 Témata, která podle výzkumu pálí mladou generaci. Ve spolupráci s{" "}
                 <a href="https://dikyzemuzem.cz" target="_blank" rel="noopener noreferrer" className="text-slate-700 hover:text-slate-900 underline underline-offset-2">
@@ -155,7 +155,7 @@ export default function Page() {
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">20 otázek</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">5 minut</span>
               </div>
-              <h3 className="mt-3 font-display ko:font-display font-bold tracking-tight text-slate-700 text-xl">Kdo má plán pro klima?</h3>
+              <h3 className="mt-3 font-display font-bold tracking-tight text-slate-700 text-xl">Kdo má plán pro klima?</h3>
               <p className="mt-1 text-slate-500">
                 Výběr otázek ke klimatické změně: povolenky, energetika, doprava. Ve spolupráci s{" "}
                 <a href="https://faktaoklimatu.cz" target="_blank" rel="noopener noreferrer" className="text-slate-700 hover:text-slate-900 underline underline-offset-2">
@@ -179,7 +179,7 @@ export default function Page() {
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">25 otázek</span>
                 <span className="rounded-full bg-slate-100 px-2.5 py-1">10 minut</span>
               </div>
-              <h3 className="mt-3 font-display ko:font-display font-bold tracking-tight text-slate-700 text-xl">Kdo sdílí vaše hodnoty?</h3>
+              <h3 className="mt-3 font-display font-bold tracking-tight text-slate-700 text-xl">Kdo sdílí vaše hodnoty?</h3>
               <p className="mt-1 text-slate-500">Hodnotové otázky místo konkrétních návrhů. Zjistěte, které strany zastávají podobné hodnoty jako vy.</p>
               <div className="grid mt-auto pt-4 md:pt-6">
                 <Link href="/volby/snemovni-2025/kompas" className="grid">

--- a/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/zapojte-se/page.tsx
+++ b/apps/www.volebnikalkulacka.cz/app/[locale]/(web)/(content)/zapojte-se/page.tsx
@@ -32,7 +32,7 @@ export default function Page() {
         </Link>
 
         {/* Heading */}
-        <h1 className="mt-4 font-display ko:font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">Pomozte nám s kalkulačkou pro vaše město</h1>
+        <h1 className="mt-4 font-display font-bold tracking-tighter text-slate-700 text-4xl md:text-5xl lg:text-6xl">Pomozte nám s kalkulačkou pro vaše město</h1>
         <p className="mt-4 max-w-prose text-slate-500">
           Ke komunálním volbám 2026 připravujeme volební kalkulačky pro vybraná města. Chcete, aby vznikla i pro to vaše? Vyberte město, nechte nám na sebe e-mail a ozveme se vám.
         </p>
@@ -46,7 +46,7 @@ export default function Page() {
                   <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 font-semibold text-blue-700">Komunální volby 2026</span>
                   <span className="rounded-full bg-slate-100 px-2.5 py-1">9.&nbsp;a&nbsp;10.&nbsp;října&nbsp;2026</span>
                 </div>
-                <h2 className="font-display ko:font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Přidejte se!</h2>
+                <h2 className="font-display font-bold tracking-tight text-slate-700 text-2xl md:text-3xl">Přidejte se!</h2>
                 <p className="text-slate-500">
                   Kalkulačka pro vaše město vznikne jen s pomocí lidí, kteří tam žijí, vědí, co se ve městě řeší, a znají místní kandidáty — od těch totiž potřebujeme získat odpovědi na otázky. Dáme
                   vám vědět, jak se můžete zapojit.

--- a/apps/www.volebnikalkulacka.cz/app/globals.css
+++ b/apps/www.volebnikalkulacka.cz/app/globals.css
@@ -1,14 +1,9 @@
 @import "tailwindcss";
+@import "@kalkulacka-one/design-system/tokens.css";
 
 @import "@kalkulacka-one/design-system/styles";
 @import "@kalkulacka-one/app/styles";
 
 :root {
   color-scheme: light;
-}
-
-@theme static {
-  --font-display: var(--ko-font-display);
-  --font-sans: var(--ko-font-sans);
-  --font-mono: var(--ko-font-mono);
 }

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["**", "!**/styles.css", "!**/globals.css"]
+    "includes": ["**", "!**/styles.css", "!**/globals.css", "!**/tokens.css"]
   },
   "assist": {
     "actions": {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "exports": {
     "./themes/*.css": "./src/themes/*.css",
+    "./tokens.css": "./src/tokens.css",
     "./styles": "./dist/index.css",
     "./fonts": "./dist/fonts",
     "./server": {

--- a/packages/design-system/src/tokens.css
+++ b/packages/design-system/src/tokens.css
@@ -1,0 +1,28 @@
+@theme static {
+  --font-display: var(--ko-font-display);
+  --font-sans: var(--ko-font-sans);
+  --font-mono: var(--ko-font-mono);
+
+  --color-primary: var(--ko-color-primary);
+  --color-primary-hover: var(--ko-color-primary-hover);
+  --color-primary-active: var(--ko-color-primary-active);
+  --color-primary-disabled: var(--ko-color-primary-disabled);
+  --color-on-bg-primary: var(--ko-color-on-bg-primary);
+
+  --color-secondary: var(--ko-color-secondary);
+  --color-secondary-hover: var(--ko-color-secondary-hover);
+  --color-secondary-active: var(--ko-color-secondary-active);
+  --color-secondary-disabled: var(--ko-color-secondary-disabled);
+  --color-on-bg-secondary: var(--ko-color-on-bg-secondary);
+
+  --color-neutral: var(--ko-color-neutral);
+  --color-neutral-hover: var(--ko-color-neutral-hover);
+  --color-neutral-active: var(--ko-color-neutral-active);
+  --color-neutral-disabled: var(--ko-color-neutral-disabled);
+  --color-neutral-inactive: var(--ko-color-neutral-inactive);
+  --color-on-bg-neutral: var(--ko-color-on-bg-neutral);
+
+  --color-green: var(--ko-color-green);
+  --color-red: var(--ko-color-red);
+  --color-yellow: var(--ko-color-yellow);
+}


### PR DESCRIPTION
There are three Tailwind builds, and each generates CSS only for classes it finds in **its own files**: each app (unprefixed), the design system (`ko:`, scans `packages/design-system/src`), the app package (`koa:`, scans `packages/app/src`).

`/metodika` was written in `ko:` classes — likely copied from design-system components, where `ko:` is right. But it lives in an app, so neither build generates them. No error, no warning: the page ships as plain text.

This PR does two things.

## 1. App markup uses the app's own namespace

I extracted every `ko:` class under `apps/*/app` and `apps/*/components` — 47 distinct, 10 files — and checked each against the built CZ bundle: **47 of 47 missing.** They're all stock utilities, so they lose the prefix.

92% of the diff is one page, twice: the CZ and SK copies of `/metodika`. The rest is removing `ko:font-display` that sat next to an unprefixed `font-display` already doing the work.

**Before:** no cards, no coloured badges, no spacing, ✓/✕ as bare characters. **After:** red/green example cards with coloured borders and circular badges, as designed. Checked on CZ and SK.

## 2. Apps inherit the design system's tokens from one file

App markup could only reach semantic colours through an escape like `text-[var(--ko-color-primary)]`, because the app's namespace doesn't know what "primary" means. Meanwhile the font aliases were copy-pasted into four `globals.css` files.

The design system now exports `tokens.css`, an `@theme` block mapping unprefixed names to its `--ko-*` values. Each app imports it once:

```css
@import "tailwindcss";
@import "@kalkulacka-one/design-system/tokens.css";
```

So plain `text-primary`, `bg-neutral-hover`, `border-secondary` in app markup resolve to the **themed** colour and follow partner themes like the design system's own components. It covers fonts; the primary, secondary and neutral families with their hover/active/disabled/inactive states and `on-bg-*`; and green, red, yellow.

Deliberately **not** aliased: `white` — stock Tailwind already has `--color-white`, so aliasing it would silently change every `bg-white` in the apps — and the `logo-*` colours, which are internal to the Logo component.

`tokens.css` joins `styles.css` and `globals.css` in Biome's exclusions, since Biome can't parse `@theme`.

## Verification

Computed styles from production builds, 36 properties per element, 2 viewports:

| | elements | changed |
|---|---|---|
| **part 1** vs `main`, CZ | 3,642 | 196, all on `/metodika` — the fix. Every other page 0 |
| **part 2** vs part 1, CZ | 3,642 | **0** |
| **part 2** vs part 1, SK | 1,124 | **0** |
| **part 2** vs part 1, www.kalkulacka.one | 566 | **0** |

## Found along the way, not fixed here

- **`BeadRow` never renders.** It looks up `getElementById("bg-grid-root")` and `getElementById("other-calcs-heading")`, but the page gives that grid a `useId()` value and no such heading exists — the effect returns early and the component stays `null`. The decorative beads have never appeared.
- **MK's homepage uses `bg-primary-50` and `text-primary-700`.** There is no shaded primary scale in any namespace, so both are dead today and stay dead — `tokens.css` adds `primary`, not `primary-50`. Worth a look alongside MK's theme.

`npm run typecheck`, `npm run lint`, `npm run test` and `turbo build --force` (12 tasks) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
