### PR TITLE
Align the Macedonian page wrappers with the Czech and Slovak ones

### DIFF
--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/comparison.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/comparison.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
 
 import { useEmbed } from "@/components/client";
+import { appConfig } from "@/config/app-config";
 import { canonical, type RouteSegments, routes } from "@/lib/routing";
 
 export function ComparisonPageWithRouting({ segments }: { segments: RouteSegments }) {
@@ -28,6 +29,7 @@ export function ComparisonPageWithRouting({ segments }: { segments: RouteSegment
   return (
     <ComparisonPage
       homepageHref={canonical.homepage()}
+      privacyHref={appConfig.links?.privacy}
       embedContext={embed}
       calculator={calculator}
       result={result}

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/guide.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/guide.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
 
 import { useEmbed } from "@/components/client";
+import { appConfig } from "@/config/app-config";
 import { useAutoSave } from "@/hooks/auto-save";
 import { reportError } from "@/lib/monitoring";
 import { canonical, type RouteSegments, routes } from "@/lib/routing";
@@ -41,6 +42,7 @@ export function GuidePageWithRouting({ segments }: { segments: RouteSegments }) 
   return (
     <AppGuidePage
       homepageHref={canonical.homepage()}
+      privacyHref={appConfig.links?.privacy}
       embedContext={embed}
       calculator={calculator}
       onNextClick={handleNavigationNextClick}

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/introduction.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/introduction.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
 
 import { useEmbed } from "@/components/client";
+import { appConfig } from "@/config/app-config";
 import { useAutoSave } from "@/hooks/auto-save";
 import { reportError } from "@/lib/monitoring";
 import { canonical, type RouteSegments, routes } from "@/lib/routing";
@@ -34,5 +35,14 @@ export function IntroductionPageWithRouting({ segments }: { segments: RouteSegme
     router.push("/");
   };
 
-  return <IntroductionPage homepageHref={canonical.homepage()} embedContext={embed} calculator={calculator} onNextClick={handleNavigationNextClick} onCloseClick={handleCloseClick} />;
+  return (
+    <IntroductionPage
+      homepageHref={canonical.homepage()}
+      privacyHref={appConfig.links?.privacy}
+      embedContext={embed}
+      calculator={calculator}
+      onNextClick={handleNavigationNextClick}
+      onCloseClick={handleCloseClick}
+    />
+  );
 }

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/question.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/question.tsx
@@ -7,6 +7,7 @@ import { useLocale } from "next-intl";
 import { useEffect, useReducer } from "react";
 
 import { useEmbed } from "@/components/client";
+import { appConfig } from "@/config/app-config";
 import { useAutoSave } from "@/hooks/auto-save";
 import { reportError } from "@/lib/monitoring";
 import { canonical, parsedParams, type RouteSegments, routes } from "@/lib/routing";
@@ -89,6 +90,7 @@ export function QuestionPageWithRouting({ current, segments }: { current: number
     <div>
       <AppQuestionPage
         homepageHref={canonical.homepage()}
+        privacyHref={appConfig.links?.privacy}
         embedContext={embed}
         calculator={calculator}
         question={question}

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/result.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/result.tsx
@@ -7,6 +7,7 @@ import { useLocale } from "next-intl";
 import { useEffect, useState } from "react";
 
 import { useEmbed } from "@/components/client";
+import { appConfig } from "@/config/app-config";
 import { reportError } from "@/lib/monitoring";
 import { canonical, type RouteSegments, routes } from "@/lib/routing";
 
@@ -61,6 +62,7 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
     <>
       <AppResultPage
         homepageHref={canonical.homepage()}
+        privacyHref={appConfig.links?.privacy}
         embedContext={embed}
         calculator={calculator}
         result={result}
@@ -76,6 +78,7 @@ export function ResultPageWithRouting({ segments }: { segments: RouteSegments })
         isOpen={isShareModalOpen}
         onClose={() => setIsShareModalOpen(false)}
         onShare={() => shareSession(calculator.id)}
+        privacyHref={appConfig.links?.privacy}
         buildShareUrl={(publicId) => canonical.publicResult({ first: segments.first, second: segments.second, third: segments.third }, publicId, locale)}
       />
     </>

--- a/apps/www.izborenkalkulator.mk/components/client/pages/calculator/review.tsx
+++ b/apps/www.izborenkalkulator.mk/components/client/pages/calculator/review.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useLocale } from "next-intl";
 
 import { useEmbed } from "@/components/client";
+import { appConfig } from "@/config/app-config";
 import { useAutoSave } from "@/hooks/auto-save";
 import { reportError } from "@/lib/monitoring";
 import { canonical, type RouteSegments, routes } from "@/lib/routing";
@@ -44,6 +45,7 @@ export function ReviewPageWithRouting({ segments }: { segments: RouteSegments })
     <div>
       <AppReviewPage
         homepageHref={canonical.homepage()}
+        privacyHref={appConfig.links?.privacy}
         embedContext={embed}
         calculator={calculator}
         questions={questions}


### PR DESCRIPTION
Before the extraction, the page wrappers under `components/client/pages/calculator/` were identical across CZ, SK and MK except `result.tsx`. The extraction added a `privacyHref` prop that CZ and SK pass and MK doesn't — so **all six MK wrappers drifted**, over a prop that evaluates to `undefined` on MK anyway. (That same gap is why #553 had to restore the Slovak link mid-series.)

MK now passes `privacyHref={appConfig.links?.privacy}` like the others.

## Result

| wrapper | CZ ↔ MK | SK ↔ MK |
|---|---|---|
| comparison, guide, introduction, public-result, question, review | identical | identical |
| result | differs | differs |

`result.tsx` keeps its one **intentional** difference: CZ and SK each pass their own localised `DonateCard`; MK has none.

## No behaviour change

MK's `app-config.ts` has no `links` block, so `appConfig.links?.privacy` is `undefined` — exactly as if the prop were omitted. The files simply match again, so the next change to a wrapper can be copied across all three apps.

`npm run typecheck`, `npm run lint`, `npm run test` and the MK build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
