### PR TITLE
Let the app package inherit the design system's tokens too

### DIFF
--- a/packages/app/src/client/components/match-card.tsx
+++ b/packages/app/src/client/components/match-card.tsx
@@ -34,7 +34,7 @@ export function MatchCard({ candidate, order, match, respondent }: MatchCard) {
                 />
               ) : (
                 <div
-                  className={`koa:flex koa:h-20 koa:w-20 koa:items-center koa:justify-center koa:rounded-2xl ${order === 1 ? "koa:bg-[var(--ko-color-primary)] koa:text-[var(--ko-color-on-bg-primary)]" : "koa:bg-white koa:text-slate-700"}`}
+                  className={`koa:flex koa:h-20 koa:w-20 koa:items-center koa:justify-center koa:rounded-2xl ${order === 1 ? "koa:bg-primary koa:text-on-bg-primary" : "koa:bg-white koa:text-slate-700"}`}
                 >
                   <span className="koa:text-3xl koa:font-bold">{order !== undefined ? order : "—"}</span>
                 </div>

--- a/packages/app/src/components/guide.tsx
+++ b/packages/app/src/components/guide.tsx
@@ -19,7 +19,7 @@ export function Guide({ calculator }: Guide) {
     <div className="koa:grid koa:gap-4">
       <Card shadow="hard" className="koa:border koa:border-slate-200">
         <div className="koa:flex koa:items-start koa:gap-3 koa:px-6 koa:py-4 koa:max-w-prose">
-          <Icon icon={logoCheck} decorative={true} className="koa:text-[var(--ko-palette-primary)]" />
+          <Icon icon={logoCheck} decorative={true} className="koa:text-primary" />
           <div>
             <p className="koa:font-semibold koa:text-slate-700">{t("agreement.title")}</p>
             <p className="koa:text-sm koa:text-slate-500">{t("agreement.description")}</p>
@@ -28,7 +28,7 @@ export function Guide({ calculator }: Guide) {
       </Card>
       <Card shadow="hard" className="koa:border koa:border-slate-200">
         <div className="koa:flex koa:items-start koa:gap-3 koa:px-6 koa:py-4 koa:max-w-prose">
-          <Icon icon={logoCross} decorative={true} className="koa:text-[var(--ko-palette-secondary)]" />
+          <Icon icon={logoCross} decorative={true} className="koa:text-secondary" />
           <div>
             <p className="koa:font-semibold koa:text-slate-700">{t("disagreement.title")}</p>
             <p className="koa:text-sm koa:text-slate-500">{t("disagreement.description")}</p>

--- a/packages/app/src/components/introduction.tsx
+++ b/packages/app/src/components/introduction.tsx
@@ -15,7 +15,7 @@ export function Introduction({ calculator }: Introduction) {
         skipHtml
         components={{
           a: ({ href, children }) => (
-            <a href={href} className="koa:text-[var(--ko-color-primary)] koa:hover:text-[var(--ko-color-primary-hover)] koa:underline koa:hover:no-underline" target="_blank" rel="noopener noreferrer">
+            <a href={href} className="koa:text-primary koa:hover:text-primary-hover koa:underline koa:hover:no-underline" target="_blank" rel="noopener noreferrer">
               {children}
             </a>
           ),

--- a/packages/app/src/styles.css
+++ b/packages/app/src/styles.css
@@ -2,9 +2,6 @@
 
 @import 'tailwindcss/theme' layer(theme) prefix(koa);
 @import 'tailwindcss/utilities' layer(utilities) prefix(koa);
+@import '@kalkulacka-one/design-system/tokens.css';
 
 @source not "**/*.test.{ts,tsx}";
-
-@theme static {
-  --font-display: var(--ko-font-display);
-}


### PR DESCRIPTION
#568 gave the apps `tokens.css`, so their markup can say `text-primary` and get the themed colour. The app package runs a **third** Tailwind build (`koa:`) with the same blind spot: it knows the stock palette but not what "primary" means. So its components reached the design system through escapes:

```tsx
koa:bg-[var(--ko-color-primary)]
koa:text-[var(--ko-palette-secondary)]
```

It now imports the same `tokens.css`, and the six escapes become ordinary classes:

| file | before | after |
|---|---|---|
| `match-card.tsx` | `koa:bg-[var(--ko-color-primary)]` | `koa:bg-primary` |
| `match-card.tsx` | `koa:text-[var(--ko-color-on-bg-primary)]` | `koa:text-on-bg-primary` |
| `introduction.tsx` | `koa:text-[var(--ko-color-primary)]` | `koa:text-primary` |
| `introduction.tsx` | `koa:hover:text-[var(--ko-color-primary-hover)]` | `koa:hover:text-primary-hover` |
| `guide.tsx` | `koa:text-[var(--ko-palette-primary)]` | `koa:text-primary` |
| `guide.tsx` | `koa:text-[var(--ko-palette-secondary)]` | `koa:text-secondary` |

So all three builds — apps, design system, app package — now take their tokens from one place. The package's own `@theme` block only defined `--font-display`, which `tokens.css` already provides, so it goes.

The two `guide.tsx` escapes were reading `--ko-palette-*`, the theme's raw **input**, instead of `--ko-color-*`, the design system's **output** — the same slip as the typeface/font lines in #567. They now go through the output and pick up light/dark handling like everything else.

## Verification

Computed styles from production builds against `main`, 36 properties per element, 2 viewports:

| | elements | changed |
|---|---|---|
| CZ — 10 pages including the **alarm** and **prima** embed guides, where the palette escapes render under non-default themes | 3,616 | **0** |
| SK | 618 | **0** |

`match-card` lives on the result page, which the harness can't reach (it needs session answers), so it's checked at the stylesheet level: `.koa\:bg-primary` resolves through `--koa-color-primary` to the same `--ko-color-primary` the escape used, and likewise for `on-bg-primary`.

`npm run typecheck`, `npm run lint`, `npm run test` and `turbo build --force` (12 tasks) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
