### PR TITLE
Declare the dependencies the packages actually import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23310,7 +23310,10 @@
       "dependencies": {
         "@kalkulacka-one/design-system": "*",
         "@kalkulacka-one/schema": "*",
+        "@mdi/js": "^7.4.47",
         "next-intl": "^4.3.9",
+        "react-markdown": "^10.1.0",
+        "zod": "^4.0.0",
         "zustand": "^5.0.2"
       },
       "devDependencies": {
@@ -23462,11 +23465,14 @@
       "devDependencies": {
         "@kalkulacka-one/typescript-config": "*",
         "@types/node": "^22.19.1",
+        "@types/react": "^19.2.7",
+        "react": "^19.2.3",
         "tsc-alias": "^1.8.16",
         "typescript": "^7.0.2"
       },
       "peerDependencies": {
-        "next": "^16.0.0"
+        "next": "^16.0.0",
+        "react": "^19.2.3"
       }
     },
     "packages/schema": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -46,7 +46,10 @@
   "dependencies": {
     "@kalkulacka-one/design-system": "*",
     "@kalkulacka-one/schema": "*",
+    "@mdi/js": "^7.4.47",
     "next-intl": "^4.3.9",
+    "react-markdown": "^10.1.0",
+    "zod": "^4.0.0",
     "zustand": "^5.0.2"
   },
   "peerDependencies": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -57,11 +57,14 @@
   "devDependencies": {
     "@kalkulacka-one/typescript-config": "*",
     "@types/node": "^22.19.1",
+    "@types/react": "^19.2.7",
+    "react": "^19.2.3",
     "tsc-alias": "^1.8.16",
     "typescript": "^7.0.2"
   },
   "peerDependencies": {
-    "next": "^16.0.0"
+    "next": "^16.0.0",
+    "react": "^19.2.3"
   },
   "packageManager": "npm@11.5.2"
 }


### PR DESCRIPTION
`packages/app` and `packages/next` import things they never declare. It works only because npm hoists a single copy of each to the workspace root — the kind of thing that breaks quietly under a different install layout, or once a range drifts and a second copy appears.

| package | imports | from | declared? |
|---|---|---|---|
| `packages/app` | `@mdi/js` | 10 files | no |
| `packages/app` | `react-markdown` | 2 files | no |
| `packages/app` | `zod` | 3 files | no |
| `packages/next` | `react/jsx-runtime` | `session-image.tsx` (compiled JSX) | no |

Each is now declared at the version **already used elsewhere in the repo**, so nothing new is introduced:

- `@mdi/js ^7.4.47` — as in `packages/design-system`
- `react-markdown ^10.1.0` — as in the apps
- `zod ^4.0.0` — as in `packages/next`
- `react ^19.2.3` — as in `packages/app`: a **peer** in `packages/next` for the runtime, plus `react` and `@types/react` as devDependencies so it typechecks without leaning on the root

## Risk

- **Lockfile**: +7 / −1, only the new declarations. No resolved version changes, and `npm install` downloads nothing ("up to date").
- **No duplicate installs**: no nested copies under `packages/app/node_modules` or `packages/next/node_modules`; one React (19.3.0) in the tree.

`npm run typecheck`, `npm run lint`, `npm run test` and `turbo build --force` (12 tasks) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
